### PR TITLE
fix(availability): keep fixed-host constraint when intersection is empty

### DIFF
--- a/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.test.ts
+++ b/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.test.ts
@@ -469,4 +469,62 @@ describe("getAggregatedAvailability", () => {
     };
     expect(isAvailable(result, timeRangeNotAvailable)).toBe(false);
   });
+
+  // Regression: empty fixed-host intersection must still constrain RR hosts (#29800).
+  // Previously `fixedDateRanges.length ? ... : []` treated "fixed host busy" like "no fixed hosts",
+  // so RR-only slots were offered and booking later failed with FixedHostsUnavailableForBooking.
+  it("does not offer RR slots when a mandatory fixed host has no overlapping availability", () => {
+    const userAvailability = [
+      {
+        dateRanges: [],
+        oooExcludedDateRanges: [], // fixed host fully busy / no availability
+        user: { isFixed: true },
+      },
+      {
+        dateRanges: [],
+        oooExcludedDateRanges: [
+          { start: dayjs("2025-01-23T11:00:00.000Z"), end: dayjs("2025-01-23T11:30:00.000Z") },
+        ],
+        user: { isFixed: false },
+      },
+      {
+        dateRanges: [],
+        oooExcludedDateRanges: [
+          { start: dayjs("2025-01-23T12:00:00.000Z"), end: dayjs("2025-01-23T12:30:00.000Z") },
+        ],
+        user: { isFixed: false },
+      },
+    ];
+
+    const result = getAggregatedAvailability(userAvailability, "ROUND_ROBIN");
+
+    expect(result).toEqual([]);
+    expect(
+      isAvailable(result, {
+        start: dayjs("2025-01-23T11:00:00.000Z"),
+        end: dayjs("2025-01-23T11:30:00.000Z"),
+      })
+    ).toBe(false);
+  });
+
+  it("still offers RR-only slots when there are no fixed hosts", () => {
+    const userAvailability = [
+      {
+        dateRanges: [],
+        oooExcludedDateRanges: [
+          { start: dayjs("2025-01-23T11:00:00.000Z"), end: dayjs("2025-01-23T11:30:00.000Z") },
+        ],
+        user: { isFixed: false },
+      },
+    ];
+
+    const result = getAggregatedAvailability(userAvailability, "ROUND_ROBIN");
+
+    expect(
+      isAvailable(result, {
+        start: dayjs("2025-01-23T11:00:00.000Z"),
+        end: dayjs("2025-01-23T11:30:00.000Z"),
+      })
+    ).toBe(true);
+  });
 });

--- a/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
+++ b/packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.ts
@@ -42,7 +42,11 @@ export const getAggregatedAvailability = (
   const fixedDateRanges = mergeOverlappingDateRanges(
     intersect(fixedHosts.map((s) => (!isTeamEvent ? s.dateRanges : s.oooExcludedDateRanges)))
   );
-  const dateRangesToIntersect = fixedDateRanges.length ? [fixedDateRanges] : [];
+  // Use fixedHosts.length (not fixedDateRanges.length): an empty intersection means
+  // mandatory fixed hosts are busy, which must still constrain RR hosts. Treating an
+  // empty fixedDateRanges as "no constraint" offered bookable slots that later fail
+  // with FixedHostsUnavailableForBooking.
+  const dateRangesToIntersect = fixedHosts.length ? [fixedDateRanges] : [];
   const roundRobinHosts = userAvailability.filter(({ user }) => user?.isFixed !== true);
   if (roundRobinHosts.length) {
     // Group round robin hosts by their groupId


### PR DESCRIPTION
## What does this PR do?

Fixes ROUND_ROBIN events offering bookable slots when a mandatory fixed host is fully busy. Those slots later failed at checkout with `FixedHostsUnavailableForBooking`.

`getAggregatedAvailability` used `fixedDateRanges.length` to decide whether to apply the fixed-host constraint. An empty intersection happens in two cases:

1. There are no fixed hosts
2. Fixed hosts exist but have no overlapping availability (mandatory host busy)

Case (2) was incorrectly treated like case (1), so RR hosts alone drove availability.

**Fix:** gate on `fixedHosts.length` instead of `fixedDateRanges.length`, so an empty fixed-host intersection still constrains RR hosts (intersect yields no slots).

Fixes #29800

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. N/A — bugfix only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Create a ROUND_ROBIN event type with one fixed (mandatory) host and one or more RR hosts.
2. Make the fixed host unavailable for a window where RR hosts are free.
3. Open the booking page for that window.
4. **Before:** slots for the RR-only window appear, then booking fails with `FixedHostsUnavailableForBooking`.
5. **After:** those slots are not offered.

Also covered by unit tests:

```bash
TZ=UTC yarn vitest run packages/features/availability/lib/getAggregatedAvailability/getAggregatedAvailability.test.ts
```
