### PR TITLE
fix(booking): show correct price for multi-seat booking confirmations

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -189,9 +189,20 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
   }
 
+  // For multi-seat bookings, find the payment matching the seat's attendee
+  // Each seat creates a separate payment with the attendee's email in metadata
+  const seatAttendeeEmail = bookingInfo.attendees?.[0]?.email;
   const payment = await prisma.payment.findFirst({
     where: {
       bookingId: bookingInfo.id,
+      ...(seatAttendeeEmail
+        ? {
+            data: {
+              path: ["metadata", "bookerEmail"],
+              equals: seatAttendeeEmail,
+            },
+          }
+        : {}),
     },
     select: {
       appId: true,


### PR DESCRIPTION
## Summary

For multi-seat paid bookings, each seat creates a separate payment with the attendee's email in the payment metadata. The confirmation page at `/booking/<seatReferenceUid>` was fetching the first payment for the booking instead of the one matching the specific seat.

## Changes

Modified `apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx` to find the payment matching the seat's attendee email from the payment metadata (`data.metadata.bookerEmail`).

## Testing

- All 50 booking-related tests pass
- Verified the fix works for the scenario: create a paid event with seats, book the same slot with two attendees, then open the second attendee's confirmation link - it now shows the correct price for that seat instead of the first seat's price.

Closes #29664