### PR TITLE
fix(locale): use resolvedOptions().hour12 for accurate 24h detection

### DIFF
--- a/packages/lib/timeFormat.test.ts
+++ b/packages/lib/timeFormat.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the webstorage module
+vi.mock("@calcom/lib/webstorage", () => {
+  const store = new Map<string, string>();
+  return {
+    localStorage: {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => { store.set(key, value); }),
+      removeItem: vi.fn((key: string) => { store.delete(key); }),
+      clear: vi.fn(() => { store.clear(); }),
+    },
+  };
+});
+
+import { isBrowserLocale24h, getIs24hClockFromLocalStorage, setIs24hClockInLocalStorage } from "./timeFormat";
+import { localStorage } from "@calcom/lib/webstorage";
+
+describe("timeFormat utilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe("isBrowserLocale24h", () => {
+    it("should return cached value from localStorage when set to true", () => {
+      setIs24hClockInLocalStorage(true);
+      expect(isBrowserLocale24h()).toBe(true);
+    });
+
+    it("should return cached value from localStorage when set to false", () => {
+      setIs24hClockInLocalStorage(false);
+      expect(isBrowserLocale24h()).toBe(false);
+    });
+
+    it("should detect 12-hour locale (en-US) correctly", () => {
+      const originalDateTimeFormat = global.Intl.DateTimeFormat;
+      global.Intl.DateTimeFormat = class MockDateTimeFormat {
+        constructor(_locale: any, _options: any) {}
+        resolvedOptions() { return { locale: "en-US", hour12: true }; }
+        format() { return "12 AM"; }
+      } as any;
+
+      localStorage.clear();
+      expect(isBrowserLocale24h()).toBe(false);
+
+      global.Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+
+    it("should detect 24-hour locale (de-DE) correctly", () => {
+      const originalDateTimeFormat = global.Intl.DateTimeFormat;
+      global.Intl.DateTimeFormat = class MockDateTimeFormat {
+        constructor(_locale: any, _options: any) {}
+        resolvedOptions() { return { locale: "de-DE", hour12: false }; }
+        format() { return "00:00"; }
+      } as any;
+
+      localStorage.clear();
+      expect(isBrowserLocale24h()).toBe(true);
+
+      global.Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+
+    it("should detect Arabic locale (ar-EG) as 12-hour despite non-Latin AM/PM", () => {
+      const originalDateTimeFormat = global.Intl.DateTimeFormat;
+      global.Intl.DateTimeFormat = class MockDateTimeFormat {
+        constructor(_locale: any, _options: any) {}
+        resolvedOptions() { return { locale: "ar-EG", hour12: true }; }
+        format() { return "١٢ ص"; } // Arabic AM marker, no Latin "M"
+      } as any;
+
+      localStorage.clear();
+      expect(isBrowserLocale24h()).toBe(false); // Should be 12-hour, not 24-hour
+
+      global.Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+
+    it("should detect Greek locale (el-GR) as 12-hour despite non-Latin AM/PM", () => {
+      const originalDateTimeFormat = global.Intl.DateTimeFormat;
+      global.Intl.DateTimeFormat = class MockDateTimeFormat {
+        constructor(_locale: any, _options: any) {}
+        resolvedOptions() { return { locale: "el-GR", hour12: true }; }
+        format() { return "12 π.μ."; } // Greek AM marker, no Latin "M"
+      } as any;
+
+      localStorage.clear();
+      expect(isBrowserLocale24h()).toBe(false);
+
+      global.Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+
+    it("should detect Chinese Traditional (zh-TW) as 12-hour despite non-Latin AM/PM", () => {
+      const originalDateTimeFormat = global.Intl.DateTimeFormat;
+      global.Intl.DateTimeFormat = class MockDateTimeFormat {
+        constructor(_locale: any, _options: any) {}
+        resolvedOptions() { return { locale: "zh-TW", hour12: true }; }
+        format() { return "上午12"; } // Chinese AM marker, no Latin "M"
+      } as any;
+
+      localStorage.clear();
+      expect(isBrowserLocale24h()).toBe(false);
+
+      global.Intl.DateTimeFormat = originalDateTimeFormat;
+    });
+  });
+
+  describe("localStorage helpers", () => {
+    it("should store and retrieve 24h preference", () => {
+      setIs24hClockInLocalStorage(true);
+      expect(getIs24hClockFromLocalStorage()).toBe(true);
+
+      setIs24hClockInLocalStorage(false);
+      expect(getIs24hClockFromLocalStorage()).toBe(false);
+    });
+
+    it("should return null when not set", () => {
+      localStorage.clear();
+      expect(getIs24hClockFromLocalStorage()).toBeNull();
+    });
+  });
+});

--- a/packages/lib/timeFormat.ts
+++ b/packages/lib/timeFormat.ts
@@ -41,14 +41,12 @@ export const isBrowserLocale24h = () => {
   } else if (localStorageTimeFormat === false) {
     return false;
   }
-  // Intl.DateTimeFormat with value=undefined uses local browser settings.
-  if (!!new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(0).match(/M/i)) {
-    setIs24hClockInLocalStorage(false);
-    return false;
-  } else {
-    setIs24hClockInLocalStorage(true);
-    return true;
-  }
+  // Use Intl.DateTimeFormat.resolvedOptions().hour12 for accurate locale detection
+  // This correctly handles locales with non-Latin AM/PM markers (ar, el, zh-TW, etc.)
+  const dtf = new Intl.DateTimeFormat(undefined, { hour: "numeric" });
+  const is12h = dtf.resolvedOptions().hour12 === true;
+  setIs24hClockInLocalStorage(!is12h);
+  return !is12h;
 };
 
 /**


### PR DESCRIPTION
## Summary

The `isBrowserLocale24h()` function in `packages/lib/timeFormat.ts` used a fragile regex heuristic (checking for 'M' in formatted output) which fails for locales with non-Latin AM/PM markers (ar, el, zh-TW, ms-MY, sq-AL, etc.).

## Changes

- Replaced regex heuristic with `Intl.DateTimeFormat.resolvedOptions().hour12` - the authoritative ICU data for locale's time format preference
- Added comprehensive test file `packages/lib/timeFormat.test.ts` covering:
  - Cached localStorage values (true/false)
  - 12-hour locale (en-US) 
  - 24-hour locale (de-DE)
  - Arabic (ar-EG) - previously misdetected as 24h
  - Greek (el-GR) - previously misdetected as 24h
  - Chinese Traditional (zh-TW) - previously misdetected as 24h
  - localStorage helper functions

## Testing

- All 9 new tests pass
- Existing timezone tests still pass (19 total)

## Verification

The fix correctly detects:
- `en-US` (12h) → `false` (12-hour)
- `de-DE` (24h) → `true$ (24-hour)  
- `ar-EG` (12h, Arabic script) → `false$ (12-hour) ✓ **was broken**
- `el-GR$ (12h, Greek script) → `false$ (12-hour) ✓ **was broken**
- `zh-TW$ (12h, Chinese script) → `false$ (12-hour) ✓ **was broken**

Closes #29845