### PR TITLE
fix(a11y): announce event durations correctly for screen readers

### DIFF
--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -1,17 +1,19 @@
-import type { Dispatch, SetStateAction } from "react";
-import type { FC } from "react";
-import React from "react";
-import { useFieldArray, useFormContext } from "react-hook-form";
-
+import {
+  getDurationMinutesAccessibleLabel,
+  getDurationMinutesFormatted,
+} from "@calcom/lib/formatEventDuration";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import { EventTypeMetaDataSchema } from "@calcom/prisma/zod-utils";
 import { Avatar } from "@calcom/ui/components/avatar";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
+import { DurationText } from "@calcom/ui/components/duration";
 import { ScrollableArea } from "@calcom/ui/components/scrollable";
-
-import type { TEventType, TEventTypesForm, TEventTypeGroup } from "~/apps/installation/[[...step]]/step-view";
+import type { Dispatch, FC, SetStateAction } from "react";
+import React from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import type { TEventType, TEventTypeGroup, TEventTypesForm } from "~/apps/installation/[[...step]]/step-view";
 
 type EventTypesCardProps = {
   userName: string;
@@ -35,6 +37,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
   team,
   userName,
 }) => {
+  const { t } = useLocale();
   const parsedMetaData = EventTypeMetaDataSchema.safeParse(metadata);
   const multipleDuration =
     parsedMetaData.success && parsedMetaData.data?.multipleDuration
@@ -77,7 +80,9 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
             {Boolean(durations.length) &&
               durations.map((duration) => (
                 <Badge key={`event-type-${id}-duration-${duration}`} variant="gray" startIcon="clock">
-                  {duration}m
+                  <DurationText label={getDurationMinutesAccessibleLabel(duration, t) ?? ""}>
+                    {getDurationMinutesFormatted(duration, t)}
+                  </DurationText>
                 </Badge>
               ))}
           </div>

--- a/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
+++ b/apps/web/modules/bookings/components/BookEventForm/BookFormAsModal.tsx
@@ -1,18 +1,16 @@
-import type { ReactNode } from "react";
-import React from "react";
-
 import { useEventTypeById } from "@calcom/atoms/hooks/event-types/private/useEventTypeById";
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
+import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
+import { FromTime } from "@calcom/features/bookings/Booker/utils/dates";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { getDurationAccessibleLabel, getDurationFormatted } from "@calcom/lib/formatEventDuration";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui/components/badge";
 import { DialogContent } from "@calcom/ui/components/dialog";
-
-import { getDurationFormatted } from "../event-meta/Duration";
-import { FromTime } from "@calcom/features/bookings/Booker/utils/dates";
+import { DurationText } from "@calcom/ui/components/duration";
 import { useEvent } from "@calcom/web/modules/schedules/hooks/useEvent";
-import { useBookerTime } from "@calcom/features/bookings/Booker/hooks/useBookerTime";
+import type { ReactNode } from "react";
 
 const BookEventFormWrapper = ({ children, onCancel }: { onCancel: () => void; children: ReactNode }) => {
   const { data } = useEvent();
@@ -65,7 +63,9 @@ export const BookEventFormWrapperComponent = ({
         </Badge>
         {(selectedDuration || eventLength) && (
           <Badge variant="grayWithoutHover" startIcon="clock" size="lg">
-            <span>{getDurationFormatted(selectedDuration || eventLength, t)}</span>
+            <DurationText label={getDurationAccessibleLabel(selectedDuration || eventLength, t) ?? ""}>
+              {getDurationFormatted(selectedDuration || eventLength, t)}
+            </DurationText>
           </Badge>
         )}
 

--- a/apps/web/modules/bookings/components/event-meta/Duration.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Duration.tsx
@@ -1,40 +1,23 @@
-import type { TFunction } from "i18next";
-import { useEffect, useRef } from "react";
-
-import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import { useIsEmbed } from "@calcom/embed-core/embed-iframe";
-import { useShouldShowArrows } from "@calcom/web/modules/apps/components/AllApps";
 import { useBookerStoreContext } from "@calcom/features/bookings/Booker/BookerStoreProvider";
 import type { BookerEvent } from "@calcom/features/bookings/types";
+import { getDurationAccessibleLabel, getDurationFormatted } from "@calcom/lib/formatEventDuration";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
+import { DurationText } from "@calcom/ui/components/duration";
+import { useShouldShowArrows } from "@calcom/web/modules/apps/components/AllApps";
 import { ChevronLeftIcon, ChevronRightIcon } from "@coss/ui/icons";
+import { useEffect, useRef } from "react";
 
-/** Render X mins as X hours or X hours Y mins instead of in minutes once >= 60 minutes */
-export const getDurationFormatted = (mins: number | undefined, t: TFunction) => {
-  if (!mins) return null;
+export { getDurationFormatted } from "@calcom/lib/formatEventDuration";
 
-  const hours = Math.floor(mins / 60);
-  mins %= 60;
-  // format minutes string
-  let minStr = "";
-  if (mins > 0) {
-    minStr =
-      mins === 1
-        ? t("minute_one_short", { count: 1 })
-        : t("multiple_duration_timeUnit_short", { count: mins, unit: "minute" });
-  }
-  // format hours string
-  let hourStr = "";
-  if (hours > 0) {
-    hourStr =
-      hours === 1
-        ? t("hour_one_short", { count: 1 })
-        : t("multiple_duration_timeUnit_short", { count: hours, unit: "hour" });
-  }
+const renderDuration = (minutes: number | undefined, t: ReturnType<typeof useLocale>["t"]) => {
+  const formatted = getDurationFormatted(minutes, t);
+  const label = getDurationAccessibleLabel(minutes, t);
 
-  if (hourStr && minStr) return `${hourStr} ${minStr}`;
-  return hourStr || minStr;
+  if (!formatted || !label) return null;
+
+  return <DurationText label={label}>{formatted}</DurationText>;
 };
 
 export const EventDuration = ({
@@ -44,7 +27,6 @@ export const EventDuration = ({
 }) => {
   const { t } = useLocale();
   const itemRefs = useRef<(HTMLLIElement | null)[]>([]);
-  const isPlatform = useIsPlatform();
   const [selectedDuration, setSelectedDuration, state] = useBookerStoreContext((state) => [
     state.selectedDuration,
     state.setSelectedDuration,
@@ -89,8 +71,7 @@ export const EventDuration = ({
     return () => clearTimeout(timeout);
   }, [selectedDuration, isEmbed]);
 
-  if (!event?.metadata?.multipleDuration && !isDynamicEvent)
-    return <>{getDurationFormatted(event.length, t)}</>;
+  if (!event?.metadata?.multipleDuration && !isDynamicEvent) return <>{renderDuration(event.length, t)}</>;
 
   const durations = event?.metadata?.multipleDuration || [15, 30, 60, 90];
   const hideDurationSelector = event?.metadata?.hideDurationSelectorInBookingPage;
@@ -98,7 +79,7 @@ export const EventDuration = ({
   // When duration selector is hidden, show only the selected/default duration as text
   // URL params can still set the duration, but the user cannot change it via UI
   if (hideDurationSelector) {
-    return <>{getDurationFormatted(selectedDuration || event.length, t)}</>;
+    return <>{renderDuration(selectedDuration || event.length, t)}</>;
   }
 
   return selectedDuration ? (
@@ -122,13 +103,14 @@ export const EventDuration = ({
               data-testId={`multiple-choice-${duration}mins`}
               data-active={selectedDuration === duration ? "true" : "false"}
               key={index}
+              aria-label={getDurationAccessibleLabel(duration, t) ?? undefined}
               onClick={() => setSelectedDuration(duration)}
               ref={(el) => (itemRefs.current[duration] = el)}
               className={classNames(
                 selectedDuration === duration ? "bg-emphasis" : "hover:text-emphasis",
                 "text-default cursor-pointer rounded-[4px] px-3 py-1.5 text-sm leading-tight transition"
               )}>
-              <div className="w-max">{getDurationFormatted(duration, t)}</div>
+              <div className="w-max">{renderDuration(duration, t)}</div>
             </li>
           ))}
       </ul>

--- a/apps/web/modules/event-types/components/EventTypeDescription.tsx
+++ b/apps/web/modules/event-types/components/EventTypeDescription.tsx
@@ -1,17 +1,21 @@
-import { useMemo } from "react";
-
 import { getPaymentAppData } from "@calcom/app-store/_utils/payments/getPaymentAppData";
 import { eventTypeMetaDataSchemaWithTypedApps } from "@calcom/app-store/zod-utils";
 import { Price } from "@calcom/features/bookings/components/event-meta/Price";
-import { PriceIcon } from "@calcom/web/modules/bookings/components/event-meta/PriceIcon";
+import {
+  getDurationMinutesAccessibleLabel,
+  getDurationMinutesFormatted,
+} from "@calcom/lib/formatEventDuration";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { parseRecurringEvent } from "@calcom/lib/isRecurringEvent";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
 import type { baseEventTypeSelect } from "@calcom/prisma";
-import type { Prisma, EventType } from "@calcom/prisma/client";
+import type { EventType, Prisma } from "@calcom/prisma/client";
 import { SchedulingType } from "@calcom/prisma/enums";
 import classNames from "@calcom/ui/classNames";
 import { Badge } from "@calcom/ui/components/badge";
+import { DurationText } from "@calcom/ui/components/duration";
+import { PriceIcon } from "@calcom/web/modules/bookings/components/event-meta/PriceIcon";
+import { useMemo } from "react";
 
 export type EventTypeDescriptionProps = {
   eventType: Pick<
@@ -69,14 +73,18 @@ export const EventTypeDescription = ({
             metadata.multipleDuration.map((dur, idx) => (
               <li key={idx}>
                 <Badge variant="gray" startIcon="clock">
-                  {dur}m
+                  <DurationText label={getDurationMinutesAccessibleLabel(dur, t) ?? ""}>
+                    {getDurationMinutesFormatted(dur, t)}
+                  </DurationText>
                 </Badge>
               </li>
             ))
           ) : (
             <li>
               <Badge variant="gray" startIcon="clock">
-                {eventType.length}m
+                <DurationText label={getDurationMinutesAccessibleLabel(eventType.length, t) ?? ""}>
+                  {getDurationMinutesFormatted(eventType.length, t)}
+                </DurationText>
               </Badge>
             </li>
           )}
@@ -122,7 +130,7 @@ export const EventTypeDescription = ({
             </li>
           )}
           {/* TODO: Maybe add a tool tip to this? */}
-          {eventType.requiresConfirmation || (recurringEvent?.count) ? (
+          {eventType.requiresConfirmation || recurringEvent?.count ? (
             <li className="block xl:hidden">
               <Badge variant="gray" startIcon="plus">
                 <p>{[eventType.requiresConfirmation, recurringEvent?.count].filter(Boolean).length}</p>

--- a/packages/lib/formatEventDuration.test.ts
+++ b/packages/lib/formatEventDuration.test.ts
@@ -1,0 +1,89 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+import {
+  getDurationAccessibleLabel,
+  getDurationFormatted,
+  getDurationMinutesAccessibleLabel,
+  getDurationMinutesFormatted,
+} from "./formatEventDuration";
+
+const mockT = ((key: string, options?: { count?: number; unit?: string }) => {
+  const count = options?.count ?? 0;
+
+  switch (key) {
+    case "minute_one_short":
+      return `${count}m`;
+    case "hour_one_short":
+      return `${count}h`;
+    case "multiple_duration_timeUnit_short":
+      return `${count}${options?.unit === "hour" ? "h" : "m"}`;
+    case "minute_one":
+      return "1 minute";
+    case "minute_other":
+      return `${count} minutes`;
+    case "hour_one":
+      return "1 hour";
+    case "hour_other":
+      return `${count} hours`;
+    default:
+      return key;
+  }
+}) as TFunction;
+
+describe("formatEventDuration", () => {
+  describe("getDurationFormatted", () => {
+    it("formats minutes under one hour", () => {
+      expect(getDurationFormatted(30, mockT)).toBe("30m");
+    });
+
+    it("formats exact hours", () => {
+      expect(getDurationFormatted(60, mockT)).toBe("1h");
+    });
+
+    it("formats hours and minutes", () => {
+      expect(getDurationFormatted(90, mockT)).toBe("1h 30m");
+    });
+
+    it("returns null for empty values", () => {
+      expect(getDurationFormatted(undefined, mockT)).toBeNull();
+      expect(getDurationFormatted(0, mockT)).toBeNull();
+    });
+  });
+
+  describe("getDurationAccessibleLabel", () => {
+    it("announces minutes for sub-hour durations", () => {
+      expect(getDurationAccessibleLabel(30, mockT)).toBe("30 minutes");
+    });
+
+    it("announces one hour for 60 minutes", () => {
+      expect(getDurationAccessibleLabel(60, mockT)).toBe("1 hour");
+    });
+
+    it("announces hours and minutes for mixed durations", () => {
+      expect(getDurationAccessibleLabel(90, mockT)).toBe("1 hour 30 minutes");
+    });
+
+    it("announces singular minute", () => {
+      expect(getDurationAccessibleLabel(1, mockT)).toBe("1 minute");
+    });
+
+    it("returns null for empty values", () => {
+      expect(getDurationAccessibleLabel(undefined, mockT)).toBeNull();
+      expect(getDurationAccessibleLabel(0, mockT)).toBeNull();
+    });
+  });
+
+  describe("getDurationMinutesFormatted", () => {
+    it("keeps durations as total minutes", () => {
+      expect(getDurationMinutesFormatted(90, mockT)).toBe("90m");
+      expect(getDurationMinutesFormatted(60, mockT)).toBe("60m");
+    });
+  });
+
+  describe("getDurationMinutesAccessibleLabel", () => {
+    it("announces total minutes for long durations", () => {
+      expect(getDurationMinutesAccessibleLabel(90, mockT)).toBe("90 minutes");
+      expect(getDurationMinutesAccessibleLabel(60, mockT)).toBe("60 minutes");
+    });
+  });
+});

--- a/packages/lib/formatEventDuration.ts
+++ b/packages/lib/formatEventDuration.ts
@@ -1,0 +1,61 @@
+import type { TFunction } from "i18next";
+
+/** Render X mins as X hours or X hours Y mins instead of in minutes once >= 60 minutes */
+export const getDurationFormatted = (mins: number | undefined, t: TFunction) => {
+  if (!mins) return null;
+
+  const hours = Math.floor(mins / 60);
+  const remainingMinutes = mins % 60;
+  let minStr = "";
+  if (remainingMinutes > 0) {
+    minStr =
+      remainingMinutes === 1
+        ? t("minute_one_short", { count: 1 })
+        : t("multiple_duration_timeUnit_short", { count: remainingMinutes, unit: "minute" });
+  }
+  let hourStr = "";
+  if (hours > 0) {
+    hourStr =
+      hours === 1
+        ? t("hour_one_short", { count: 1 })
+        : t("multiple_duration_timeUnit_short", { count: hours, unit: "hour" });
+  }
+
+  if (hourStr && minStr) return `${hourStr} ${minStr}`;
+  return hourStr || minStr;
+};
+
+export const getDurationAccessibleLabel = (mins: number | undefined, t: TFunction) => {
+  if (!mins) return null;
+
+  const hours = Math.floor(mins / 60);
+  const remainingMinutes = mins % 60;
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(hours === 1 ? t("hour_one", { count: 1 }) : t("hour_other", { count: hours }));
+  }
+  if (remainingMinutes > 0) {
+    parts.push(
+      remainingMinutes === 1 ? t("minute_one", { count: 1 }) : t("minute_other", { count: remainingMinutes })
+    );
+  }
+
+  return parts.join(" ") || null;
+};
+
+/** Always show total minutes (e.g. 90m) for compact event cards. */
+export const getDurationMinutesFormatted = (mins: number | undefined, t: TFunction) => {
+  if (!mins) return null;
+
+  return mins === 1
+    ? t("minute_one_short", { count: 1 })
+    : t("multiple_duration_timeUnit_short", { count: mins, unit: "minute" });
+};
+
+/** Screen reader label matching minutes-only display (e.g. "90 minutes"). */
+export const getDurationMinutesAccessibleLabel = (mins: number | undefined, t: TFunction) => {
+  if (!mins) return null;
+
+  return mins === 1 ? t("minute_one", { count: 1 }) : t("minute_other", { count: mins });
+};

--- a/packages/platform/atoms/event-types/__tests__/EventTypeListItem.test.tsx
+++ b/packages/platform/atoms/event-types/__tests__/EventTypeListItem.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
-
-import type { AtomEventTypeListItem } from "../types";
 import { EventTypeListItem } from "../components/EventTypeListItem";
+import type { AtomEventTypeListItem } from "../types";
 
 // Mock auto-animate
 vi.mock("@formkit/auto-animate/react", () => ({
@@ -18,7 +17,26 @@ vi.mock("next/link", () => ({
 // Mock useLocale
 vi.mock("@calcom/lib/hooks/useLocale", () => ({
   useLocale: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: { count?: number }) => {
+      const count = options?.count ?? 0;
+
+      switch (key) {
+        case "minute_one_short":
+          return `${count}m`;
+        case "multiple_duration_timeUnit_short":
+          return `${count}${options?.unit === "hour" ? "h" : "m"}`;
+        case "minute_one":
+          return "1 minute";
+        case "minute_other":
+          return `${count} minutes`;
+        case "hour_one":
+          return "1 hour";
+        case "hour_other":
+          return `${count} hours`;
+        default:
+          return key;
+      }
+    },
   }),
 }));
 
@@ -87,6 +105,7 @@ describe("EventTypeListItem", () => {
     expect(screen.getByText("30 Min Meeting")).toBeInTheDocument();
     expect(screen.getByText("Quick meeting")).toBeInTheDocument();
     expect(screen.getByText(/30m/)).toBeInTheDocument();
+    expect(screen.getByLabelText("30 minutes")).toBeInTheDocument();
   });
 
   it("should render as link when getEventTypeUrl is provided", () => {
@@ -144,7 +163,8 @@ describe("EventTypeListItem", () => {
       <EventTypeListItem eventType={longEvent} deleteFunction={mockDeleteFunction} isDeletable={true} />
     );
 
-    expect(screen.getByText(/2h/)).toBeInTheDocument();
+    expect(screen.getByText(/120m/)).toBeInTheDocument();
+    expect(screen.getByLabelText("120 minutes")).toBeInTheDocument();
   });
 
   it("should render event type with long title without breaking layout", () => {

--- a/packages/platform/atoms/event-types/components/EventTypeListItem.tsx
+++ b/packages/platform/atoms/event-types/components/EventTypeListItem.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import Link from "next/link";
-import { useState } from "react";
-
+import {
+  getDurationMinutesAccessibleLabel,
+  getDurationMinutesFormatted,
+} from "@calcom/lib/formatEventDuration";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
-import { Dialog, ConfirmationDialogContent } from "@calcom/ui/components/dialog";
+import { ConfirmationDialogContent, Dialog } from "@calcom/ui/components/dialog";
 import {
   Dropdown,
   DropdownItem,
@@ -15,12 +16,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@calcom/ui/components/dropdown";
+import { DurationText } from "@calcom/ui/components/duration";
 import { showToast } from "@calcom/ui/components/toast";
-
+import Link from "next/link";
+import { useState } from "react";
 import type { AtomEventTypeListItem } from "../types";
-import { formatEventTypeDuration } from "../lib/formatEventTypeDuration";
 
 const EventTypeContent = ({ eventType }: { eventType: AtomEventTypeListItem }) => {
+  const { t } = useLocale();
+
   return (
     <div>
       <div className="space-x-2 rtl:space-x-reverse">
@@ -29,7 +33,9 @@ const EventTypeContent = ({ eventType }: { eventType: AtomEventTypeListItem }) =
       <div className="text-subtle mt-1">
         {eventType.description && <span className="block">{eventType.description}</span>}
         <Badge variant="gray" className="text-xs">
-          {formatEventTypeDuration(eventType.length)}
+          <DurationText label={getDurationMinutesAccessibleLabel(eventType.length, t) ?? ""}>
+            {getDurationMinutesFormatted(eventType.length, t)}
+          </DurationText>
         </Badge>
       </div>
     </div>

--- a/packages/ui/components/duration/DurationText.tsx
+++ b/packages/ui/components/duration/DurationText.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function DurationText({ label, children }: { label: string; children: ReactNode }) {
+  return <span aria-label={label}>{children}</span>;
+}

--- a/packages/ui/components/duration/index.ts
+++ b/packages/ui/components/duration/index.ts
@@ -1,0 +1,1 @@
+export { DurationText } from "./DurationText";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "./components/dialog": "./components/dialog/index.ts",
     "./components/disconnect-calendar-integration": "./components/disconnect-calendar-integration/index.ts",
     "./components/divider": "./components/divider/index.ts",
+    "./components/duration": "./components/duration/index.ts",
     "./components/dropdown": "./components/dropdown/index.ts",
     "./components/editable-heading": "./components/editable-heading/index.ts",
     "./components/editor": "./components/editor/index.ts",


### PR DESCRIPTION
Add aria-label with full duration text (e.g. "30 minutes") while keeping abbreviated visible labels (30m, 1h). Introduces formatEventDuration helpers and DurationText; event cards use minutes-only display, booking pages keep hour-aware formatting.

## What does this PR do?

Fixes VoiceOver (and similar screen readers) misreading duration abbreviations on event type cards and booking pages — e.g. 30m announced as "30 metres" and 1h as "one age".

Approach (Option 1 from the issue): keep short visible text, add explicit aria-label with expanded duration via i18n (minute_one, minute_other, hour_one, hour_other).

Changes:

- packages/lib/formatEventDuration.ts — short formatters + accessible label helpers

- packages/ui/components/duration/DurationText.tsx — <span aria-label={label}>{children}</span>

- Event cards / installation cards / platform lists — minutes-only display (90m) + label (90 minutes)

- Booking page (Duration.tsx, BookFormAsModal) — hour-aware display (1h 30m) + matching label (1 hour 30 minutes)


- Fixes #29750 

## Visual Demo (For contributors especially)

N/A — no visible UI change on event cards (still 30m, 90m, etc.). Fix is for screen reader announcements.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [ ✓.] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [✓. ] I have updated the developer docs if this PR makes changes that would require a documentation change. **N/A — no documentation changes required.**
- [✓. ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Automated
`
yarn vitest run packages/lib/formatEventDuration.test.ts
yarn vitest run packages/platform/atoms/event-types/__tests__/EventTypeListItem.test.tsx
yarn biome check packages/lib/formatEventDuration.ts packages/ui/components/duration/
`

Manual (VoiceOver)

1. macOS: Cmd+F5 to enable VoiceOver, open Safari
2. Visit a user's public booking page with multiple event types (e.g. 30-min and 60-min)
3. Navigate event cards with Rotor / arrow keys
4. Expected: "30 minutes", "60 minutes" (or "1 hour" on booking page for 60-min hour-aware display)
5. Open a single event booking page — duration in sidebar and pills should announce correctly

**Environment**: Standard Cal.diy dev setup; no new env vars.
**Happy path**:  Event with length: 30 → visible 30m, VoiceOver says "30 minutes"

