### PR TITLE
fix(bookings): consume private link before creating booking

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
@@ -76,7 +76,7 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
     test(
       `should increment hashed link usage when booking is created with hashed link
           1. Should create a booking in the database
-          2. Should increment hashed link usage count via BookingEventHandler.onBookingCreated
+          2. Should consume/increment hashed link usage before booking creation
     `,
       async () => {
         const handleNewBooking = getNewBookingHandler();
@@ -365,10 +365,9 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
     );
 
     test(
-      `should handle hashed link service errors gracefully without failing booking creation
-          1. Should create a booking successfully
-          2. Should handle hashed link service errors gracefully in BookingEventHandler
-          3. Should log errors but continue booking flow
+      `should reject booking when private link has already reached max usage
+          1. Should not create a booking
+          2. Should throw PrivateLinkExpired
     `,
       async () => {
         const handleNewBooking = getNewBookingHandler();
@@ -388,8 +387,8 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
 
         const hashedLinkData = createHashedLinkTestData({
           eventTypeId: 1,
-          usageLimit: 5,
-          currentUsage: 2,
+          usageLimit: 1,
+          currentUsage: 1, // already exhausted
         });
 
         await createBookingScenario(
@@ -404,7 +403,6 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
                     id: 101,
                   },
                 ],
-                // hashedLink will be created separately in database
               },
             ],
             users: [organizer],
@@ -413,23 +411,12 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
 
         mockCalendarToHaveNoBusySlots("googlecalendar", {
           create: {
-            uid: "ERROR_HANDLING_BOOKING_UID",
-          },
-          update: {
-            iCalUID: "ERROR_HANDLING_BOOKING_UID",
-            uid: "ERROR_HANDLING_BOOKING_UID",
+            uid: "EXPIRED_LINK_BOOKING_UID",
           },
         });
 
-        // Create an invalid hashed link that will cause validation to fail
-        // (maxUsageCount = 0 means it should be expired)
-        const invalidHashedLinkData = {
-          ...hashedLinkData,
-          maxUsageCount: 0, // This will cause validation to fail
-        };
-
         await prismaMock.hashedLink.create({
-          data: invalidHashedLinkData,
+          data: hashedLinkData,
         });
 
         const mockBookingRequest = getMockRequestDataForBooking({
@@ -445,27 +432,16 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
           },
         });
 
-        const bookingResponse = await handleNewBooking({
-          bookingData: mockBookingRequest,
+        await expect(
+          handleNewBooking({
+            bookingData: mockBookingRequest,
+          })
+        ).rejects.toMatchObject({
+          statusCode: 404,
+          message: "private_link_expired",
         });
 
-        // Booking should still be created successfully despite hashed link error
-        await expectBookingToBeInDatabase({
-          description: "",
-          uid: bookingResponse.uid,
-          location: BookingLocations.CalVideo,
-          responses: expect.objectContaining({
-            email: booker.email,
-            name: booker.name,
-          }),
-          status: BookingStatus.ACCEPTED,
-        });
-
-        // Verify that even though hashed link processing failed,
-        await expectHashedLinkUsageToBe(hashedLinkData.link, invalidHashedLinkData.usageCount);
-
-        expect(bookingResponse.status).toEqual(BookingStatus.ACCEPTED);
-        expect(bookingResponse.uid).toBeDefined();
+        await expectHashedLinkUsageToBe(hashedLinkData.link, 1);
       },
       timeout
     );

--- a/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
@@ -441,6 +441,10 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
           message: "private_link_expired",
         });
 
+        // Ensure rejection happens before any booking persistence (not just after a write).
+        const bookings = await prismaMock.booking.findMany();
+        expect(bookings).toHaveLength(0);
+
         await expectHashedLinkUsageToBe(hashedLinkData.link, 1);
       },
       timeout

--- a/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
@@ -437,7 +437,7 @@ describe("Post-Booking Events - Hashed Link Usage", () => {
             bookingData: mockBookingRequest,
           })
         ).rejects.toMatchObject({
-          statusCode: 404,
+          code: "private_link_expired",
           message: "private_link_expired",
         });
 

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -579,10 +579,7 @@ async function handler(
       await deps.hashedLinkService.validateAndIncrementUsage(reqBody.hashedLink);
     } catch (error) {
       tracingLogger.error("Private link validation/consume failed", safeStringify(error));
-      throw new HttpError({
-        statusCode: 404,
-        message: ErrorCode.PrivateLinkExpired,
-      });
+      throw ErrorWithCode.Factory.PrivateLinkExpired(ErrorCode.PrivateLinkExpired);
     }
   }
 

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -571,6 +571,21 @@ async function handler(
     ...reqBody
   } = bookingData;
 
+  // Consume private links before creating the booking so expire-after-N-uses cannot
+  // be bypassed via back/bfcache, concurrent tabs, or a swallowed post-booking increment.
+  // Reschedules keep the existing post-booking increment path.
+  if (hasHashedBookingLink && reqBody.hashedLink && !isDryRun && !rawBookingData.rescheduleUid) {
+    try {
+      await deps.hashedLinkService.validateAndIncrementUsage(reqBody.hashedLink);
+    } catch (error) {
+      tracingLogger.error("Private link validation/consume failed", safeStringify(error));
+      throw new HttpError({
+        statusCode: 404,
+        message: ErrorCode.PrivateLinkExpired,
+      });
+    }
+  }
+
   let troubleshooterData = buildTroubleshooterData({
     eventType,
   });
@@ -2220,7 +2235,10 @@ async function handler(
       userEmail: booking.user?.email ?? null,
     },
     organizerUser,
-    hashedLink: hasHashedBookingLink ? (reqBody.hashedLink ?? null) : null,
+    // New bookings already consumed the private link above; only reschedules still
+    // increment via BookingEventHandler (existing behavior / tests).
+    hashedLink:
+      hasHashedBookingLink && rawBookingData.rescheduleUid ? (reqBody.hashedLink ?? null) : null,
     isDryRun,
     bookerEmail,
     bookerName: fullName,

--- a/packages/lib/server/getServerErrorFromUnknown.ts
+++ b/packages/lib/server/getServerErrorFromUnknown.ts
@@ -170,6 +170,7 @@ export function getHttpStatusCode(cause: Error | ErrorWithCode): number {
     case ErrorCode.EventTypeNotFound:
     case ErrorCode.BookingNotFound:
     case ErrorCode.RestrictionScheduleNotFound:
+    case ErrorCode.PrivateLinkExpired:
       return 404;
     case ErrorCode.UnableToSubscribeToThePlatform:
     case ErrorCode.UpdatingOauthClientError:


### PR DESCRIPTION
## What does this PR do?

Private links with "Expire after one booking" (usage-based `maxUsageCount`) could still be reused after a successful booking because:

1. `/d/...` SSR only **validates** the link
2. Usage was incremented **after** booking creation
3. Increment failures were **swallowed**, so the booking succeeded while usage stayed at 0

This PR **validates + increments usage before creating** a new booking. Exhausted links fail with `PrivateLinkExpired` (404) and no booking is created.

Reschedules keep the existing post-booking increment behavior (covered by existing tests).

Fixes #29815

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] Docs N/A
- [x] Automated tests are in place

## How should this be tested?

1. Create an event type with a private link, max usage = 1.
2. Complete one booking via that link.
3. Attempt a second booking with the same `hashedLink` (API or reused form).
4. Second attempt should fail with `private_link_expired` / 404 — no second booking.

```bash
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/test/post-booking-handling.test.ts
```
