### PR TITLE
fix: sum failures when aggregating apps status across bookings

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import type { AdditionalInformation, AppsStatus } from "@calcom/types/Calendar";
+import type { EventResult } from "@calcom/types/EventManager";
+
+import { handleAppsStatus } from "./handleAppsStatus";
+
+function makeResult(
+  type: string,
+  appName: string,
+  success: boolean,
+  calError?: string
+): EventResult<AdditionalInformation> {
+  return { type, appName, success, calError, uid: "uid" } as unknown as EventResult<AdditionalInformation>;
+}
+
+function makeReqStatus(type: string, appName: string, success: number, failures: number): AppsStatus {
+  return { type, appName, success, failures, errors: [] } as AppsStatus;
+}
+
+describe("handleAppsStatus", () => {
+  it("sums failures when the same app type is aggregated across bookings", () => {
+    const result = handleAppsStatus(
+      [makeResult("google_calendar", "google-calendar", false, "current failure")],
+      null,
+      [makeReqStatus("google_calendar", "google-calendar", 0, 1)]
+    );
+
+    const gcal = result.find((s) => s.type === "google_calendar");
+    expect(gcal?.failures).toBe(2);
+    expect(gcal?.success).toBe(0);
+  });
+
+  it("does not hide a failure when a prior booking of the same type succeeded", () => {
+    const result = handleAppsStatus(
+      [makeResult("google_calendar", "google-calendar", false, "current failure")],
+      null,
+      [makeReqStatus("google_calendar", "google-calendar", 1, 0)]
+    );
+
+    const gcal = result.find((s) => s.type === "google_calendar");
+    expect(gcal?.success).toBe(1);
+    expect(gcal?.failures).toBe(1);
+  });
+
+  it("keeps success and failures symmetric and separates distinct app types", () => {
+    const result = handleAppsStatus(
+      [
+        makeResult("google_calendar", "google-calendar", true),
+        makeResult("zoom_video", "zoom", false, "zoom failure"),
+      ],
+      null,
+      [
+        makeReqStatus("google_calendar", "google-calendar", 1, 0),
+        makeReqStatus("zoom_video", "zoom", 0, 1),
+      ]
+    );
+
+    const gcal = result.find((s) => s.type === "google_calendar");
+    const zoom = result.find((s) => s.type === "zoom_video");
+    expect(gcal).toMatchObject({ success: 2, failures: 0 });
+    expect(zoom).toMatchObject({ success: 0, failures: 2 });
+  });
+
+  it("returns the mapped result status when there is no prior status to aggregate", () => {
+    const result = handleAppsStatus(
+      [makeResult("google_calendar", "google-calendar", false, "boom")],
+      null,
+      undefined
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "google_calendar", success: 0, failures: 1 });
+  });
+});

--- a/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.ts
+++ b/packages/features/bookings/lib/handleNewBooking/handleAppsStatus.ts
@@ -50,6 +50,7 @@ function calculateAggregatedAppsStatus(
     (acc, curr) => {
       if (acc[curr.type]) {
         acc[curr.type].success += curr.success;
+        acc[curr.type].failures += curr.failures;
         acc[curr.type].errors = acc[curr.type].errors.concat(curr.errors);
         acc[curr.type].warnings = acc[curr.type].warnings?.concat(curr.warnings || []);
       } else {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `calculateAggregatedAppsStatus` (`packages/features/bookings/lib/handleNewBooking/handleAppsStatus.ts`) where the `failures` count was dropped when merging `AppsStatus` entries of the same `type`.

When aggregating app statuses (e.g. across the bookings of a recurring series), the reducer summed the `success` count but never summed `failures`:

```ts
acc[curr.type].success += curr.success;
// failures was never aggregated
```

Since `failures` is a numeric count that is rendered in booking confirmation emails (`AppsStatus.tsx` and `CalEventParser.ts` both display it as a failure marker with an `(xN)` count), only the first same-type entry's `failures` value survived the merge. This meant:

- An app failing in multiple bookings of a series showed the failure marker with no count (or a count of 1) instead of the correct total (e.g. `(x2)`).
- An app that succeeded first and then failed kept `failures: 0`, so the failure marker did not render at all and the failure was hidden from the user.

`success` and `failures` are symmetric fields populated together, so the fix is to sum `failures` the same way `success` is already summed.


## Visual Demo (For contributors especially)

N/A — this is a backend aggregation fix with no UI surface of its own. The observable effect is in the booking confirmation email's apps-status line: for a recurring booking where the same app fails more than once, the failure count is now correct (e.g. `(x2)`) instead of being under-reported or omitted entirely.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the unit test added in this PR:

```
yarn vitest run packages/features/bookings/lib/handleNewBooking/handleAppsStatus.test.ts
```

- Environment variables: none required.
- Minimal test data: a recurring booking (a series) where the same app `type` (e.g. a calendar such as `google_calendar`) appears in both the incoming request `appsStatus` and the current booking's result status, and fails in more than one of them.
- Expected (happy path): the aggregated `AppsStatus` for that `type` reports the summed failure count, so the confirmation email shows the correct total (e.g. `(x2)`). Before this change, only the first entry's `failures` survived, so the count was under-reported or the failure marker did not render at all. The added tests fail against the pre-fix code and pass with the fix.
