### PR TITLE
fix: improve booking page detection and satisfy explicit type lint

### DIFF
--- a/apps/web/lib/__tests__/useIsBookingPage.test.ts
+++ b/apps/web/lib/__tests__/useIsBookingPage.test.ts
@@ -1,0 +1,49 @@
+import { isBookingPagePath } from "@lib/hooks/useIsBookingPage";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import { describe, expect, it } from "vitest";
+
+describe("isBookingPagePath", () => {
+  it("returns true for a dynamic public booking page root path", () => {
+    expect(isBookingPagePath("/rick", null)).toBe(true);
+    expect(isBookingPagePath("/john+jane", null)).toBe(true);
+    expect(isBookingPagePath("/john%2Bjane/anything", null)).toBe(true);
+  });
+
+  it("returns false for reserved root paths that are not booking pages", () => {
+    expect(isBookingPagePath("/apps", null)).toBe(false);
+    expect(isBookingPagePath("/auth/login", null)).toBe(false);
+    expect(isBookingPagePath("/event-types", null)).toBe(false);
+    expect(isBookingPagePath("/getting-started", null)).toBe(false);
+  });
+
+  it("returns true for known booking page prefixes", () => {
+    expect(isBookingPagePath("/team/sales", null)).toBe(true);
+    expect(isBookingPagePath("/d/private", null)).toBe(true);
+    expect(isBookingPagePath("/booking", null)).toBe(true);
+    expect(isBookingPagePath("/reschedule/abc", null)).toBe(true);
+  });
+
+  it("returns false for booking list pages even when prefix matches", () => {
+    expect(isBookingPagePath("/upcoming", null)).toBe(false);
+    expect(isBookingPagePath("/past", null)).toBe(false);
+  });
+
+  it("returns true when user parameters indicate a booking page", () => {
+    const searchParams = {
+      get: (name: string) => {
+        if (name === "type") {
+          return "30min";
+        }
+
+        if (name === "user") {
+          return "123";
+        }
+
+        return null;
+      },
+    } as unknown as ReadonlyURLSearchParams;
+
+    expect(isBookingPagePath("/some/page", searchParams)).toBe(true);
+    expect(isBookingPagePath("/some/page", searchParams)).toBe(true);
+  });
+});

--- a/apps/web/lib/hooks/useIsBookingPage.ts
+++ b/apps/web/lib/hooks/useIsBookingPage.ts
@@ -1,27 +1,77 @@
-import { usePathname } from "next/navigation";
-
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
-// TODO: This approach of checking booking page isn't correct.
-// app.cal.com/rick is a booking page but useIsBookingPage won't return true. This is because all unregistered router in Next.js could technically be a booking page throw catch all routes.
-// The only way to confirm it is by actually checking if we actually rendered a booking route.
+import { type ReadonlyURLSearchParams, usePathname } from "next/navigation";
+
+const reservedRootPaths: Set<string> = new Set([
+  "api",
+  "auth",
+  "apps",
+  "availability",
+  "enterprise",
+  "event-types",
+  "getting-started",
+  "maintenance",
+  "more",
+  "onboarding",
+  "payment",
+  "refer",
+  "settings",
+  "signup",
+  "upgrade",
+  "video",
+  "icons",
+  "e2e",
+  "reschedule",
+  "_next",
+  "_static",
+  "favicon.ico",
+  "robots.txt",
+  "sitemap.xml",
+  "manifest.json",
+]);
+
+const bookingPagePrefixes = [
+  "/booking",
+  "/cancel",
+  "/reschedule",
+  "/instant-meeting",
+  "/team",
+  "/d",
+  "/router",
+] as const;
+
+const bookingsListSuffixes = ["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"] as const;
+
+export function isBookingPagePath(
+  pathname?: string | null,
+  searchParams?: ReadonlyURLSearchParams | null
+): boolean {
+  const normalizedPathname = (pathname ?? "").trim();
+  const lowerPathname = normalizedPathname.toLowerCase();
+
+  const isUserBookingPage = Boolean(searchParams?.get("user"));
+  const isUserBookingTypePage = isUserBookingPage && Boolean(searchParams?.get("type"));
+  if (isUserBookingPage || isUserBookingTypePage) {
+    return true;
+  }
+
+  const isBookingsListPage = bookingsListSuffixes.some((route) => lowerPathname.endsWith(route));
+  const isKnownBookingPage = bookingPagePrefixes.some((route) => lowerPathname.startsWith(route));
+
+  if (isKnownBookingPage) {
+    return !isBookingsListPage;
+  }
+
+  if (isBookingsListPage) {
+    return false;
+  }
+
+  const pathSegment = lowerPathname.split("/")[1] ?? lowerPathname.split("/")[0];
+  return Boolean(pathSegment) && !reservedRootPaths.has(pathSegment);
+}
+
 export default function useIsBookingPage(): boolean {
   const pathname = usePathname();
-  const isBookingPage = [
-    "/booking",
-    "/cancel",
-    "/reschedule",
-    "/instant-meeting", // Instant booking page
-    "/team", // Team booking pages
-    "/d", // Private Link of booking page
-    "/router", // Headless router page - Loads as a page when redirect type is customPageMessage
-  ].some((route) => pathname?.startsWith(route));
-  const isBookingsListPage = ["/upcoming", "/unconfirmed", "/recurring", "/cancelled", "/past"].some(
-    (route) => pathname?.endsWith(route)
-  );
-
   const searchParams = useCompatSearchParams();
-  const isUserBookingPage = Boolean(searchParams?.get("user"));
-  const isUserBookingTypePage = Boolean(searchParams?.get("user") && searchParams?.get("type"));
 
-  return (isBookingPage && !isBookingsListPage) || isUserBookingPage || isUserBookingTypePage;
+  return isBookingPagePath(pathname, searchParams);
 }


### PR DESCRIPTION


## What does this PR do?

- fix `useIsBookingPage` to detect dynamic public booking pages like `/rick` and `/john+jane`
- preserve known booking prefixes and exclude reserved root paths
- add explicit `Set<string>` type annotation for `reservedRootPaths`
- add regression coverage for booking route detection

Note: Cal.diy is a community-maintained open-source project. Contributions here do NOT flow to Cal.com's production service. -->

- Fixes #29798

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.
