### PR TITLE
fix(lib): update OG_ASSETS sizes to numeric types for Satori rendering (#29895)

### DIFF
--- a/packages/lib/OgImages.test.ts
+++ b/packages/lib/OgImages.test.ts
@@ -5,6 +5,7 @@ import {
   constructMeetingImage,
   constructAppImage,
   constructGenericImage,
+  OG_ASSETS,
 } from "./OgImages";
 
 describe("OgImages", () => {
@@ -114,6 +115,27 @@ describe("OgImages", () => {
       const v1 = await getOGImageVersion("generic");
       const v2 = await getOGImageVersion("generic");
       expect(v1).toBe(v2);
+    });
+  });
+
+  describe("OG_ASSETS size data types for Satori image rendering", () => {
+    it("passes numeric sizes for meeting OG asset (logoWidth, avatarSize)", () => {
+      expect(typeof OG_ASSETS.meeting.logoWidth).toBe("number");
+      expect(typeof OG_ASSETS.meeting.avatarSize).toBe("number");
+      expect(OG_ASSETS.meeting.logoWidth).toBe(350);
+      expect(OG_ASSETS.meeting.avatarSize).toBe(160);
+    });
+
+    it("passes numeric sizes for app OG asset (logoWidth, iconSize)", () => {
+      expect(typeof OG_ASSETS.app.logoWidth).toBe("number");
+      expect(typeof OG_ASSETS.app.iconSize).toBe("number");
+      expect(OG_ASSETS.app.logoWidth).toBe(150);
+      expect(OG_ASSETS.app.iconSize).toBe(172);
+    });
+
+    it("passes numeric sizes for generic OG asset (logoWidth)", () => {
+      expect(typeof OG_ASSETS.generic.logoWidth).toBe("number");
+      expect(OG_ASSETS.generic.logoWidth).toBe(350);
     });
   });
 });

--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -49,25 +49,25 @@ const joinMultipleNames = (names: string[] = []) => {
 
 const makeAbsoluteUrl = (url: string) => (/^https?:\/\//.test(url) ? url : `${CAL_URL}${url}`);
 
-const OG_ASSETS = {
+export const OG_ASSETS = {
   meeting: {
     id: "meeting-og-image-v1", // Bump version when changing Meeting component structure/styling
     logo: LOGO,
-    logoWidth: "350",
-    avatarSize: "160",
+    logoWidth: 350,
+    avatarSize: 160,
     variant: "dark" as const,
   },
   app: {
     id: "app-og-image-v1", // Bump version when changing App component structure/styling
     logo: LOGO,
-    logoWidth: "150",
-    iconSize: "172",
+    logoWidth: 150,
+    iconSize: 172,
     variant: "light" as const,
   },
   generic: {
     id: "generic-og-image-v1", // Bump version when changing Generic component structure/styling
     logo: LOGO_DARK,
-    logoWidth: "350",
+    logoWidth: 350,
     variant: "light" as const,
   },
 };


### PR DESCRIPTION
## Description
Fixes issue #29895 where OG image logo and avatar sizes were defined as strings in `OG_ASSETS` instead of numbers, preventing Satori (`next/og` / `@vercel/og`) from rendering logo and avatar elements in generated OG images.
