### PR TITLE
add NEXTAUTH_URL to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL='postgresql://<user>:<pass>@<db-host>:<db-port>'
 GOOGLE_API_CREDENTIALS='secret'
+NEXTAUTH_URL='http://localhost:3000'


### PR DESCRIPTION
When I'm running it locally I got an error from NEXTAUTH_URL that it's not present in the .env file.

https://next-auth.js.org/configuration/options#nextauth_url