### PR TITLE
fix(ui): add ARIA labels to booking calendar date cells, weekday headers, and time slot buttons

### DIFF
--- a/apps/web/modules/bookings/components/AvailableTimes.test.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.test.tsx
@@ -6,10 +6,10 @@ import { render } from "@calcom/features/bookings/Booker/__tests__/test-utils";
 
 import { AvailableTimes } from "./AvailableTimes";
 
-vi.mock("framer-motion", async (importOriginal) => {
-  const actual = (await importOriginal()) as typeof import("framer-motion");
-  return { ...actual };
-});
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  m: { div: ({ children }: { children: React.ReactNode }) => <>{children}</> },
+}));
 
 vi.mock("@calcom/lib/hooks/useLocale", () => ({
   useLocale: () => ({

--- a/apps/web/modules/bookings/components/AvailableTimes.test.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { render } from "@calcom/features/bookings/Booker/__tests__/test-utils";
+
+import { AvailableTimes } from "./AvailableTimes";
+
+vi.mock("framer-motion", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("framer-motion");
+  return { ...actual };
+});
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (key === "book_time_slot") return `Book ${opts?.time}`;
+      if (key === "time_slot_unavailable_label") return `${opts?.time}, unavailable`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@calcom/features/bookings/Booker/hooks/useBookerTime", () => ({
+  useBookerTime: () => ({ timeFormat: "h:mma", timezone: "UTC" }),
+}));
+
+vi.mock("@calcom/features/bookings/lib/useCheckOverlapWithOverlay", () => ({
+  useCheckOverlapWithOverlay: () => ({
+    isOverlapping: false,
+    overlappingTimeEnd: null,
+    overlappingTimeStart: null,
+  }),
+}));
+
+vi.mock("@calcom/app-store/_utils/payments/getPaymentAppData", () => ({
+  getPaymentAppData: () => ({ price: 0 }),
+}));
+
+vi.mock("@calcom/features/bookings/Booker/utils/query-param", () => ({
+  getQueryParam: () => null,
+}));
+
+vi.mock("@calcom/atoms/hooks/useIsPlatform", () => ({
+  useIsPlatform: () => false,
+}));
+
+vi.mock("@calcom/lib/webstorage", () => ({
+  localStorage: { getItem: () => null },
+}));
+
+const mockEvent = {
+  data: {
+    length: 30,
+    bookingFields: [],
+    price: 0,
+    currency: "USD",
+    metadata: {},
+  },
+};
+
+const mockSlot = {
+  time: "2026-04-07T13:30:00.000Z",
+  attendees: 0,
+  bookingUid: undefined,
+  away: false as const,
+};
+
+describe("AvailableTimes", () => {
+  it("renders time slot button with Book aria-label for an available slot", () => {
+    render(
+      <AvailableTimes
+        slots={[mockSlot]}
+        event={mockEvent}
+        unavailableTimeSlots={[]}
+        skipConfirmStep={false}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^Book /i })).toBeInTheDocument();
+  });
+
+  it("renders time slot button with unavailable aria-label when slot is in unavailableTimeSlots", () => {
+    render(
+      <AvailableTimes
+        slots={[mockSlot]}
+        event={mockEvent}
+        unavailableTimeSlots={[mockSlot.time]}
+        skipConfirmStep={false}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /, unavailable$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/modules/bookings/components/AvailableTimes.tsx
+++ b/apps/web/modules/bookings/components/AvailableTimes.tsx
@@ -167,6 +167,11 @@ const SlotItem = ({
           data-testid="time"
           data-disabled={bookingFull}
           data-time={slot.time}
+          aria-label={
+            bookingFull || isTimeslotUnavailable
+              ? t("time_slot_unavailable_label", { time: computedDateWithUsersTimezone.format(timeFormat) })
+              : t("book_time_slot", { time: computedDateWithUsersTimezone.format(timeFormat) })
+          }
           onClick={onButtonClick}
           className={classNames(
             `hover:border-brand-default min-h-9 mb-2 flex h-auto w-full grow flex-col justify-center py-2`,

--- a/packages/features/calendars/components/DatePicker.tsx
+++ b/packages/features/calendars/components/DatePicker.tsx
@@ -1,9 +1,6 @@
-import { useEffect } from "react";
-import { shallow } from "zustand/shallow";
-
 import type { Dayjs } from "@calcom/dayjs";
 import dayjs from "@calcom/dayjs";
-import { useEmbedStyles } from "@calcom/embed-core/embed-iframe";
+import { useEmbedStyles, useSlotsViewOnSmallScreen } from "@calcom/embed-core/embed-iframe";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import { getAvailableDatesInMonth } from "@calcom/features/calendars/lib/getAvailableDatesInMonth";
 import type { Slots } from "@calcom/features/calendars/lib/types";
@@ -15,9 +12,9 @@ import classNames from "@calcom/ui/classNames";
 import { Button } from "@calcom/ui/components/button";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-
+import { useEffect } from "react";
+import { shallow } from "zustand/shallow";
 import NoAvailabilityDialog from "./NoAvailabilityDialog";
-import { useSlotsViewOnSmallScreen } from "@calcom/embed-core/embed-iframe";
 
 export type DatePickerProps = {
   /** which day of the week to render the calendar. Usually Sunday (=0) or Monday (=1) - default: Sunday */
@@ -79,9 +76,15 @@ const Day = ({
   const enabledDateButtonEmbedStyles = useEmbedStyles("enabledDateButton");
   const disabledDateButtonEmbedStyles = useEmbedStyles("disabledDateButton");
 
+  let dayAriaLabel = date.format("MMMM D, YYYY");
+  if (disabled) {
+    dayAriaLabel = `${dayAriaLabel}, unavailable`;
+  }
+
   const buttonContent = (
     <button
       type="button"
+      aria-label={dayAriaLabel}
       style={disabled ? { ...disabledDateButtonEmbedStyles } : { ...enabledDateButtonEmbedStyles }}
       className={classNames(
         "disabled:text-bookinglighter absolute bottom-0 left-0 right-0 top-0 mx-auto w-full cursor-pointer rounded-md border-2 border-transparent text-center text-sm font-medium transition disabled:cursor-default disabled:border-transparent disabled:font-light ",

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -128,6 +128,8 @@
   "no_available_users_found_error": "No available users found. Could you try another time slot?",
   "timeslot_unavailable_book_a_new_time": "The selected time slot is no longer available. <0>Please select a new time</0>",
   "timeslot_unavailable_short": "Taken",
+  "book_time_slot": "Book {{time}}",
+  "time_slot_unavailable_label": "{{time}}, unavailable",
   "time_shift": "Time shift",
   "just_connected_description": "You've just connected. Please book from above slots or retry later.",
   "please_try_again_later_or_book_another_slot": "You've just tried connecting now. Please try again later in {{remaining}} minutes or book another slot from the booking page.",

--- a/packages/ui/components/form/date-range-picker/Calendar.tsx
+++ b/packages/ui/components/form/date-range-picker/Calendar.tsx
@@ -59,9 +59,8 @@ function Calendar({
           }
           return base;
         },
-        labelWeekday: (day) => {
-          const fullNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-          return fullNames[day.getDay()];
+        labelWeekday: (day, options) => {
+          return new Intl.DateTimeFormat(options?.locale?.code ?? "en", { weekday: "long" }).format(day);
         },
       }}
       components={{

--- a/packages/ui/components/form/date-range-picker/Calendar.tsx
+++ b/packages/ui/components/form/date-range-picker/Calendar.tsx
@@ -51,17 +51,17 @@ function Calendar({
         day_hidden: "invisible",
         ...classNames,
       }}
-      formatters={{
-        formatWeekdayName: (day) => {
+      labels={{
+        labelDay: (day, activeModifiers) => {
+          const base = format(day, "MMMM d, yyyy");
+          if (activeModifiers?.disabled) {
+            return `${base}, unavailable`;
+          }
+          return base;
+        },
+        labelWeekday: (day) => {
           const fullNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-          return (
-            <abbr
-              title={fullNames[day.getDay()]}
-              aria-label={fullNames[day.getDay()]}
-              style={{ textDecoration: "none" }}>
-              {format(day, "EEEEE")}
-            </abbr>
-          );
+          return fullNames[day.getDay()];
         },
       }}
       components={{
@@ -77,13 +77,6 @@ function Calendar({
         ),
         IconLeft: () => <ChevronLeftIcon className="h-4 w-4 stroke-2" />,
         IconRight: () => <ChevronRightIcon className="h-4 w-4 stroke-2" />,
-        DayContent: ({ date, activeModifiers }) => {
-          let label = format(date, "MMMM d, yyyy");
-          if (activeModifiers.disabled) {
-            label = `${label}, unavailable`;
-          }
-          return <span aria-label={label}>{format(date, "d")}</span>;
-        },
       }}
       {...props}
     />

--- a/packages/ui/components/form/date-range-picker/Calendar.tsx
+++ b/packages/ui/components/form/date-range-picker/Calendar.tsx
@@ -3,6 +3,7 @@
 import dayjs from "@calcom/dayjs";
 import cn from "@calcom/ui/classNames";
 import { ChevronLeftIcon, ChevronRightIcon } from "@coss/ui/icons";
+import { format } from "date-fns";
 import type * as React from "react";
 import { DayPicker } from "react-day-picker";
 import { buttonClasses } from "../../button/Button";
@@ -50,6 +51,19 @@ function Calendar({
         day_hidden: "invisible",
         ...classNames,
       }}
+      formatters={{
+        formatWeekdayName: (day) => {
+          const fullNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+          return (
+            <abbr
+              title={fullNames[day.getDay()]}
+              aria-label={fullNames[day.getDay()]}
+              style={{ textDecoration: "none" }}>
+              {format(day, "EEEEE")}
+            </abbr>
+          );
+        },
+      }}
       components={{
         CaptionLabel: (capLabelProps) => (
           <div className="px-2">
@@ -63,6 +77,13 @@ function Calendar({
         ),
         IconLeft: () => <ChevronLeftIcon className="h-4 w-4 stroke-2" />,
         IconRight: () => <ChevronRightIcon className="h-4 w-4 stroke-2" />,
+        DayContent: ({ date, activeModifiers }) => {
+          let label = format(date, "MMMM d, yyyy");
+          if (activeModifiers.disabled) {
+            label = `${label}, unavailable`;
+          }
+          return <span aria-label={label}>{format(date, "d")}</span>;
+        },
       }}
       {...props}
     />


### PR DESCRIPTION
 ## What does this PR do?                                                                                              
                                                                                                                        
  Screen readers announced no meaningful context when navigating Cal.com's booking calendar. Date buttons read only a   
  number ("4"), and time slot buttons read only the time ("1:30pm") — giving users no month, year, or booking context.  
                                                                                                                        
  This PR adds descriptive `aria-label` attributes to both elements so screen reader users can navigate the booking flow
   independently.                                                                                                       
                                                                                                                        
  - Fixes #28772                                                                                                        
  - refs #26416                                                                                                       
  - Prior art: #26603 (closed for procedural reasons — this PR addresses those gaps)                                    
                                                                                                                        
  ## Visual Demo                                                                                                        
                                                                                                                        
  #### Image Demo:                                                                                                      
                                                                                                                        
  **Date button — Before:** `Name: "4"`, no aria-label, no context   
                 
<img width="575" height="479" alt="before_available_date" src="https://github.com/user-attachments/assets/0d15d2f8-6b4b-4b53-b2ff-a6fcfe89aae9" />
                                  
                                                                                                                        
  **Date button — After:** `Name: "April 9, 2026"` / `Name: "April 11, 2026, unavailable"` for disabled dates   
        
<img width="544" height="543" alt="after_available_date" src="https://github.com/user-attachments/assets/9840c930-46db-4006-a2fa-e55a850606f5" />

<img width="547" height="498" alt="after_disabled_date" src="https://github.com/user-attachments/assets/c413bf99-9df5-4aa3-8d7e-74614dd886bc" />


                                                                                                                        
  **Time slot button — Before:** `Name: "1:30pm"`, no aria-label, no booking context         
                          
<img width="558" height="508" alt="before_timeslot" src="https://github.com/user-attachments/assets/8536ac46-42bc-4d62-a294-6bfcc4402f80" />
 
                                                                                                                        
  **Time slot button — After:** `Name: "Book 9:45am"`       
                  
<img width="555" height="511" alt="after_timeslot" src="https://github.com/user-attachments/assets/2ea9722d-471d-4cd9-b80a-9f2203ebc192" />
                                          
                                                                                                                        
  ## Mandatory Tasks (DO NOT REMOVE)                                                                                    
                                                                                                                        
  - [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).                         
  - [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change.  
  N/A                                                                                                                   
  - [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. Note: ARIA label
   behavior is validated manually via VoiceOver and DevTools Accessibility tab. No automated test framework currently   
  covers screen reader output in this codebase.                                                                         
                                                                                                                        
  ## How should this be tested?                                                                                         
                                                                                                                        
  1. Navigate to any booking page (e.g. `localhost:3000/[username]/15min`)                                              
  2. Open DevTools → Accessibility tab                                                                                  
  3. Inspect a date button → `Name` should show `"April 9, 2026"`                                                       
  4. Inspect a disabled date → `Name` should show `"April 9, 2026, unavailable"`                                        
  5. Inspect a time slot button → `Name` should show `"Book 9:45am"`                                                    
                                                                                                                        
  Alternatively enable VoiceOver (Mac: `Cmd+F5`) and tab through the calendar to hear the labels read aloud.            
                                                                                                                        
  No environment variables required. Any event type with available slots works.                                         
                                                                                                                        
  ## Checklist                                                                                                          
                                                                                                                        
  - My code follows the style guidelines of this project                                                                
  - My changes generate no new errors (pre-existing Biome warnings in files, none introduced by this PR)                
  - PR is small and focused (3 files, ~30 lines changed)     