### PR TITLE
fix(bookings): reject API bookings past the max rolling window

### DIFF
--- a/packages/lib/isOutOfBounds.timezone.test.ts
+++ b/packages/lib/isOutOfBounds.timezone.test.ts
@@ -3,7 +3,8 @@ process.env.TZ = "Asia/Dubai";
 import dayjs from "@calcom/dayjs";
 import { PeriodType } from "@calcom/prisma/enums";
 import { describe, expect, it } from "vitest";
-import { calculatePeriodLimits, getRollingWindowEndDate } from "./isOutOfBounds";
+import { ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK } from "./constants";
+import isOutOfBounds, { calculatePeriodLimits, getRollingWindowEndDate } from "./isOutOfBounds";
 
 const getDayJsTimeWithUtcOffset = ({
   dateStringWithOffset,
@@ -655,5 +656,41 @@ describe("calculatePeriodLimits - PeriodType.RANGE", () => {
       expect(result.startOfRangeStartDayInEventTz!.date()).toBe(19);
       expect(result.endOfRangeEndDayInEventTz!.date()).toBe(19);
     });
+  });
+});
+
+describe("isOutOfBounds - ROLLING_WINDOW enforcement in the booking path", () => {
+  const rollingWindowEventType = {
+    periodType: PeriodType.ROLLING_WINDOW,
+    periodDays: 5,
+    periodStartDate: null,
+    periodEndDate: null,
+    eventUtcOffset: 0,
+    bookerUtcOffset: 0,
+  };
+
+  it("rejects a booking past the furthest the window could reach (calendar days)", () => {
+    const beyondWindow = dayjs()
+      .add(ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK + 5, "day")
+      .hour(10)
+      .toISOString();
+    expect(isOutOfBounds(beyondWindow, { ...rollingWindowEventType, periodCountCalendarDays: true })).toBe(
+      true
+    );
+  });
+
+  it("rejects a booking past the furthest the window could reach (business days)", () => {
+    // A business-day window spans more calendar days than the step count, so book well past it.
+    const beyondWindow = dayjs().add(150, "day").hour(10).toISOString();
+    expect(isOutOfBounds(beyondWindow, { ...rollingWindowEventType, periodCountCalendarDays: false })).toBe(
+      true
+    );
+  });
+
+  it("still allows a booking that falls inside the window", () => {
+    const withinWindow = dayjs().add(2, "day").hour(10).toISOString();
+    expect(isOutOfBounds(withinWindow, { ...rollingWindowEventType, periodCountCalendarDays: true })).toBe(
+      false
+    );
   });
 });

--- a/packages/lib/isOutOfBounds.tsx
+++ b/packages/lib/isOutOfBounds.tsx
@@ -236,6 +236,25 @@ export function getRollingWindowEndDate({
 }
 
 /**
+ * Furthest date a ROLLING_WINDOW can ever reach. getRollingWindowEndDate stops after
+ * ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK steps, so the real window end can't be later than this
+ * regardless of which days are bookable. Used where day-by-day availability isn't computed.
+ */
+export function getMaxRollingWindowEndDateInBookerTz({
+  periodCountCalendarDays,
+  bookerUtcOffset,
+}: {
+  periodCountCalendarDays: boolean | null;
+  bookerUtcOffset: number;
+}) {
+  const currentTimeInBookerTz = dayjs().utcOffset(bookerUtcOffset);
+  const maxEndDay = periodCountCalendarDays
+    ? currentTimeInBookerTz.add(ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK, "days")
+    : currentTimeInBookerTz.businessDaysAdd(ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK);
+  return maxEndDay.endOf("day");
+}
+
+/**
  * To be used when we work on Timeslots(and not Dates) to check boundaries
  * It ensures that the time isn't in the past and also checks if the time is within the minimum booking notice.
  * Note: It throws error that needs to be caught by caller.
@@ -375,6 +394,16 @@ export default function isOutOfBounds(
     eventUtcOffset,
     bookerUtcOffset,
   });
+
+  // calculatePeriodLimits skips ROLLING_WINDOW here because this path has no day-by-day availability
+  // to compute the exact window end, which let direct API bookings bypass the limit entirely (#29729).
+  // The window can never reach past its maximum, so enforce that as an upper bound.
+  if (periodType === PeriodType.ROLLING_WINDOW) {
+    periodLimits.endOfRollingPeriodEndDayInBookerTz = getMaxRollingWindowEndDateInBookerTz({
+      periodCountCalendarDays,
+      bookerUtcOffset,
+    });
+  }
 
   const isOutOfBoundsByPeriod = isTimeViolatingFutureLimit({
     time: dayjs.isDayjs(time) ? time.toDate() : time,


### PR DESCRIPTION
## What does this PR do?

The booking path never checks `ROLLING_WINDOW`, so API bookings skip the window entirely. It can't reach past `ROLLING_WINDOW_PERIOD_MAX_DAYS_TO_CHECK`, so I enforce that as an upper bound. Doesn't catch bookings inside the max but past the event's real window (that needs availability this path doesn't have). Glad to do the precise version if you'd prefer.

- Fixes #29729

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

`TZ=UTC yarn vitest run packages/lib/isOutOfBounds.timezone.test.ts` — the new ROLLING_WINDOW cases fail on `main` and pass here. No UI change.
