### PR TITLE
docs: document docker postgres env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ DATABASE_URL="postgresql://postgres:@localhost:5450/calendso"
 DATABASE_DIRECT_URL="postgresql://postgres:@localhost:5450/calendso"
 INSIGHTS_DATABASE_URL=
 
+# Used by the root docker-compose.yml when running the bundled Postgres service.
+POSTGRES_USER=unicorn_user
+POSTGRES_PASSWORD=magical_password
+DATABASE_HOST=database
+POSTGRES_DB=calendso
+
 # ***********************************************************************************************************
 
 # - SHARED **************************************************************************************************


### PR DESCRIPTION
## Summary

- add the Postgres variables consumed by the root `docker-compose.yml` to `.env.example`
- keep the sample values aligned with the bundled Postgres service (`database` host, `calendso` database)

## Why

The Docker guide tells users to copy `.env.example` to `.env` before running `docker compose up -d`, but the root Compose file builds `DATABASE_URL` from `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DATABASE_HOST`, and `POSTGRES_DB`. Without those variables in the example env file, Compose defaults them to empty values and produces a malformed database URL for the app containers.

Related to #27250.

## Testing

- `python3` static check confirmed `.env.example` defines all Postgres variables referenced by `docker-compose.yml`.
- `cp .env.example .env && docker compose --env-file .env.example config --quiet` passed. Compose still reports unrelated existing warnings for optional unset variables such as `API_URL`, `JWT_SECRET`, and Stripe/Axiom settings.
