### PR TITLE
fix(app-store): escape analytics app data in inline booking page scripts

### DIFF
--- a/packages/app-store/BookingPageTagManager.test.tsx
+++ b/packages/app-store/BookingPageTagManager.test.tsx
@@ -99,6 +99,15 @@ describe("BookingPageTagManager", () => {
     expect(source).toContain("\\x3C/script\\x3E");
   });
 
+  it("escapes the interpolation opener so a value cannot interpolate in a template literal", () => {
+    const source = renderApp("gtm", { trackingId: "GTM-X${alert(1)}" });
+
+    // No shipped template delimits its literals with backticks today, but a value that carries
+    // the opener must not become active interpolation if one ever does.
+    expect(source).not.toContain("GTM-X${alert(1)}");
+    expect(source).toContain("GTM-X\\${alert(1)}");
+  });
+
   it("leaves a legitimate tracking id untouched", () => {
     const source = renderApp("gtm", { trackingId: "GTM-ABC123" });
 

--- a/packages/app-store/BookingPageTagManager.test.tsx
+++ b/packages/app-store/BookingPageTagManager.test.tsx
@@ -56,6 +56,56 @@ describe("BookingPageTagManager", () => {
     expect(pushEventScript.innerHTML).toContain("cal_analytics_app__gtm");
   });
 
+  const renderApp = (appId: string, appData: Record<string, unknown>) => {
+    render(
+      <BookingPageTagManager
+        eventType={{
+          metadata: {
+            apps: {
+              [appId]: { enabled: true, ...appData },
+            },
+          },
+          price: 0,
+          currency: "USD",
+        }}
+      />
+    );
+    return screen
+      .getAllByTestId(`cal-analytics-app-${appId}`)
+      .map((script) => script.textContent)
+      .join("\n");
+  };
+
+  // posthog is covered by the same code path but is not asserted through the DOM here: its
+  // template contains a bare `<` (`n<o.length`), which the div that stands in for next/script
+  // in this file parses as markup, so textContent stops before the substituted value.
+  it.each([
+    ["gtm", { trackingId: "GTM-X');alert(1);//" }, "GTM-X');alert(1);//"],
+    ["ga4", { trackingId: "G-X'});alert(1);gtag('config',('" }, "G-X'});alert(1);gtag('config',('"],
+    ["matomo", { MATOMO_URL: "https://x", SITE_ID: "1'-alert(1)-'" }, "1'-alert(1)-'"],
+    ["metapixel", { trackingId: "1');alert(1);//" }, "1');alert(1);//"],
+  ])("%s keeps app data inside the JS string literal it is substituted into", (appId, appData, value) => {
+    const source = renderApp(appId, appData);
+
+    // The raw value would close the literal; only its escaped form may appear.
+    expect(source).not.toContain(value);
+    expect(source).toContain(value.replace(/'/g, "\\'"));
+  });
+
+  it("escapes characters that would end the inline script element", () => {
+    const source = renderApp("gtm", { trackingId: "GTM-X</script><script>alert(1)</script>" });
+
+    expect(source).not.toContain("</script>");
+    expect(source).toContain("\\x3C/script\\x3E");
+  });
+
+  it("leaves a legitimate tracking id untouched", () => {
+    const source = renderApp("gtm", { trackingId: "GTM-ABC123" });
+
+    expect(source).toContain("'GTM-ABC123'");
+    expect(source).not.toContain("\\");
+  });
+
   it("GTM App when disabled should not have its scripts added", () => {
     const GTM_CONFIG = {
       enabled: false,

--- a/packages/app-store/BookingPageTagManager.tsx
+++ b/packages/app-store/BookingPageTagManager.tsx
@@ -10,6 +10,28 @@ import type { appDataSchemas } from "./apps.schemas.generated";
 
 const PushEventPrefix = "cal_analytics_app_";
 
+const JS_STRING_LITERAL_ESCAPES: Record<string, string> = {
+  "\\": "\\\\",
+  "'": "\\'",
+  '"': '\\"',
+  "`": "\\`",
+  "<": "\\x3C",
+  ">": "\\x3E",
+  "\r": "\\r",
+  "\n": "\\n",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+/**
+ * Escapes a value that is substituted into a JS string literal inside an inline <script>.
+ * Quotes and backslashes keep the value inside its literal, and `<`/`>` keep it from ending
+ * the script element. Values that analytics apps legitimately hold (ids, hostnames, URLs)
+ * contain none of these characters, so their rendered output is unchanged.
+ */
+const escapeJsStringLiteral = (value: string) =>
+  value.replace(/[\\'"`<>\r\n\u2028\u2029]/g, (char) => JS_STRING_LITERAL_ESCAPES[char]);
+
 // AnalyticApp has appData.tag always set
 type AnalyticApp = Omit<AppMeta, "appData"> & {
   appData: Omit<NonNullable<AppMeta["appData"]>, "tag"> & {
@@ -99,7 +121,10 @@ export default function BookingPageTagManager({
     <>
       {Object.entries(analyticsApps).map(([appId, { meta: app, eventTypeAppData }]) => {
         const tag = app.appData.tag;
-        const parseValue = <T extends string | undefined>(val: T): T => {
+        const parseValue = <T extends string | undefined>(
+          val: T,
+          escapeSubstitution: (value: string) => string = (value) => value
+        ): T => {
           if (!val) {
             return val;
           }
@@ -111,11 +136,10 @@ export default function BookingPageTagManager({
           while ((matches = regex.exec(val))) {
             const variableName = matches[1];
             if (appDataRecord[variableName]) {
+              const substitution = escapeSubstitution(String(appDataRecord[variableName]));
               // Replace if value is available. It can possible not be a template variable that just matches the regex.
-              val = val.replace(
-                new RegExp(`{${variableName}}`, "g"),
-                String(appDataRecord[variableName])
-              ) as NonNullable<T>;
+              // The replacement is a function so that `$&` and friends in the value stay literal.
+              val = val.replace(new RegExp(`{${variableName}}`, "g"), () => substitution) as NonNullable<T>;
             }
           }
           return val;
@@ -143,7 +167,10 @@ export default function BookingPageTagManager({
               // And we don't want it to error here anyways
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{
-                __html: parseValue(script.content) || "",
+                // The content is inline script source, so substituted values are escaped for the
+                // JS string literals they land in. `src` and `attrs` are React props and stay
+                // unescaped because React escapes attribute values itself.
+                __html: parseValue(script.content, escapeJsStringLiteral) || "",
               }}
               {...parsedAttributes}
               defer

--- a/packages/app-store/BookingPageTagManager.tsx
+++ b/packages/app-store/BookingPageTagManager.tsx
@@ -15,6 +15,7 @@ const JS_STRING_LITERAL_ESCAPES: Record<string, string> = {
   "'": "\\'",
   '"': '\\"',
   "`": "\\`",
+  "$": "\\$",
   "<": "\\x3C",
   ">": "\\x3E",
   "\r": "\\r",
@@ -25,12 +26,13 @@ const JS_STRING_LITERAL_ESCAPES: Record<string, string> = {
 
 /**
  * Escapes a value that is substituted into a JS string literal inside an inline <script>.
- * Quotes and backslashes keep the value inside its literal, and `<`/`>` keep it from ending
- * the script element. Values that analytics apps legitimately hold (ids, hostnames, URLs)
- * contain none of these characters, so their rendered output is unchanged.
+ * Quotes and backslashes keep the value inside its literal, `$` keeps it from starting an
+ * interpolation when the literal is delimited by backticks, and `<`/`>` keep it from ending
+ * the script element. A backslash before `$` is a no-op in every literal form, so values that
+ * analytics apps legitimately hold (ids, hostnames, URLs, amounts) render unchanged.
  */
 const escapeJsStringLiteral = (value: string) =>
-  value.replace(/[\\'"`<>\r\n\u2028\u2029]/g, (char) => JS_STRING_LITERAL_ESCAPES[char]);
+  value.replace(/[\\'"`<>$\r\n\u2028\u2029]/g, (char) => JS_STRING_LITERAL_ESCAPES[char]);
 
 // AnalyticApp has appData.tag always set
 type AnalyticApp = Omit<AppMeta, "appData"> & {


### PR DESCRIPTION
## What does this PR do?

`BookingPageTagManager` renders the analytics apps' script templates into the public booking page and replaces their `{TOKEN}` placeholders with values from `EventType.metadata.apps.<app>` (`packages/app-store/BookingPageTagManager.tsx:124-144`). The substitution is a plain `String()` interpolation, and the templates put those tokens inside single-quoted JS string literals: `_paq.push(['setSiteId', '{SITE_ID}']);` (matomo), `gtag('config', '{TRACKING_ID}', ...)` (ga4), `posthog.init('{TRACKING_ID}',{api_host:'{API_HOST}'})`, and the same shape in gtm and metapixel. A value containing `'` leaves its literal, so the remainder of that value is parsed as code in the inline `<script>`. Those values are event-type app data, editable by the owner of the event type, and the booking page they land on is public.

`escapeJsStringLiteral` escapes backslash, the three quote characters, `<`, `>`, CR/LF and U+2028/U+2029, and is applied on the `content` path only. `src` and `attrs` keep the plain substitution: they are React props, so React escapes them, and `<script src="javascript:...">` does not execute.

Two details worth calling out:

- The replacement argument is now a function, so `$&`, `` $` `` and `$1` inside a value stay literal instead of being expanded by `String.prototype.replace`.
- `packages/embeds/embed-core/src/lib/utils.ts:120` already has an `escapeHtmlAttribute`, but entity escaping is wrong inside a `<script>` element, whose content is not entity-decoded, so this needs its own escaper rather than reusing that one.

No behaviour change for valid analytics values: tracking ids, hostnames and URLs contain none of the escaped characters, so the rendered script is byte-identical. A value that does contain one now renders as an escaped literal instead of as code.

- Fixes # (issue): n/a, reported privately.

### References

GHSA-hc9g-2v72-c2v3 (reported privately, unpublished at time of writing)

## Visual Demo (For contributors especially)

n/a. The change is not user-visible: a valid analytics configuration renders exactly the same script as before.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A, no documented behaviour changes.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or test data are needed; the tests render the component against the real `config.json` of each analytics app.

- `npx vitest run packages/app-store/BookingPageTagManager.test.tsx`: 13 passed. Six of those are new. Five of the six fail on `main` without the source change (the sixth is the no-regression case and passes either way).
- `npx vitest run packages/app-store`: 13 files and 10 tests fail, the identical set fails on unpatched `main` in my environment because the Prisma client is not generated there, so they are unrelated to this change.
- `npx biome check packages/app-store/BookingPageTagManager*.tsx`: same error count as `main` (2, both the pre-existing `organizeImports` on the untouched import block); files are `biome format` clean.
- `npx tsc --noEmit` in `packages/app-store`: 823 errors on both `main` and this branch, none of them in the two touched files, same Prisma-client cause as above.
- Manual check of the substitution itself against each app's real template, including posthog: with a quote-carrying value the pre-change output breaks out of the literal in all five apps, the post-change output does not.

The unit test asserts through the DOM for gtm, ga4, matomo and metapixel. posthog goes through the same code path but is not asserted there, because its template contains a bare `<` (`n<o.length`) that the `div` standing in for `next/script` in that test file parses as markup, cutting `textContent` short. That is noted in a comment above the test.

## Checklist

None of the bullet points below apply.
