### PR TITLE
fix: apply recurring DST correction in the event timezone

### DIFF
--- a/packages/lib/parse-dates.timezone.test.ts
+++ b/packages/lib/parse-dates.timezone.test.ts
@@ -1,0 +1,36 @@
+process.env.TZ = "Asia/Dubai";
+
+import dayjs from "@calcom/dayjs";
+import { Frequency } from "rrule";
+import { describe, expect, it } from "vitest";
+
+import { parseRecurringDates } from "./parse-dates";
+
+describe("parseRecurringDates DST handling", () => {
+  it("keeps occurrences at a constant wall-clock in the event timezone across a DST change, independent of the runtime timezone", () => {
+    // Runtime TZ is Asia/Dubai (set above); the meeting timezone is America/New_York.
+    // A weekly 10:00 New York booking that crosses US spring-forward (2025-03-09) must keep
+    // every occurrence at 10:00 New York rather than drifting to 11:00 for a booker whose
+    // browser timezone differs from the meeting timezone.
+    const [, recurringDates] = parseRecurringDates(
+      {
+        startDate: "2025-03-05T10:00:00-05:00",
+        timeZone: "America/New_York",
+        recurringEvent: { freq: Frequency.WEEKLY, interval: 1, count: 4 },
+        recurringCount: 4,
+      },
+      "en"
+    );
+
+    const wallClock = recurringDates.map((date) =>
+      dayjs.utc(date).tz("America/New_York").format("YYYY-MM-DD HH:mm")
+    );
+
+    expect(wallClock).toEqual([
+      "2025-03-05 10:00",
+      "2025-03-12 10:00",
+      "2025-03-19 10:00",
+      "2025-03-26 10:00",
+    ]);
+  });
+});

--- a/packages/lib/parse-dates.ts
+++ b/packages/lib/parse-dates.ts
@@ -108,7 +108,6 @@ export const parseRecurringDates = (
   const startUtcOffset = dayjs(startDate).tz(timeZone).utcOffset();
   // UTC still need to have DST applied, rrule does not do this.
   const times = rule.all().map((t) => {
-    // applying the DST offset.
     return dayjs.utc(t).add(startUtcOffset - dayjs.utc(t).tz(timeZone).utcOffset(), "minute");
   });
   const dateStrings = times.map((t) => {

--- a/packages/lib/parse-dates.ts
+++ b/packages/lib/parse-dates.ts
@@ -102,11 +102,14 @@ export const parseRecurringDates = (
     dtstart: new Date(dayjs(startDate).valueOf()),
   });
 
-  const startUtcOffset = dayjs(startDate).utcOffset();
+  // Offsets must be read in the event timeZone, not the runtime's local zone, so a
+  // booker whose browser timezone differs from the meeting timezone still gets the
+  // occurrences kept at a constant wall-clock time across the event zone's DST change.
+  const startUtcOffset = dayjs(startDate).tz(timeZone).utcOffset();
   // UTC still need to have DST applied, rrule does not do this.
   const times = rule.all().map((t) => {
     // applying the DST offset.
-    return dayjs.utc(t).add(startUtcOffset - dayjs(t).utcOffset(), "minute");
+    return dayjs.utc(t).add(startUtcOffset - dayjs.utc(t).tz(timeZone).utcOffset(), "minute");
   });
   const dateStrings = times.map((t) => {
     // finally; show in local timeZone again


### PR DESCRIPTION
## What does this PR do?

`parseRecurringDates` (`packages/lib/parse-dates.ts`) computes its per-occurrence DST correction from the **runtime's local timezone** rather than the event `timeZone`:

```ts
const startUtcOffset = dayjs(startDate).utcOffset();          // runtime-local offset
// ...
return dayjs.utc(t).add(startUtcOffset - dayjs(t).utcOffset(), "minute");  // runtime-local offset
```

The booker lets a user pick a meeting timezone independent of their browser timezone, so `browser TZ ≠ meeting TZ` is normal input. When they differ, every recurring occurrence **after the event zone's DST transition drifts by an hour**, and these instants are used as the actual booking start/end — `parseRecurringDates`'s returned `Date[]` feeds `mapRecurringBookingToMutationInput` (`packages/features/bookings/lib/client/booking-event-form/booking-to-mutation-input-mapper.tsx:107`) and the occurrence list in `Occurences.tsx`. So this is wrong booking times, not just a display glitch.

Reproduced with a weekly 10:00 `America/New_York` booking crossing US spring-forward (2025-03-09), booker runtime `Asia/Dubai` (each instant shown as its New-York wall clock):

- **before:** `10:00, 11:00, 11:00, 11:00` ❌ (post-DST occurrences drift +1h)
- **after:** `10:00, 10:00, 10:00, 10:00` ✅

When the runtime timezone equals the event timezone the current code is already correct — confirming the intent is to hold the event-timezone wall-clock, so the cross-timezone drift is a genuine bug.

**Fix:** read both offsets in the event `timeZone` (`.tz(timeZone).utcOffset()`), matching the function's own comment ("UTC still need to have DST applied").

- No linked issue — found by reading the code.

## Visual Demo (For contributors especially)

Non-visual (timezone/scheduling logic). The reproduction is the code + before/after above.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A — this fix does not require a developer-docs change.
- [x] I confirm automated tests are in place that prove my fix is effective (`packages/lib/parse-dates.timezone.test.ts`).

## How should this be tested?

`packages/lib/parse-dates.timezone.test.ts` (runs in the `VITEST_MODE=timezone` suite; sets `process.env.TZ = "Asia/Dubai"`) asserts a weekly 10:00 `America/New_York` recurrence crossing the 2025-03-09 DST boundary keeps all four occurrences at 10:00. It fails on the current code (occurrences 2–4 become 11:00) and passes with the fix.

- No environment variables needed.
- No test data / DB needed — `parseRecurringDates` is a pure function.
- Expected: `["2025-03-05 10:00","2025-03-12 10:00","2025-03-19 10:00","2025-03-26 10:00"]` (New-York wall clock), regardless of the runtime timezone.
