### PR TITLE
fix: preserve delegation fields on the user path of getLocationGroupedOptions

### DIFF
--- a/packages/app-store/repositories/PrismaCredentialRepository.test.ts
+++ b/packages/app-store/repositories/PrismaCredentialRepository.test.ts
@@ -1,0 +1,67 @@
+import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+import { describe, expect, it } from "vitest";
+import { PrismaCredentialRepository } from "./PrismaCredentialRepository";
+
+const storedCredential = {
+  id: 1,
+  type: "google_video",
+  key: {},
+  encryptedKey: null,
+  userId: 42,
+  user: { email: "user@example.com" },
+  teamId: null,
+  appId: "google-meet",
+  invalid: false,
+  delegationCredentialId: "delegation-credential-1",
+  team: null,
+  subscriptionId: null,
+  billingCycleStart: null,
+  paymentStatus: null,
+};
+
+describe("PrismaCredentialRepository", () => {
+  describe("findNonDelegationCredentialsByAppCategories", () => {
+    it("queries credentials by the given filter and app categories", async () => {
+      prismaMock.credential.findMany.mockResolvedValue([]);
+
+      const repository = new PrismaCredentialRepository(prismaMock);
+      await repository.findNonDelegationCredentialsByAppCategories({
+        idToSearchObject: { userId: 42 },
+        appCategories: ["conferencing"],
+      });
+
+      expect(prismaMock.credential.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 42,
+          app: {
+            categories: {
+              hasSome: ["conferencing"],
+            },
+          },
+        },
+        select: {
+          ...credentialForCalendarServiceSelect,
+          team: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      });
+    });
+
+    it("returns rows as stored, preserving delegation linkage fields", async () => {
+      prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+      const repository = new PrismaCredentialRepository(prismaMock);
+      const result = await repository.findNonDelegationCredentialsByAppCategories({
+        idToSearchObject: { userId: 42 },
+        appCategories: ["conferencing"],
+      });
+
+      expect(result).toEqual([storedCredential]);
+      expect(result[0].delegationCredentialId).toBe("delegation-credential-1");
+    });
+  });
+});

--- a/packages/app-store/repositories/PrismaCredentialRepository.ts
+++ b/packages/app-store/repositories/PrismaCredentialRepository.ts
@@ -1,40 +1,41 @@
-import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
-import { prisma } from "@calcom/prisma";
-import type { Prisma } from "@calcom/prisma/client";  
-import type { AppCategories } from "@calcom/prisma/client";
+import type { prisma } from "@calcom/prisma";
+import type { AppCategories, Prisma } from "@calcom/prisma/client";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export class PrismaCredentialRepository {
-    constructor(private readonly prismaClient: typeof prisma){}
+  constructor(private readonly prismaClient: typeof prisma) {}
 
-    async findNonDelegationCredentialsByAppCategories({
-        idToSearchObject,  
-        appCategories,
-    }: {
-        idToSearchObject: Prisma.CredentialWhereInput;  
-        appCategories: AppCategories[];  
-    }){
+  /**
+   * Rows are returned as stored — delegation linkage fields (e.g. delegationCredentialId)
+   * are preserved. Callers that need rows marked as plain credentials must apply
+   * buildNonDelegationCredentials themselves.
+   */
+  async findNonDelegationCredentialsByAppCategories({
+    idToSearchObject,
+    appCategories,
+  }: {
+    idToSearchObject: Prisma.CredentialWhereInput;
+    appCategories: AppCategories[];
+  }) {
+    const credentials = await this.prismaClient.credential.findMany({
+      where: {
+        ...idToSearchObject,
+        app: {
+          categories: {
+            hasSome: appCategories,
+          },
+        },
+      },
+      select: {
+        ...credentialForCalendarServiceSelect,
+        team: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
 
-        const credentials = await this.prismaClient.credential.findMany({
-            where: {
-                ...idToSearchObject,
-                app: {
-                    categories: {
-                        hasSome: appCategories
-                    }
-                }
-            },
-            select: {
-                ...credentialForCalendarServiceSelect,
-                team: {
-                    select: {
-                        name: true
-                    }
-                }
-            }
-        })
-
-
-        return buildNonDelegationCredentials(credentials)
-    }
+    return credentials;
+  }
 }

--- a/packages/app-store/server.test.ts
+++ b/packages/app-store/server.test.ts
@@ -1,0 +1,78 @@
+import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import { enrichUserWithDelegationConferencingCredentialsWithoutOrgId } from "@calcom/app-store/delegationCredential";
+import type { User } from "@calcom/prisma/client";
+import type { TFunction } from "i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getEnabledAppsFromCredentials from "./_utils/getEnabledAppsFromCredentials";
+import { getLocationGroupedOptions } from "./server";
+
+vi.mock("@calcom/app-store/delegationCredential", () => ({
+  enrichUserWithDelegationConferencingCredentialsWithoutOrgId: vi.fn(),
+}));
+
+vi.mock("./_utils/getEnabledAppsFromCredentials", () => ({
+  default: vi.fn(),
+}));
+
+const t = ((key: string) => key) as TFunction;
+
+const storedCredential = {
+  id: 1,
+  type: "google_video",
+  key: {},
+  encryptedKey: null,
+  userId: 42,
+  user: { email: "user@example.com" },
+  teamId: null,
+  appId: "google-meet",
+  invalid: false,
+  delegationCredentialId: "delegation-credential-1",
+  team: null,
+  subscriptionId: null,
+  billingCycleStart: null,
+  paymentStatus: null,
+};
+
+const mockUser = {
+  id: 42,
+  email: "user@example.com",
+} as unknown as User;
+
+describe("getLocationGroupedOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnabledAppsFromCredentials).mockResolvedValue([]);
+    vi.mocked(enrichUserWithDelegationConferencingCredentialsWithoutOrgId).mockImplementation(
+      async ({ user }) => user
+    );
+  });
+
+  it("passes user credentials to the delegation enrichment with delegation fields as stored", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(mockUser);
+    prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+    await getLocationGroupedOptions({ userId: 42 }, t);
+
+    const enrichMock = vi.mocked(enrichUserWithDelegationConferencingCredentialsWithoutOrgId);
+    expect(enrichMock).toHaveBeenCalledTimes(1);
+    const { user } = enrichMock.mock.calls[0][0];
+    expect(user.credentials).toEqual([storedCredential]);
+    expect(user.credentials[0].delegationCredentialId).toBe("delegation-credential-1");
+  });
+
+  it("marks credentials as non-delegation on the team path", async () => {
+    prismaMock.team.findFirst.mockResolvedValue(null);
+    prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+    await getLocationGroupedOptions({ teamId: 7 }, t);
+
+    expect(enrichUserWithDelegationConferencingCredentialsWithoutOrgId).not.toHaveBeenCalled();
+    const [credentials] = vi.mocked(getEnabledAppsFromCredentials).mock.calls[0];
+    expect(credentials[0]).toEqual({
+      ...storedCredential,
+      delegatedTo: null,
+      delegatedToId: null,
+      delegationCredentialId: null,
+    });
+  });
+});

--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -1,14 +1,13 @@
-import type { TFunction } from "i18next";
-
 import { enrichUserWithDelegationConferencingCredentialsWithoutOrgId } from "@calcom/app-store/delegationCredential";
 import { defaultVideoAppCategories } from "@calcom/app-store/utils";
+import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
 import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { AppCategories } from "@calcom/prisma/enums";
-import { PrismaCredentialRepository } from "./repositories/PrismaCredentialRepository";
-
+import type { TFunction } from "i18next";
 import getEnabledAppsFromCredentials from "./_utils/getEnabledAppsFromCredentials";
 import { defaultLocations } from "./locations";
+import { PrismaCredentialRepository } from "./repositories/PrismaCredentialRepository";
 
 export async function getLocationGroupedOptions(
   userOrTeamId: { userId: number } | { teamId: number },
@@ -61,10 +60,10 @@ export async function getLocationGroupedOptions(
     });
   }
 
-  const credentialRepository = new PrismaCredentialRepository(prisma);  
-  const nonDelegationCredentials = await credentialRepository.findNonDelegationCredentialsByAppCategories({  
+  const credentialRepository = new PrismaCredentialRepository(prisma);
+  const nonDelegationCredentials = await credentialRepository.findNonDelegationCredentialsByAppCategories({
     idToSearchObject,
-    appCategories: defaultVideoAppCategories,  
+    appCategories: defaultVideoAppCategories,
   });
 
   let credentials;
@@ -80,7 +79,7 @@ export async function getLocationGroupedOptions(
     );
     credentials = allCredentials;
   } else {
-    credentials = nonDelegationCredentials;  
+    credentials = buildNonDelegationCredentials(nonDelegationCredentials);
   }
 
   const integrations = await getEnabledAppsFromCredentials(credentials, { filterOnCredentials: true });


### PR DESCRIPTION
## What does this PR do?

Fixes #29898

PR #29724 moved the credential query from `getLocationGroupedOptions` into `PrismaCredentialRepository.findNonDelegationCredentialsByAppCategories`. The moved query is identical, but the move also relocated the `buildNonDelegationCredentials` call — the helper that forces `delegatedTo`, `delegatedToId`, and `delegationCredentialId` to `null` — from the non-user branch of `getLocationGroupedOptions` into the repository method, where it now runs for **both** branches.

Before the refactor, the user branch passed credentials to `enrichUserWithDelegationConferencingCredentialsWithoutOrgId` with delegation fields **as stored**; only the non-user (team) branch nulled them. After the refactor, the user branch also receives rows with those three fields overwritten to `null`. Nothing user-visible breaks today because the CE enrich function is an identity stub, but the refactor silently changed behavior it read as preserving, and any future implementation reading `delegationCredentialId` off incoming rows would silently get `null`.

## Fix

Restores the pre-#29724 per-branch behavior while keeping the repository pattern:

- `PrismaCredentialRepository.findNonDelegationCredentialsByAppCategories` now returns rows as stored and documents that contract (it no longer applies `buildNonDelegationCredentials`, which also keeps transformation logic out of the repository per the repo's data-layer rules).
- `getLocationGroupedOptions` applies `buildNonDelegationCredentials` only in the non-user branch, exactly where it ran before the refactor.

Biome formatting was applied to the touched files (the repository file was previously unformatted), which accounts for most of the diff — the semantic change is the moved `buildNonDelegationCredentials` call.

## Visual Demo (For contributors especially)

N/A — server-side behavior fix with no UI change. The behavior delta is pinned by the regression tests below (the issue itself is a static, code-level trace).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A — no developer-docs impact; the repository method's contract is documented inline.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables or test data needed — unit tests only.
- Run: `TZ=UTC yarn vitest run packages/app-store/server.test.ts packages/app-store/repositories/PrismaCredentialRepository.test.ts`
- `packages/app-store/server.test.ts` pins the per-branch behavior:
  - user path: the credentials array passed to `enrichUserWithDelegationConferencingCredentialsWithoutOrgId` keeps `delegationCredentialId` as stored (this test **fails on current `main`**, reproducing #29898, and passes with this fix);
  - team path: credentials passed to `getEnabledAppsFromCredentials` still have `delegatedTo` / `delegatedToId` / `delegationCredentialId` nulled.
- `packages/app-store/repositories/PrismaCredentialRepository.test.ts` pins the repository contract: rows are returned as stored, and the query filter/select are unchanged.
