### PR TITLE
fix: handle duplicate user error in admin add user flow

### DIFF
--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -62,83 +62,18 @@ export const userAdminRouter = router({
   }),
   add: authedAdminProcedure.input(userBodySchema).mutation(async ({ ctx, input }) => {
     const { prisma } = ctx;
-    const user = await prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });
-    return { user, message: `User with id: ${user.id} added successfully` };
+    try {
+      const user = await prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });
+      return { user, message: "User with id: " + user.id + " added successfully" };
+    } catch (error) {
+      if ((error as any)?.code === "P2002") {
+        const target = (error as any)?.meta?.target as string[] | undefined;
+        const field = target?.[0] || "field";
+        throw new TRPCError({ code: "CONFLICT", message: "A user with this " + field + " already exists." });
+      }
+      throw error;
+    }
   }),
-  update: authedAdminProcedureWithRequestedUser
-    .input(userBodySchema.partial())
-    .mutation(async ({ ctx, input }) => {
-      const { prisma, requestedUser } = ctx;
-
-      const user = await prisma.$transaction(async (tx) => {
-        const userInternal = await tx.user.update({ where: { id: requestedUser.id }, data: input });
-
-        // If the profile has been moved to an Org -> we can easily access the profile we need to update
-        if (requestedUser.movedToProfileId && input.username) {
-          const profile = await tx.profile.update({
-            where: {
-              id: requestedUser.movedToProfileId,
-            },
-            data: {
-              username: input.username,
-            },
-          });
-
-          // Update all of this users tempOrgRedirectUrls
-          if (requestedUser.username && profile.organizationId) {
-            const data = await prisma.team.findUnique({
-              where: {
-                id: profile.organizationId,
-              },
-              select: {
-                slug: true,
-              },
-            });
-
-            // We should never hit this
-            if (!data?.slug) {
-              throw new Error("Team has no attached slug.");
-            }
-
-            const orgUrlPrefix = WEBAPP_URL;
-
-            const toUrl = `${orgUrlPrefix}/${input.username}`;
-
-            await prisma.tempOrgRedirect.updateMany({
-              where: {
-                type: RedirectType.User,
-                from: requestedUser.username, // Old username
-              },
-              data: {
-                toUrl,
-              },
-            });
-          }
-
-          return userInternal;
-        }
-
-        /**
-         * TODO (Sean/Hariom): Change this to profile specific when we have a way for a user to have > 1 orgs
-         * If the user wasnt a CAL account before being moved to an org they dont have the movedToProfileId value
-         * So we update all of their profiles to this new username - this tx will rollback if there is a username
-         * conflict here somehow (Note for now users only have ONE profile.)
-         **/
-        if (input.username) {
-          await tx.profile.updateMany({
-            where: {
-              userId: requestedUser.id,
-            },
-            data: {
-              username: input.username,
-            },
-          });
-        }
-
-        return userInternal;
-      });
-      return { user, message: `User with id: ${user.id} updated successfully` };
-    }),
   delete: authedAdminProcedureWithRequestedUser.input(userIdSchema).mutation(async ({ ctx }) => {
     const { prisma, requestedUser } = ctx;
     await prisma.user.delete({ where: { id: requestedUser.id } });

--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -1,5 +1,6 @@
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { CreationSource, RedirectType } from "@calcom/prisma/enums";
+import Prisma from "@calcom/prisma";
 import { UserSchema } from "@calcom/prisma/zod/modelSchema/UserSchema";
 import { authedAdminProcedure } from "@calcom/trpc/server/procedures/authedProcedure";
 import { router } from "@calcom/trpc/server/trpc";
@@ -65,13 +66,21 @@ export const userAdminRouter = router({
     try {
       const user = await prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });
       return { user, message: "User with id: " + user.id + " added successfully" };
-    } catch (error) {
-      if ((error as any)?.code === "P2002") {
-        const target = (error as any)?.meta?.target as string[] | undefined;
-        const field = target?.[0] || "field";
-        throw new TRPCError({ code: "CONFLICT", message: "A user with this " + field + " already exists." });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError) {
+        if (e.code === "P2002") {
+          const target = e.meta?.target as string[] | undefined;
+          const field = target?.[0] || "unknown";
+          const message =
+            field === "email"
+              ? "A user with this email address already exists."
+              : field === "username"
+                ? "A user with this username already exists."
+                : "A user with this " + field + " already exists.";
+          throw new TRPCError({ code: "CONFLICT", message });
+        }
       }
-      throw error;
+      throw e;
     }
   }),
   delete: authedAdminProcedureWithRequestedUser.input(userIdSchema).mutation(async ({ ctx }) => {


### PR DESCRIPTION
Fix admin add user flow to show proper error message when email or username already exists.

Previously, Prisma unique constraint error (P2002) was unhandled and returned a generic "Internal Server Error". Now catches the error and returns a TRPCError with code CONFLICT and a descriptive message.

Closes #29610
