### PR TITLE
feat: add hidden event toggle support for managed events

### DIFF
--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -555,6 +555,10 @@ export const InfiniteEventTypeList = ({
             const isChildrenManagedEventType =
               type.metadata?.managedEventConfig !== undefined &&
               type.schedulingType !== SchedulingType.MANAGED;
+            // A child's "Hide from profile" toggle is controlled by the parent when the
+            // `hidden` field is locked (i.e. not present in the parent's unlockedFields).
+            const isChildHiddenLocked =
+              isChildrenManagedEventType && !type.metadata?.managedEventConfig?.unlockedFields?.hidden;
             return (
               <li key={type.id}>
                 <div className="flex w-full items-center justify-between transition hover:bg-cal-muted">
@@ -594,29 +598,31 @@ export const InfiniteEventTypeList = ({
                           />
                         )}
                         <div className="flex items-center justify-between space-x-2 rtl:space-x-reverse">
-                          {!isManagedEventType && (
-                            <>
-                              {type.hidden && <span className="text-gray-400 text-sm">{t("hidden")}</span>}
-                              <Tooltip
-                                content={
-                                  type.hidden ? t("show_eventtype_on_profile") : t("hide_from_profile")
-                                }>
-                                <div className="self-center rounded-md p-2">
-                                  <Switch
-                                    name="Hidden"
-                                    disabled={lockedByOrg}
-                                    checked={!type.hidden}
-                                    onCheckedChange={() => {
-                                      setHiddenMutation.mutate({
-                                        id: type.id,
-                                        hidden: !type.hidden,
-                                      });
-                                    }}
-                                  />
-                                </div>
-                              </Tooltip>
-                            </>
-                          )}
+                          <>
+                            {type.hidden && <span className="text-gray-400 text-sm">{t("hidden")}</span>}
+                            <Tooltip
+                              content={
+                                isChildHiddenLocked
+                                  ? t("locked_by_team_admin")
+                                  : type.hidden
+                                  ? t("show_eventtype_on_profile")
+                                  : t("hide_from_profile")
+                              }>
+                              <div className="self-center rounded-md p-2">
+                                <Switch
+                                  name="Hidden"
+                                  disabled={lockedByOrg || isChildHiddenLocked}
+                                  checked={!type.hidden}
+                                  onCheckedChange={() => {
+                                    setHiddenMutation.mutate({
+                                      id: type.id,
+                                      hidden: !type.hidden,
+                                    });
+                                  }}
+                                />
+                              </div>
+                            </Tooltip>
+                          </>
 
                           <ButtonGroup combined>
                             {!isManagedEventType && (
@@ -833,7 +839,7 @@ export const InfiniteEventTypeList = ({
                             </DropdownMenuItem>
                           )}
                           <DropdownMenuSeparator />
-                          {!isManagedEventType && (
+                          {!isChildHiddenLocked && (
                             <div className="flex h-9 cursor-pointer flex-row items-center justify-between rounded-b-lg px-4 py-2 transition hover:bg-subtle">
                               <Skeleton
                                 as={Label}

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/handleChildrenEventTypes.test.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/handleChildrenEventTypes.test.ts
@@ -1,0 +1,162 @@
+import type { PrismaClient } from "@calcom/prisma";
+import { SchedulingType } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it } from "vitest";
+import { type DeepMockProxy, mockDeep, mockReset } from "vitest-mock-extended";
+
+import handleChildrenEventTypes from "./handleChildrenEventTypes";
+
+const PARENT_ID = 1;
+
+// Minimal parent row returned by the `findUniqueOrThrow` used inside the engine.
+const buildParent = (overrides: Record<string, unknown> = {}) => ({
+  title: "Managed",
+  slug: "managed",
+  description: null,
+  length: 30,
+  hidden: false,
+  metadata: {},
+  position: 0,
+  scheduleId: null,
+  ...overrides,
+});
+
+const buildChildInput = (id: number, hidden = false) => ({
+  owner: { id, name: `user-${id}`, email: `user-${id}@example.com`, eventTypeSlugs: [] as string[] },
+  hidden,
+});
+
+describe("handleChildrenEventTypes", () => {
+  let prismaMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    prismaMock = mockDeep<PrismaClient>();
+    mockReset(prismaMock);
+  });
+
+  it("is a no-op for non-managed event types", async () => {
+    const res = await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.COLLECTIVE },
+      oldEventType: { children: [] },
+      children: [buildChildInput(2)],
+      prisma: prismaMock,
+    });
+
+    expect(res).toEqual({ message: "Not a managed event type" });
+    expect(prismaMock.eventType.findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+
+  it("creates children for newly assigned users and propagates the parent's hidden value when locked", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(buildParent({ hidden: true }) as never);
+
+    const res = await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [] },
+      // Child says hidden:false, but the field is locked → parent's hidden:true wins.
+      children: [buildChildInput(2, false)],
+      prisma: prismaMock,
+    });
+
+    expect(res).toMatchObject({ newUserIds: [2], oldUserIds: [], deletedUserIds: [] });
+    expect(prismaMock.eventType.create).toHaveBeenCalledTimes(1);
+    const createArg = prismaMock.eventType.create.mock.calls[0][0];
+    expect(createArg.data.hidden).toBe(true);
+    expect(createArg.data.parent).toEqual({ connect: { id: PARENT_ID } });
+    expect(createArg.data.owner).toEqual({ connect: { id: 2 } });
+  });
+
+  it("respects the child's own hidden value when the field is unlocked", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(
+      buildParent({
+        hidden: false,
+        metadata: { managedEventConfig: { unlockedFields: { hidden: true } } },
+      }) as never
+    );
+
+    await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [] },
+      children: [buildChildInput(2, true)],
+      prisma: prismaMock,
+    });
+
+    const createArg = prismaMock.eventType.create.mock.calls[0][0];
+    // Unlocked → the child's own hidden value (true) is used.
+    expect(createArg.data.hidden).toBe(true);
+  });
+
+  it("updates existing children with the parent's hidden value when locked", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(buildParent({ hidden: true }) as never);
+
+    const res = await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [{ userId: 2 }] },
+      children: [buildChildInput(2, false)],
+      prisma: prismaMock,
+    });
+
+    expect(res).toMatchObject({ newUserIds: [], oldUserIds: [2], deletedUserIds: [] });
+    expect(prismaMock.eventType.create).not.toHaveBeenCalled();
+    expect(prismaMock.eventType.updateMany).toHaveBeenCalledTimes(1);
+    const updateArg = prismaMock.eventType.updateMany.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ parentId: PARENT_ID, userId: 2 });
+    expect(updateArg.data.hidden).toBe(true);
+  });
+
+  it("deletes children for unassigned users", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(buildParent() as never);
+
+    const res = await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [{ userId: 2 }, { userId: 3 }] },
+      children: [buildChildInput(2)],
+      prisma: prismaMock,
+    });
+
+    expect(res).toMatchObject({ deletedUserIds: [3] });
+    expect(prismaMock.eventType.deleteMany).toHaveBeenCalledWith({
+      where: { parentId: PARENT_ID, userId: { in: [3] } },
+    });
+  });
+
+  it("syncs hidden to existing children on the quick-toggle path (no children payload)", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(buildParent({ hidden: true }) as never);
+
+    const res = await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [{ userId: 2 }, { userId: 3 }] },
+      children: undefined,
+      prisma: prismaMock,
+    });
+
+    expect(res).toMatchObject({ syncedUserIds: [2, 3] });
+    expect(prismaMock.eventType.updateMany).toHaveBeenCalledTimes(1);
+    const updateArg = prismaMock.eventType.updateMany.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ parentId: PARENT_ID, userId: { in: [2, 3] } });
+    expect(updateArg.data.hidden).toBe(true);
+  });
+
+  it("skips child creation when the assignee already owns an event with the same slug", async () => {
+    prismaMock.eventType.findUniqueOrThrow.mockResolvedValue(buildParent() as never);
+
+    await handleChildrenEventTypes({
+      eventTypeId: PARENT_ID,
+      updatedEventType: { slug: "managed", schedulingType: SchedulingType.MANAGED },
+      oldEventType: { children: [] },
+      children: [
+        {
+          owner: { id: 2, name: "u2", email: "u2@example.com", eventTypeSlugs: ["managed"] },
+          hidden: false,
+        },
+      ],
+      prisma: prismaMock,
+    });
+
+    expect(prismaMock.eventType.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/handleChildrenEventTypes.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/handleChildrenEventTypes.ts
@@ -1,0 +1,202 @@
+import type { ChildInput } from "@calcom/features/eventtypes/lib/types";
+import logger from "@calcom/lib/logger";
+import type { PrismaClient } from "@calcom/prisma";
+import { Prisma } from "@calcom/prisma/client";
+import { SchedulingType } from "@calcom/prisma/enums";
+import { EventTypeMetaDataSchema, allManagedEventTypePropsForZod } from "@calcom/prisma/zod-utils";
+
+const log = logger.getSubLogger({ prefix: ["handleChildrenEventTypes"] });
+
+// Managed scalar props whose values live on the parent but must never be copied
+// verbatim onto children:
+// - scheduleId: availability is per-assignee (unlocked by default)
+// - assignAllTeamMembers: parent-only assignment concept
+// - metadata: contains managedEventConfig which is parent-only (handled separately)
+// - hidden: has dedicated lock semantics (handled separately)
+// - position: children keep their own ordering
+const NON_PROPAGATED_PROPS = new Set<string>([
+  "scheduleId",
+  "assignAllTeamMembers",
+  "metadata",
+  "hidden",
+  "position",
+]);
+
+// Slug follows the parent on creation but is not re-propagated on updates to avoid
+// unique-constraint collisions (userId, slug) once a child exists.
+const UPDATE_EXCLUDED_PROPS = new Set<string>([...NON_PROPAGATED_PROPS, "slug"]);
+
+// Scalar Json columns that require Prisma.DbNull instead of a literal `null`.
+const JSON_PROPS = new Set<string>([
+  "locations",
+  "recurringEvent",
+  "bookingLimits",
+  "bookingFields",
+  "durationLimits",
+  "eventTypeColor",
+  "metadata",
+]);
+
+const MANAGED_SCALAR_KEYS = Object.keys(allManagedEventTypePropsForZod) as Array<
+  keyof typeof allManagedEventTypePropsForZod
+>;
+
+const coerceValue = (key: string, value: unknown) => {
+  if (JSON_PROPS.has(key)) {
+    return value === null || value === undefined ? Prisma.DbNull : (value as Prisma.InputJsonValue);
+  }
+  return value;
+};
+
+/**
+ * Builds a plain data object of the managed scalar props copied from the parent,
+ * skipping the excluded keys and any field the user has explicitly unlocked.
+ */
+const buildPropagatedData = (
+  parent: Record<string, unknown>,
+  excluded: Set<string>,
+  unlockedFields: Record<string, boolean | undefined>
+) => {
+  const data: Record<string, unknown> = {};
+  for (const key of MANAGED_SCALAR_KEYS) {
+    if (excluded.has(key)) continue;
+    // Unlocked fields are owned by the assignee and must not be overwritten.
+    if (unlockedFields[key]) continue;
+    data[key] = coerceValue(key, parent[key as keyof typeof parent]);
+  }
+  return data;
+};
+
+type HandleChildrenEventTypesArgs = {
+  eventTypeId: number;
+  updatedEventType: { slug: string; schedulingType: SchedulingType | null };
+  oldEventType: { children?: { userId: number | null }[] | null };
+  children?: ChildInput[];
+  prisma: PrismaClient;
+};
+
+/**
+ * Synchronises the child event types of a managed event type with the list of
+ * assigned users, propagating the parent's locked managed props (including the
+ * `hidden` / "Hide from profile" toggle) to each child.
+ *
+ * Lock semantics for `hidden`:
+ * - locked (default, not in unlockedFields): every child inherits the parent's `hidden`.
+ * - unlocked: each child keeps its own `hidden` value supplied in the payload.
+ */
+export default async function handleChildrenEventTypes({
+  eventTypeId,
+  updatedEventType,
+  oldEventType,
+  children,
+  prisma,
+}: HandleChildrenEventTypesArgs) {
+  // Only managed event types have children to propagate to.
+  if (updatedEventType.schedulingType !== SchedulingType.MANAGED) {
+    return { message: "Not a managed event type" };
+  }
+
+  // Fetch the freshly-updated parent scalar values to copy onto children.
+  const parent = await prisma.eventType.findUniqueOrThrow({
+    where: { id: eventTypeId },
+    select: { ...allManagedEventTypePropsForZod },
+  });
+
+  const metadata = EventTypeMetaDataSchema.safeParse(parent.metadata);
+  const unlockedFields =
+    (metadata.success && metadata.data?.managedEventConfig?.unlockedFields) || ({} as Record<string, boolean>);
+  const isHiddenLocked = !unlockedFields.hidden;
+
+  const previousUserIds = (oldEventType.children ?? [])
+    .map((child) => child.userId)
+    .filter((userId): userId is number => typeof userId === "number");
+
+  // Quick-update path: the full assignment list isn't part of this request (e.g. the
+  // "Hide from profile" toggle in the event type listing only sends `{ id, hidden }`).
+  // Sync the locked managed props to the existing children without creating/deleting any.
+  if (!children) {
+    if (!previousUserIds.length) {
+      return { message: "No children to sync" };
+    }
+    const updateData = buildPropagatedData(parent, UPDATE_EXCLUDED_PROPS, unlockedFields);
+    await prisma.eventType.updateMany({
+      where: { parentId: eventTypeId, userId: { in: previousUserIds } },
+      data: {
+        ...(updateData as Prisma.EventTypeUpdateManyMutationInput),
+        // Only propagate hidden when it is a locked field; when unlocked, children own it.
+        ...(isHiddenLocked ? { hidden: parent.hidden } : {}),
+      },
+    });
+    return { syncedUserIds: previousUserIds };
+  }
+
+  const currentUserIds = children.map((child) => child.owner.id);
+
+  const deletedUserIds = previousUserIds.filter((userId) => !currentUserIds.includes(userId));
+  const newUserIds = currentUserIds.filter((userId) => !previousUserIds.includes(userId));
+  const oldUserIds = currentUserIds.filter((userId) => previousUserIds.includes(userId));
+
+  // Children carry the parent's metadata (including managedEventConfig.unlockedFields)
+  // so the child editor knows which fields are locked. Copied verbatim on creation.
+  const childMetadata = coerceValue("metadata", parent.metadata);
+
+  // 1) Create children for newly assigned users.
+  if (newUserIds.length) {
+    const createBase = buildPropagatedData(parent, NON_PROPAGATED_PROPS, {});
+    await Promise.all(
+      newUserIds.map((userId) => {
+        const childInput = children.find((child) => child.owner.id === userId);
+        // Skip if the assignee already owns an event type with this slug to avoid collisions.
+        if (childInput?.owner.eventTypeSlugs.includes(updatedEventType.slug)) {
+          log.warn(
+            `Skipping child creation for user ${userId}: slug "${updatedEventType.slug}" already in use`
+          );
+          return Promise.resolve();
+        }
+        const hidden = isHiddenLocked ? parent.hidden : childInput?.hidden ?? false;
+        return prisma.eventType.create({
+          data: {
+            ...(createBase as Prisma.EventTypeCreateInput),
+            slug: parent.slug,
+            hidden,
+            metadata: childMetadata,
+            parent: { connect: { id: eventTypeId } },
+            owner: { connect: { id: userId } },
+            users: { connect: { id: userId } },
+          },
+        });
+      })
+    );
+  }
+
+  // 2) Update existing children with the parent's locked managed props.
+  if (oldUserIds.length) {
+    const updateData = buildPropagatedData(parent, UPDATE_EXCLUDED_PROPS, unlockedFields);
+    await Promise.all(
+      oldUserIds.map((userId) => {
+        const childInput = children.find((child) => child.owner.id === userId);
+        const hidden = isHiddenLocked ? parent.hidden : childInput?.hidden ?? false;
+        return prisma.eventType.updateMany({
+          where: { parentId: eventTypeId, userId },
+          data: {
+            ...(updateData as Prisma.EventTypeUpdateManyMutationInput),
+            hidden,
+          },
+        });
+      })
+    );
+  }
+
+  // 3) Remove children for unassigned users.
+  if (deletedUserIds.length) {
+    await prisma.eventType.deleteMany({
+      where: { parentId: eventTypeId, userId: { in: deletedUserIds } },
+    });
+  }
+
+  return {
+    newUserIds,
+    oldUserIds,
+    deletedUserIds,
+  };
+}

--- a/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/heavy/update.handler.ts
@@ -25,10 +25,10 @@ import {
   handleCustomInputs,
   handlePeriodType,
 } from "../util";
+import handleChildrenEventTypes from "./handleChildrenEventTypes";
 import type { TUpdateInputSchema } from "./update.schema";
 
 const isUrlScanningEnabled = (..._args: unknown[]) => false;
-const updateChildrenEventTypes = async (..._args: unknown[]) => {};
 const allowDisablingHostConfirmationEmails = (..._args: unknown[]): boolean => false;
 const allowDisablingAttendeeConfirmationEmails = (..._args: unknown[]): boolean => false;
 
@@ -722,35 +722,15 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     });
   }
 
-  const updatedValues = Object.entries(data).reduce<Record<string, unknown>>((acc, [key, value]) => {
-    if (value !== undefined) {
-      acc[key] = value;
-    }
-    return acc;
-  }, {});
-
-  // Determine calVideoSettings to pass to children:
-  // - If calVideoSettings provided in input, sync to children
-  // - If Cal Video location removed, delete from children (pass null)
-  // - Otherwise, leave children's settings untouched (pass undefined)
-  let calVideoSettingsForChildren: typeof calVideoSettings | null | undefined;
-  if (calVideoSettings !== undefined) {
-    calVideoSettingsForChildren = calVideoSettings;
-  } else if (eventType.calVideoSettings && !isCalVideoLocationActive) {
-    calVideoSettingsForChildren = null;
-  }
-
-  // Handling updates to children event types (managed events types)
-  await updateChildrenEventTypes({
+  // Handling updates to children event types (managed events types).
+  // Propagates the parent's locked managed props (including the `hidden` /
+  // "Hide from profile" toggle) to the assigned child event types.
+  await handleChildrenEventTypes({
     eventTypeId: id,
-    currentUserId: ctx.user.id,
-    oldEventType: eventType,
     updatedEventType,
+    oldEventType: eventType,
     children,
-    profileId: ctx.user.profile.id,
     prisma: ctx.prisma,
-    updatedValues,
-    calVideoSettings: calVideoSettingsForChildren,
   });
 
   // Clean up empty host groups


### PR DESCRIPTION
## What does this PR do?

Adds support for the **"Hide from profile"** toggle for managed event types and propagates the value to assigned child event types, matching the behavior of standard event types.

When configured on a managed parent event, the `hidden` value is synced to child events and respects the existing lock/unlock mechanism via `managedEventConfig.unlockedFields`.

Fixes #25903

## Motivation

The **"Hide from profile"** setting was available for standard event types but missing for managed events, preventing team admins from hiding managed event bookings from assignees' public profiles.

This PR brings managed events to feature parity with standard event types.

## Changes

### `handleChildrenEventTypes.ts`

* Implemented child event synchronization logic.
* Creates child event types for newly assigned users.
* Updates existing children with locked parent properties.
* Removes children for unassigned users.
* Supports syncing `hidden` through the listing quick-toggle flow.

#### Hidden field behavior

* **Locked (default):** children inherit the parent's `hidden` value.
* **Unlocked:** children retain their own `hidden` value.

### `update.handler.ts`

* Replaced the previous stub implementation with the new synchronization engine.

### `event-types-listing-view.tsx`

* Enabled the toggle for managed parent events.
* Disabled the toggle for child events when the field is locked.
* Added a **"Locked by team admin"** tooltip.

## Notes

`updateNewTeamMemberEventTypes` (member joins after event creation) is still a stub in this implementation. Newly added members receive the updated child event on the next managed event save or via **Assign All**.

Support for that flow can be added in a follow-up PR if required.
