### PR TITLE
fix(docs): update Zoom marketplace app creation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ following
 6. Click **Create** to proceed.
 7. Use the **Development** tab credentials for self-hosted Cal.diy. Copy **Client ID** and **Client Secret** into your `.env` file:
 
-   ```
+   ```dotenv
    ZOOM_CLIENT_ID=your_zoom_client_id
    ZOOM_CLIENT_SECRET=your_zoom_client_secret
    ```

--- a/README.md
+++ b/README.md
@@ -713,7 +713,14 @@ following
 4. Name your app.
 5. Under **Select how the app is managed**, choose **User-managed app**.
 6. Click **Create** to proceed.
-7. Use the **Development** tab credentials for self-hosted Cal.diy. Copy **Client ID** and **Client Secret** into `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET` in your `.env` file. You do not need to publish the app to the Zoom App Marketplace or activate Production for self-hosted use.
+7. Use the **Development** tab credentials for self-hosted Cal.diy. Copy **Client ID** and **Client Secret** into your `.env` file:
+
+   ```
+   ZOOM_CLIENT_ID=your_zoom_client_id
+   ZOOM_CLIENT_SECRET=your_zoom_client_secret
+   ```
+
+   **Development credentials** work for Zoom users on the app owner's account (typical for a single self-hosted instance you operate). To let other Zoom accounts connect, activate the **Production** version and complete Zoom's app publishing review.
 8. Set the **OAuth Redirect URL** under **OAuth Information** to `<Cal.diy URL>/api/integrations/zoomvideo/callback`, replacing `<Cal.diy URL>` with your application URL.
 9. Add the same URL to the **OAuth Allow List** and enable **Subdomain check**. Confirm it shows **saved** below the form.
 10. Go to **Scopes** → **+ Add Scopes**:

--- a/README.md
+++ b/README.md
@@ -708,19 +708,20 @@ following
 ### Obtaining Zoom Client ID and Secret
 
 1. Open [Zoom Marketplace](https://marketplace.zoom.us/) and sign in with your Zoom account.
-2. On the upper right, click "Develop" => "Build App".
-3. Select "General App" , click "Create".
-4. Name your App.
-5. Choose "User-managed app" for "Select how the app is managed".
-6. De-select the option to publish the app on the Zoom App Marketplace, if asked.
-7. Now copy the Client ID and Client Secret to your `.env` file into the `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET` fields.
-8. Set the "OAuth Redirect URL" under "OAuth Information" as `<Cal.diy URL>/api/integrations/zoomvideo/callback` replacing Cal.diy URL with the URI at which your application runs.
-9. Also add the redirect URL given above as an allow list URL and enable "Subdomain check". Make sure, it says "saved" below the form.
-10. You don't need to provide basic information about your app. Instead click on "Scopes" and then on "+ Add Scopes". On the left,
-    1. click the category "Meeting" and check the scope `meeting:write:meeting`.
-    2. click the category "User" and check the scope `user:read:settings`.
-11. Click "Done".
-12. You're good to go. Now you can easily add your Zoom integration in the Cal.diy settings.
+2. On the upper right, click **Develop** → **Build App**.
+3. Select **General App** and click **Create**.
+4. Name your app.
+5. Under **Select how the app is managed**, choose **User-managed app**.
+6. Click **Create** to proceed.
+7. Use the **Development** tab credentials for self-hosted Cal.diy. Copy **Client ID** and **Client Secret** into `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET` in your `.env` file. You do not need to publish the app to the Zoom App Marketplace or activate Production for self-hosted use.
+8. Set the **OAuth Redirect URL** under **OAuth Information** to `<Cal.diy URL>/api/integrations/zoomvideo/callback`, replacing `<Cal.diy URL>` with your application URL.
+9. Add the same URL to the **OAuth Allow List** and enable **Subdomain check**. Confirm it shows **saved** below the form.
+10. Go to **Scopes** → **+ Add Scopes**:
+    1. **Meeting** → `meeting:write:meeting`
+    2. **User** → `user:read:settings`
+11. Click **Done**.
+12. If Zoom prompts **Add App Now**, you can skip it for Cal.diy — OAuth from Cal.diy settings is sufficient.
+13. Restart Cal.diy after updating `.env`, then connect Zoom from **Settings → Conferencing apps**.
 
 ### Obtaining Daily API Credentials
 

--- a/apps/docs/content/apps/zoom.mdx
+++ b/apps/docs/content/apps/zoom.mdx
@@ -17,11 +17,11 @@
 7. **Use Development Credentials** — Zoom shows **Development** and **Production** tabs. For self-hosted Cal.diy, use the **Development** tab and copy the **Client ID** and **Client Secret** into your `.env` file:
 
 ```
-ZOOM_CLIENT_ID
-ZOOM_CLIENT_SECRET
+ZOOM_CLIENT_ID=your_zoom_client_id
+ZOOM_CLIENT_SECRET=your_zoom_client_secret
 ```
 
-   You do not need to publish the app to the Zoom App Marketplace or activate a Production version for self-hosted use.
+   **Development credentials** work for Zoom users on the app owner's account (typical for a single self-hosted instance you operate). To let other Zoom accounts connect, activate the **Production** version and complete Zoom's app publishing review.
 
 8. **Set the Redirect URL for OAuth** — Under **OAuth Information**, set the redirect URL to:
 

--- a/apps/docs/content/apps/zoom.mdx
+++ b/apps/docs/content/apps/zoom.mdx
@@ -2,39 +2,43 @@
 
 ### Obtaining Zoom Client ID and Secret
 
-1. **Sign into Zoom Marketplace** - Go to [Zoom Marketplace](https://marketplace.zoom.us/) and sign in with your Zoom account.
+1. **Sign into Zoom Marketplace** — Go to [Zoom Marketplace](https://marketplace.zoom.us/) and sign in with your Zoom account.
 
-2. **Build a New App** - In the upper right, click "Develop" and then "Build App".
+2. **Build a New App** — In the upper right, click **Develop** and then **Build App**.
 
-3. **Create an OAuth App** - Under "OAuth", select "Create".
+3. **Select General App** — On the app type selection screen, choose **General App** and click **Create**.
 
-4. **Name Your App** - Provide a name for your app.
+4. **Name Your App** — Provide a name for your app.
 
-5. **Choose User-managed App Type** - Select "User-managed app" as the app type.
+5. **Choose User-managed App Type** — Under **Select how the app is managed**, select **User-managed app**.
 
-6. **Set Marketplace Visibility** - De-select the option to publish the app on the Zoom App Marketplace.
+6. **Create the App** — Click **Create** to proceed.
 
-7. **Create the App** - Click "Create" to proceed.
-
-8. **Save Client ID and Secret** - Copy the Client ID and Client Secret and add them to your `.env` file under the fields:
+7. **Use Development Credentials** — Zoom shows **Development** and **Production** tabs. For self-hosted Cal.diy, use the **Development** tab and copy the **Client ID** and **Client Secret** into your `.env` file:
 
 ```
 ZOOM_CLIENT_ID
 ZOOM_CLIENT_SECRET
 ```
 
-9. **Set the Redirect URL for OAuth** - Set the Redirect URL for OAuth to:
+   You do not need to publish the app to the Zoom App Marketplace or activate a Production version for self-hosted use.
+
+8. **Set the Redirect URL for OAuth** — Under **OAuth Information**, set the redirect URL to:
 
 ```
 <Cal.diy URL>/api/integrations/zoomvideo/callback
 ```
 
-Replace `<Cal.diy URL>` with your application URL.
+   Replace `<Cal.diy URL>` with your application URL.
 
-10. **Configure Allow List and Subdomain Check** - Add the redirect URL to the allow list and enable "Subdomain check". Ensure it displays "saved" below the form.
+9. **Configure Allow List and Subdomain Check** — Add the same redirect URL to the **OAuth Allow List** and enable **Subdomain check**. Make sure it displays **saved** below the form.
 
-11. **Skip Basic Information and Add Scopes** - You don't need to provide basic information about your app. Instead, go to "Scopes", click "+ Add Scopes", then select the category "Meeting" on the left, and check the scope `meeting:write`.
+10. **Add Scopes** — Go to **Scopes**, click **+ Add Scopes**, then:
+    1. Select the **Meeting** category and enable `meeting:write:meeting`.
+    2. Select the **User** category and enable `user:read:settings`.
 
-12. **Save the Scope** - Click "Done" to save the scope settings.
+11. **Save Scopes** — Click **Done** to save the scope settings.
 
-13. **Complete Zoom Integration** - Your Zoom integration is now ready and can be easily added in the Cal.diy settings.
+12. **Skip Local Test Installation** — Zoom may prompt you to add the app locally via **Add App Now**. This step is optional for Cal.diy and can fail on development apps; you can skip it. The integration works through OAuth when users connect Zoom from Cal.diy settings.
+
+13. **Complete Zoom Integration** — Restart your Cal.diy instance after updating `.env`, then connect Zoom from **Settings → Conferencing apps**.

--- a/apps/docs/content/apps/zoom.mdx
+++ b/apps/docs/content/apps/zoom.mdx
@@ -16,7 +16,7 @@
 
 7. **Use Development Credentials** — Zoom shows **Development** and **Production** tabs. For self-hosted Cal.diy, use the **Development** tab and copy the **Client ID** and **Client Secret** into your `.env` file:
 
-```
+```dotenv
 ZOOM_CLIENT_ID=your_zoom_client_id
 ZOOM_CLIENT_SECRET=your_zoom_client_secret
 ```


### PR DESCRIPTION
## What does this PR do?

Zoom Marketplace updated the General App creation flow. The previous docs referenced an OAuth-only path, listed bare env var names without example values, and did not explain when Development vs Production credentials apply.

This PR updates the Zoom setup guide for the current marketplace UI and clarifies that Development credentials work for the app owner's Zoom account, with Production required for external users.

- Fixes #16193
- Updates `apps/docs/content/apps/zoom.mdx` for General App, Development credentials, scopes, and optional local install skip
- Updates the matching section in `README.md`
- Addresses CodeRabbit feedback on `.env` placeholder format and Development credential scope

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- N/A — documentation-only change.

#### Image Demo (if applicable):

- Compare the updated steps in `apps/docs/content/apps/zoom.mdx` against the Zoom Marketplace **General App → Development** credentials screen.
- Verify the `.env` example shows `ZOOM_CLIENT_ID=your_zoom_client_id` style assignments.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (N/A — docs-only change.)

## How should this be tested?

- Are there environment variables that should be set?
  - No env vars required to review this PR. The docs describe `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET`.
- What are the minimal test data to have?
  - A Zoom account with access to [Zoom Marketplace](https://marketplace.zoom.us/).
- What is expected (happy path) to have (input and output)?
  - Input: follow the updated docs to create a General App and copy Development credentials.
  - Output: credentials can be added to `.env` and Zoom connects from **Settings → Conferencing apps** for users on the app owner's Zoom account.
- Any other important info that could help to test that PR
  1. Read `apps/docs/content/apps/zoom.mdx` and the README Zoom section.
  2. Walk through Zoom Marketplace UI and confirm step order, scopes (`meeting:write:meeting`, `user:read:settings`), and Development credential guidance match the live UI.


