### PR TITLE
fix(csv): prevent formula injection and handle bare CR per RFC 4180

### DIFF
--- a/apps/web/modules/users/lib/UserListTableUtils.ts
+++ b/apps/web/modules/users/lib/UserListTableUtils.ts
@@ -75,9 +75,9 @@ export const generateCsvRawForMembersTable = (
     );
 
     const requiredColumns = [
-      email, // Members column
-      `${orgDomain}/${username}`, // Link column
-      role, // Role column
+      sanitizeValue(email), // Members column
+      sanitizeValue(`${orgDomain}/${username}`), // Link column
+      sanitizeValue(role), // Role column
       sanitizeValue(teams.map((team: { id: number; name: string }) => team.name).join(",")), // Teams column
     ];
 

--- a/packages/lib/csvUtils.test.ts
+++ b/packages/lib/csvUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeValue, objectsToCsv } from "./csvUtils";
+
+describe("csvUtils", () => {
+  describe("sanitizeValue", () => {
+    it("should escape quotes by doubling them and wrap in quotes", () => {
+      // "hello "world"" has 2 embedded quotes -> each becomes 2 = 4, plus 2 wrapping = 6 total
+      expect(sanitizeValue('hello "world"')).toBe('"hello ""world"""');
+    });
+
+    it("should quote values containing commas", () => {
+      expect(sanitizeValue("hello,world")).toBe('"hello,world"');
+    });
+
+    it("should quote values containing newlines", () => {
+      expect(sanitizeValue("hello\nworld")).toBe('"hello\nworld"');
+    });
+
+    it("should quote values containing carriage returns (RFC 4180)", () => {
+      expect(sanitizeValue("hello\rworld")).toBe('"hello\rworld"');
+    });
+
+    it("should quote values containing CRLF", () => {
+      expect(sanitizeValue("hello\r\nworld")).toBe('"hello\r\nworld"');
+    });
+
+    it("should not quote simple values without special characters", () => {
+      expect(sanitizeValue("hello world")).toBe("hello world");
+    });
+
+    it("should neutralize formula injection with = prefix", () => {
+      expect(sanitizeValue("=1+1")).toBe("'=1+1");
+    });
+
+    it("should neutralize formula injection with + prefix", () => {
+      expect(sanitizeValue("+1-1")).toBe("'+1-1");
+    });
+
+    it("should neutralize formula injection with - prefix", () => {
+      expect(sanitizeValue("-SUM(A1:A10)")).toBe("'-SUM(A1:A10)");
+    });
+
+    it("should neutralize formula injection with @ prefix", () => {
+      expect(sanitizeValue("@SUM(A1:A10)")).toBe("'@SUM(A1:A10)");
+    });
+
+    it("should neutralize formula injection with tab prefix", () => {
+      expect(sanitizeValue("\tmalicious")).toBe("'\tmalicious");
+    });
+
+    it("should neutralize formula injection with carriage return prefix AND quote due to CR", () => {
+      // \rmalicious -> '\rmalicious (prefix) -> "'\rmalicious" (quote due to CR)
+      expect(sanitizeValue("\rmalicious")).toBe('"\'\rmalicious"');
+    });
+
+    it("should handle formula injection that also needs quoting (prefix + quote)", () => {
+      // =1,2 -> '=1,2 (prefix) -> "'=1,2" (quote due to comma)
+      expect(sanitizeValue("=1,2")).toBe('"\'=1,2"');
+    });
+
+    it("should handle empty string", () => {
+      expect(sanitizeValue("")).toBe("");
+    });
+
+    it("should handle values with only safe characters", () => {
+      expect(sanitizeValue("Safe Value 123")).toBe("Safe Value 123");
+    });
+  });
+
+  describe("objectsToCsv", () => {
+    it("should sanitize all values including headers", () => {
+      const data = [
+        { name: "John", email: "john@example.com" },
+        { name: "Jane", email: "jane@example.com" },
+      ];
+      const csv = objectsToCsv(data);
+      expect(csv).toContain("name,email");
+      expect(csv).toContain("John,john@example.com");
+    });
+
+    it("should sanitize formula injection in data cells", () => {
+      const data = [
+        { name: "=1+1", email: "test@example.com" },
+      ];
+      const csv = objectsToCsv(data);
+      // Formula should be neutralized
+      expect(csv).toContain("'=1+1");
+    });
+
+    it("should sanitize carriage returns in data", () => {
+      const data = [
+        { name: "hello\rworld", email: "test@example.com" },
+      ];
+      const csv = objectsToCsv(data);
+      // CR should be quoted
+      expect(csv).toContain('"hello\rworld"');
+    });
+
+    it("should sanitize CRLF in data", () => {
+      const data = [
+        { name: "hello\r\nworld", email: "test@example.com" },
+      ];
+      const csv = objectsToCsv(data);
+      // CRLF should be quoted
+      expect(csv).toContain('"hello\r\nworld"');
+    });
+  });
+});

--- a/packages/lib/csvUtils.ts
+++ b/packages/lib/csvUtils.ts
@@ -1,6 +1,11 @@
-export const downloadAsCsv = (data: string | Record<string, any>[], filename: string) => {
+export const downloadAsCsv = (data: string | Record<string, unknown>[], filename: string): void => {
   // If data is an array of objects, convert it to CSV string
-  const csvString = typeof data === "string" ? data : objectsToCsv(data);
+  let csvString: string;
+  if (typeof data === "string") {
+    csvString = data;
+  } else {
+    csvString = objectsToCsv(data);
+  }
 
   // Create a Blob from the text data
   const blob = new Blob([csvString], { type: "text/plain" });
@@ -20,7 +25,7 @@ export const downloadAsCsv = (data: string | Record<string, any>[], filename: st
   window.URL.revokeObjectURL(url);
 };
 
-export const objectsToCsv = (data: Record<string, any>[]): string => {
+export const objectsToCsv = (data: Record<string, unknown>[]): string => {
   if (!data.length) return "";
 
   // Get headers from the first object
@@ -46,16 +51,23 @@ export const objectsToCsv = (data: Record<string, any>[]): string => {
   return csvRows.join("\n");
 };
 
-export const sanitizeValue = (value: string) => {
-  // handling three cases:
-  // 1. quotes - we need to double quotes for CSV
-  // 2. commas
-  // 3. newlines
-  if (value.includes('"')) {
-    return `"${value.replace(/"/g, '""')}"`;
+export const sanitizeValue = (value: string): string => {
+  // Neutralize formula injection (OWASP CSV injection prevention)
+  // Prefix with single quote to prevent formula evaluation
+  // Characters that can start formulas: = + - @ \t \r
+  if (/^[=+\-@\t\r]/.test(value)) {
+    value = `'${value}`;
   }
-  if (value.includes(",") || value.includes("\n")) {
-    return `"${value}"`;
+
+  // Check for characters that require quoting per RFC 4180
+  // \r and \r\n are record separators in RFC 4180
+  const needsQuoting =
+    value.includes('"') || value.includes(",") || value.includes("\n") || value.includes("\r");
+
+  if (needsQuoting) {
+    // Escape quotes by doubling them
+    const escaped = value.replace(/"/g, '""');
+    return `"${escaped}"`;
   }
   return value;
 };


### PR DESCRIPTION
## Summary

The `sanitizeValue` function in `packages/lib/csvUtils.ts` had two security issues:

1. **Bare carriage return (\r) not handled** - RFC 4180 treats \r as record separator, allowing row injection
2. **Formula injection** - Values starting with `=`, `+`, `-`, `@`, `\t`, `\r` could execute formulas in Excel/Sheets (CWE-1236)

Also, the member export in `apps/web/modules/users/lib/UserListTableUtils.ts` was not sanitizing email, role, and link columns.

## Changes

- `packages/lib/csvUtils.ts`: 
  - Added formula injection prevention (prefix dangerous chars with single quote)
  - Added \r and \r\n handling per RFC 4180
  - Fixed biome issues (explicit types, no ternary, template literals, no any)

- `packages/lib/csvUtils.test.ts`: Added 19 comprehensive tests covering:
  - Quote escaping, commas, newlines, CRLF
  - Formula injection with =, +, -, @, \t, \r
  - Combined cases (formula + quoting needed)

- `apps/web/modules/users/lib/UserListTableUtils.ts`: 
  - Applied sanitizeValue to ALL columns (email, role, link, teams, attributes)

## Testing

- All 19 new csvUtils tests pass
- All 13 user module tests pass
- All booking tests pass

Closes #29843