### PR TITLE
fix: allow initial reservation for seated events

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-04-15/services/slots.service.ts
@@ -10,7 +10,7 @@ export class SlotsService_2024_04_15 {
   constructor(
     private readonly eventTypeRepo: EventTypesRepository_2024_04_15,
     private readonly slotsRepo: SlotsRepository_2024_04_15
-  ) {}
+  ) { }
 
   async reserveSlot(input: ReserveSlotInput_2024_04_15, headerUid?: string) {
     const uid = headerUid || uuid();
@@ -25,11 +25,9 @@ export class SlotsService_2024_04_15 {
         ? await this.slotsRepo.getBookingWithAttendees(input.bookingUid)
         : undefined;
       const bookingAttendeesLength = bookingWithAttendees?.attendees?.length;
-      if (bookingAttendeesLength) {
+      if (bookingAttendeesLength !== undefined) {
         const seatsLeft = eventType.seatsPerTimeSlot - bookingAttendeesLength;
         if (seatsLeft < 1) shouldReserveSlot = false;
-      } else {
-        shouldReserveSlot = false;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #29448 where seated event slot reservations could incorrectly fail for the very first booking attempt.

### Changes

* Remove the fallback branch that set `shouldReserveSlot = false` when no existing booking was found
* Check `bookingAttendeesLength !== undefined` instead of relying on truthiness

### Result

Slot reservations now remain allowed when no booking exists yet, while still correctly preventing reservations once the seat limit is reached.
