### PR TITLE
fix(auth): prevent concurrent initial setup from creating multiple 

### DIFF
--- a/apps/web/app/api/auth/setup/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/setup/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecuteRaw = vi.fn().mockResolvedValue(undefined);
+const mockUserCount = vi.fn();
+const mockUserCreate = vi.fn().mockResolvedValue({ id: 1 });
+const mockTransaction = vi.fn();
+
+vi.mock("app/api/defaultResponderForAppDir", () => ({
+  defaultResponderForAppDir:
+    (handler: (req: NextRequest) => Promise<Response>) =>
+    (req: NextRequest, _context: { params: Promise<Record<string, string>> }) =>
+      handler(req),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: vi.fn().mockResolvedValue(body),
+    })),
+  },
+}));
+
+vi.mock("@calcom/lib/auth/hashPassword", () => ({
+  hashPassword: vi.fn().mockResolvedValue("hashed-password"),
+}));
+
+vi.mock("@calcom/lib/slugify", () => ({
+  default: vi.fn((value: string) => value.toLowerCase()),
+}));
+
+let mockRequestBody: Record<string, unknown> = {};
+
+vi.mock("app/api/parseRequestData", () => ({
+  parseRequestData: vi.fn().mockImplementation(() => Promise.resolve(mockRequestBody)),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+
+import { POST } from "../route";
+
+const validSetupBody = {
+  username: "admin1",
+  full_name: "Admin User One",
+  email_address: "admin1@example.com",
+  password: "TestPassword123!!",
+};
+
+const createMockRequest = (): NextRequest => ({}) as NextRequest;
+
+describe("POST /api/auth/setup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequestBody = { ...validSetupBody };
+    mockUserCount.mockResolvedValue(0);
+    mockTransaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        $executeRaw: mockExecuteRaw,
+        user: {
+          count: mockUserCount,
+          create: mockUserCreate,
+        },
+      };
+      await callback(tx);
+    });
+  });
+
+  it("creates the first admin user inside a transaction with an advisory lock", async () => {
+    const res = await POST(createMockRequest(), { params: Promise.resolve({}) });
+    const body = await res.json();
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(mockUserCount).toHaveBeenCalledTimes(1);
+    expect(mockUserCreate).toHaveBeenCalledWith({
+      data: {
+        username: "admin1",
+        email: "admin1@example.com",
+        password: { create: { hash: "hashed-password" } },
+        role: "ADMIN",
+        name: "Admin User One",
+        emailVerified: expect.any(Date),
+        locale: "en",
+        identityProvider: "CAL",
+        creationSource: "WEBAPP",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ message: "First admin user created successfully." });
+  });
+
+  it("returns 400 when users already exist inside the transaction", async () => {
+    mockUserCount.mockResolvedValue(1);
+
+    await expect(POST(createMockRequest(), { params: Promise.resolve({}) })).rejects.toMatchObject({
+      statusCode: 400,
+      message: "No setup needed.",
+    });
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    expect(mockUserCount).toHaveBeenCalledTimes(1);
+    expect(mockUserCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid request body", async () => {
+    mockRequestBody = {
+      ...validSetupBody,
+      email_address: "not-an-email",
+    };
+
+    await expect(POST(createMockRequest(), { params: Promise.resolve({}) })).rejects.toMatchObject({
+      statusCode: 422,
+    });
+
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockUserCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/auth/setup/route.ts
+++ b/apps/web/app/api/auth/setup/route.ts
@@ -1,17 +1,15 @@
-import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
-import { parseRequestData } from "app/api/parseRequestData";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import z from "zod";
-
 import { hashPassword } from "@calcom/lib/auth/hashPassword";
 import { isPasswordValid } from "@calcom/lib/auth/isPasswordValid";
 import { emailRegex } from "@calcom/lib/emailSchema";
 import { HttpError } from "@calcom/lib/http-error";
 import slugify from "@calcom/lib/slugify";
 import prisma from "@calcom/prisma";
-import { IdentityProvider } from "@calcom/prisma/enums";
-import { CreationSource } from "@calcom/prisma/enums";
+import { CreationSource, IdentityProvider } from "@calcom/prisma/enums";
+import { defaultResponderForAppDir } from "app/api/defaultResponderForAppDir";
+import { parseRequestData } from "app/api/parseRequestData";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import z from "zod";
 
 const querySchema = z.object({
   username: z
@@ -25,11 +23,9 @@ const querySchema = z.object({
   }),
 });
 
+const INITIAL_SETUP_LOCK_KEY = "cal_initial_setup";
+
 async function handler(req: NextRequest) {
-  const userCount = await prisma.user.count();
-  if (userCount !== 0) {
-    throw new HttpError({ statusCode: 400, message: "No setup needed." });
-  }
   const body = await parseRequestData(req);
 
   const parsedQuery = querySchema.safeParse(body);
@@ -39,21 +35,31 @@ async function handler(req: NextRequest) {
 
   const username = slugify(parsedQuery.data.username.trim());
   const userEmail = parsedQuery.data.email_address.toLowerCase();
-
   const hashedPassword = await hashPassword(parsedQuery.data.password);
 
-  await prisma.user.create({
-    data: {
-      username,
-      email: userEmail,
-      password: { create: { hash: hashedPassword } },
-      role: "ADMIN",
-      name: parsedQuery.data.full_name,
-      emailVerified: new Date(),
-      locale: "en", // TODO: We should revisit this
-      identityProvider: IdentityProvider.CAL,
-      creationSource: CreationSource.WEBAPP,
-    },
+  // Concurrent setup requests can all pass a user-count check before any insert completes.
+  // Serialize the check-and-create with a transaction-scoped advisory lock so only one admin is created.
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${INITIAL_SETUP_LOCK_KEY}))`;
+
+    const userCount = await tx.user.count();
+    if (userCount !== 0) {
+      throw new HttpError({ statusCode: 400, message: "No setup needed." });
+    }
+
+    await tx.user.create({
+      data: {
+        username,
+        email: userEmail,
+        password: { create: { hash: hashedPassword } },
+        role: "ADMIN",
+        name: parsedQuery.data.full_name,
+        emailVerified: new Date(),
+        locale: "en", // TODO: We should revisit this
+        identityProvider: IdentityProvider.CAL,
+        creationSource: CreationSource.WEBAPP,
+      },
+    });
   });
 
   return NextResponse.json({ message: "First admin user created successfully." });


### PR DESCRIPTION

admins Serialize POST /api/auth/setup with a PostgreSQL advisory transaction lock so only one request can create the first admin on a fresh instance. Fixes #29730

## What does this PR do?

Fixes a TOCTOU race in POST /api/auth/setup on fresh Cal.diy instances.

Previously, concurrent setup requests could all pass user.count() === 0 before any insert completed (especially during bcrypt hashing), allowing multiple admin users to be created with different emails/usernames.

This PR:
    
    Wraps the user count check and admin creation in a prisma.$transaction
    
    Acquires a transaction-scoped PostgreSQL advisory lock before checking/creating
    
    Keeps request validation and password hashing outside the transaction to avoid holding the lock during bcrypt
    
    Returns 400 "No setup needed." for losing concurrent requests, same as before

Fixes #29730


## Visual Demo (For contributors especially)

N/A — backend-only race-condition fix with no UI changes.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [✓ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ✓] I have updated the developer docs if this PR makes changes that would require a documentation change. **N/A — no documentation changes required for this backend fix.**
- [ ✓] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Automated
```
yarn prisma generate
TZ=UTC yarn vitest run apps/web/app/api/auth/setup/__tests__/route.test.ts
yarn biome check apps/web/app/api/auth/setup/

```

**Manual (optional, recommended for reviewers)**
**Environment:**
-     Fresh Cal.diy instance with zero users in the database
-     PostgreSQL 15+
-     POST /api/auth/setup is unauthenticated

Steps:

1. On a fresh DB, send 5 simultaneous POST /api/auth/setup requests with different username, full_name, and email_address
2. Verify exactly one request returns 200
3. Verify the other requests return 400 with "No setup needed."
4. Confirm in DB:
```
SELECT count(*)::int AS admin_count
FROM users
WHERE role = 'ADMIN';
```


Expected: admin_count = 1

Control case:
• Single setup request on fresh DB → 200, one admin created
• Second request after setup → 400

Environment variables:
• Standard Cal.diy setup (DATABASE_URL, NEXTAUTH_SECRET, etc.)
• No new env vars required

Minimal test data:
• Empty users table

Happy path:
• Input: valid setup payload
• Output: 200 with { "message": "First admin user created successfully." }
• Exactly one ADMIN user in the database

