### PR TITLE
fix: use numeric values for OG image dimensions in Satori renderer

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -53,21 +53,21 @@ const OG_ASSETS = {
   meeting: {
     id: "meeting-og-image-v1", // Bump version when changing Meeting component structure/styling
     logo: LOGO,
-    logoWidth: "350",
-    avatarSize: "160",
+    logoWidth: 350,
+    avatarSize: 160,
     variant: "dark" as const,
   },
   app: {
     id: "app-og-image-v1", // Bump version when changing App component structure/styling
     logo: LOGO,
-    logoWidth: "150",
-    iconSize: "172",
+    logoWidth: 150,
+    iconSize: 172,
     variant: "light" as const,
   },
   generic: {
     id: "generic-og-image-v1", // Bump version when changing Generic component structure/styling
     logo: LOGO_DARK,
-    logoWidth: "350",
+    logoWidth: 350,
     variant: "light" as const,
   },
 };


### PR DESCRIPTION
## What and why

`OG_ASSETS` in `packages/lib/OgImages.tsx` declares all image dimension values as string literals (`"350"`, `"160"`, `"172"`, `"150"`). These values are passed directly as `width` and `height` attributes to Satori's `<img>` elements.

Satori requires `width` and `height` to be numbers (or `"auto"`). Passing bare numeric strings causes Satori to silently drop the `<img>` elements, so every generated OG image is missing its logo and, for meeting cards, all host avatars.

The Tailwind class on line 227 (`w-[${config.avatarSize}px]`) is unaffected — JavaScript still interpolates `"160px"` from the number `160`.

Fixes #29895

## Changes

Change `logoWidth`, `avatarSize`, and `iconSize` in `OG_ASSETS` from string literals to number literals (6 values, 1 file).

```diff
-    logoWidth: "350",
-    avatarSize: "160",
+    logoWidth: 350,
+    avatarSize: 160,
```

## Testing

The fix is a type change only. Manually: hit `/api/social/og/image?type=meeting` before and after — logo and avatars will appear with the fix applied.

No tests added (no existing tests for this function; adding them would be a separate PR).