### PR TITLE
fix(addGuests): use first occurrence for guest deduplication consistency

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts
@@ -208,10 +208,21 @@ export async function sanitizeAndFilterGuests(
   const guestEmailsLowerCase = deduplicatedGuests.map((email) => extractBaseEmail(email).toLowerCase());
   const emailToRequiresVerification = await getEmailVerificationRequirements(guestEmailsLowerCase);
 
-  // Create a map of email to guest object for easy lookup
-  const emailToGuestMap = new Map(
-    guests.map((guest) => [extractBaseEmail(guest.email).toLowerCase(), guest])
-  );
+  // Create a map of email to guest object using FIRST occurrence (consistent with deduplicateGuestEmails)
+  type Guest = {
+    email: string;
+    name?: string;
+    timeZone?: string;
+    phoneNumber?: string;
+    language?: string;
+  };
+  const emailToGuestMap = new Map<string, Guest>();
+  for (const guest of guests) {
+    const baseEmail = extractBaseEmail(guest.email).toLowerCase();
+    if (!emailToGuestMap.has(baseEmail)) {
+      emailToGuestMap.set(baseEmail, guest);
+    }
+  }
 
   const uniqueGuestEmails = deduplicatedGuests.filter((email) => {
     const baseGuestEmail = extractBaseEmail(email).toLowerCase();
@@ -228,7 +239,7 @@ export async function sanitizeAndFilterGuests(
     throw new TRPCError({ code: "BAD_REQUEST", message: "emails_must_be_unique_valid" });
   }
 
-  // Return the full guest objects for unique emails
+  // Return the full guest objects for unique emails (using first occurrence)
   return uniqueGuestEmails
     .map((email) => emailToGuestMap.get(extractBaseEmail(email).toLowerCase()))
     .filter((guest): guest is NonNullable<typeof guest> => guest !== undefined);


### PR DESCRIPTION
## Summary

The `sanitizeAndFilterGuests` function in `packages/trpc/server/routers/viewer/bookings/addGuests.handler.ts` used a Map that kept the LAST occurrence of duplicate emails (via `new Map(guests.map(...))`), but `deduplicateGuestEmails` keeps the FIRST occurrence. This caused a mismatch where the wrong guest data (name, timezone, language) could be used for a deduplicated email.

## Changes

- Fixed `emailToGuestMap` to use first occurrence only (consistent with `deduplicateGuestEmails`)
- Used `for...of` loop that doesn't overwrite existing keys

## Testing

- All 35 booking-related tests pass
- Verified the fix maintains consistency between deduplication and guest data mapping

Closes #29849