### PR TITLE
fix(bookings): fix round-robin recurring calendar series split

### DIFF
--- a/packages/features/bookings/lib/service/RecurringBookingService.test.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.test.ts
@@ -9,6 +9,13 @@ import {
   mockSuccessfulVideoMeetingCreation,
   TestData,
 } from "@calcom/testing/lib/bookingScenario/bookingScenario";
+import process from "node:process";
+import { getRecurringBookingService } from "@calcom/features/bookings/di/RecurringBookingService.container";
+import { RecurringBookingService } from "@calcom/features/bookings/lib/service/RecurringBookingService";
+import type { RegularBookingService } from "@calcom/features/bookings/lib/service/RegularBookingService";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+import logger from "@calcom/lib/logger";
+import { BookingStatus, SchedulingType } from "@calcom/prisma/enums";
 import {
   expectBookingCreatedWebhookToHaveBeenFired,
   expectBookingToBeInDatabase,
@@ -17,15 +24,9 @@ import {
 } from "@calcom/testing/lib/bookingScenario/expects";
 import { getMockRequestDataForBooking } from "@calcom/testing/lib/bookingScenario/getMockRequestDataForBooking";
 import { setupAndTeardown } from "@calcom/testing/lib/bookingScenario/setupAndTeardown";
-
-import { v4 as uuidv4 } from "uuid";
-import { describe, expect } from "vitest";
-
-import { getRecurringBookingService } from "@calcom/features/bookings/di/RecurringBookingService.container";
-import { WEBAPP_URL } from "@calcom/lib/constants";
-import logger from "@calcom/lib/logger";
-import { BookingStatus } from "@calcom/prisma/enums";
 import { test } from "@calcom/testing/lib/fixtures/fixtures";
+import { v4 as uuidv4 } from "uuid";
+import { describe, expect, it, vi } from "vitest";
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
@@ -250,6 +251,81 @@ describe("handleNewRecurringBooking", () => {
               videoCallUrl: "http://mock-dailyvideo.example.com/meeting-1",
             },
           ]);
+        },
+        timeout
+      );
+    });
+
+    describe("Round robin event type:", () => {
+      it(
+        `propagates thirdPartyRecurringEventId from the first (lucky-user) booking to
+          subsequent occurrences, so every occurrence attaches to the same third-party
+          calendar recurring series`,
+        async () => {
+          const createBooking = vi
+            .fn()
+            .mockResolvedValueOnce({
+              luckyUsers: [101],
+              references: [{ type: "google_calendar", thirdPartyRecurringEventId: "SERIES_A" }],
+            })
+            .mockResolvedValueOnce({
+              luckyUsers: [101],
+              references: [],
+            })
+            .mockResolvedValueOnce({
+              luckyUsers: [101],
+              references: [],
+            });
+
+          const regularBookingService = {
+            createBooking,
+          } as unknown as RegularBookingService;
+
+          const recurringBookingService = new RecurringBookingService({ regularBookingService });
+
+          const plus1DateString = getDate({ dateIncrement: 1 }).dateString;
+          const mockBookingData = getMockRequestDataForBooking({
+            data: {
+              eventTypeId: 1,
+              start: `${plus1DateString}T04:00:00.000Z`,
+              end: `${plus1DateString}T04:30:00.000Z`,
+              recurringEventId: uuidv4(),
+              recurringCount: 3,
+              responses: {
+                email: "booker@example.com",
+                name: "Booker",
+                location: { optionValue: "", value: "New York" },
+              },
+            },
+          });
+
+          const bookingDataArray = Array(3)
+            .fill(mockBookingData)
+            .map((data, index) => ({
+              ...data,
+              schedulingType: SchedulingType.ROUND_ROBIN,
+              start: getPlusDayDate(data.start, index).toISOString(),
+              end: getPlusDayDate(data.end, index).toISOString(),
+            }));
+
+          await recurringBookingService.createBooking({
+            bookingData: bookingDataArray,
+            bookingMeta: { userId: -1 },
+            creationSource: "WEBAPP",
+          });
+
+          expect(createBooking).toHaveBeenCalledTimes(3);
+
+          // First (lucky-user) booking has no prior series to attach to.
+          expect(createBooking.mock.calls[0][0].bookingData.thirdPartyRecurringEventId).toBeNull();
+
+          // Occurrence 1 must attach to the series created by the first booking —
+          // this is null on `main` because the first booking's `references` are
+          // never scanned, so occurrence 1 starts a brand-new calendar series.
+          expect(createBooking.mock.calls[1][0].bookingData.thirdPartyRecurringEventId).toBe("SERIES_A");
+
+          // Occurrence 2 must keep using the same series, not overwrite it.
+          expect(createBooking.mock.calls[2][0].bookingData.thirdPartyRecurringEventId).toBe("SERIES_A");
         },
         timeout
       );

--- a/packages/features/bookings/lib/service/RecurringBookingService.ts
+++ b/packages/features/bookings/lib/service/RecurringBookingService.ts
@@ -8,6 +8,21 @@ export type BookingHandlerInput = {
   bookingData: CreateRecurringBookingData;
 } & CreateBookingMeta;
 
+// Every occurrence of a recurring booking must attach to the same third-party
+// (e.g. Google Calendar) recurring series, so we reuse the id from whichever
+// booking first receives one from its calendar references.
+function extractThirdPartyRecurringEventId(booking: BookingResponse): string | null {
+  if (!booking.references || booking.references.length === 0) {
+    return null;
+  }
+  for (const reference of booking.references) {
+    if (reference.thirdPartyRecurringEventId) {
+      return reference.thirdPartyRecurringEventId;
+    }
+  }
+  return null;
+}
+
 export const handleNewRecurringBooking = async function (
   this: RecurringBookingService,
   {
@@ -69,6 +84,7 @@ export const handleNewRecurringBooking = async function (
       },
     });
     luckyUsers = firstBookingResult.luckyUsers;
+    thirdPartyRecurringEventId = extractThirdPartyRecurringEventId(firstBookingResult);
   }
 
   for (let key = isRoundRobin ? 1 : 0; key < data.length; key++) {
@@ -117,14 +133,7 @@ export const handleNewRecurringBooking = async function (
     createdBookings.push(eachRecurringBooking);
 
     if (!thirdPartyRecurringEventId) {
-      if (eachRecurringBooking.references && eachRecurringBooking.references.length > 0) {
-        for (const reference of eachRecurringBooking.references) {
-          if (reference.thirdPartyRecurringEventId) {
-            thirdPartyRecurringEventId = reference.thirdPartyRecurringEventId;
-            break;
-          }
-        }
-      }
+      thirdPartyRecurringEventId = extractThirdPartyRecurringEventId(eachRecurringBooking);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a round-robin recurring booking gets split into two separate third-party calendar recurring series (Google Calendar and similar providers), instead of all occurrences belonging to one series.

**Root cause:** in `RecurringBookingService.ts`, round-robin recurring bookings create the first occurrence outside the main loop (to resolve the "lucky" host first). That first booking's result was only read for `luckyUsers` — never scanned for `thirdPartyRecurringEventId` the way every subsequent occurrence's result already is, inside the loop. So when the loop creates occurrence 1, `thirdPartyRecurringEventId` is still `null`, and occurrence 1 starts a brand-new calendar series instead of attaching to occurrence 0's. Occurrences 1..N then correctly share a series with each other — the split is exactly {0} vs {1..N}, which matches what's reported in #29766.

The non-round-robin recurring path doesn't have this bug — it doesn't create a booking outside the loop, so it was never missing the propagation step.

**Fix:** extracted the existing reference-scanning logic into a small helper (`extractThirdPartyRecurringEventId`) and call it for the first round-robin booking too, in addition to the loop. Both code paths now do the same extraction, so they can't drift apart again the way they did here (the loop's logic existed; the first-booking case's never did).

- Fixes #29766

## Visual Demo (For contributors especially)

N/A — this is a backend service-layer bug only observable via a real third-party calendar's recurring-series grouping (e.g. opening Google Calendar and seeing two series instead of one). It isn't reproducible as a UI screenshot; the regression test added here reproduces it directly at the service layer instead (see below).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — internal service-layer fix, no public API or documented behavior changed.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or special test data needed — the new test is a fully self-contained unit test.

- `TZ=UTC yarn vitest run packages/features/bookings/lib/service/RecurringBookingService.test.ts`
- New test: `"Round robin event type:" > "propagates thirdPartyRecurringEventId from the first (lucky-user) booking..."` — mocks `regularBookingService.createBooking`, drives 3 round-robin recurring occurrences, and asserts occurrence 1 and 2 both receive the `thirdPartyRecurringEventId` from occurrence 0's calendar references.
  - Fails on `main` today: `AssertionError: expected null to be 'SERIES_A'`
  - Passes with this fix.
- Full suite unaffected: `TZ=UTC yarn test` → 4076 passed, 47 skipped, 3 todo, 0 failed (baseline on `main` is 4075 passed — this PR adds exactly 1 test, no regressions).
- `yarn lint` → 11/11 tasks successful (same as baseline).
- `yarn type-check:ci --force` → 9/9 tasks successful (same as baseline).

## Checklist

<!-- None of the listed items apply — contributing guide read, code follows style, the one comment explains a non-obvious "why", no new lint warnings introduced, and the PR is 2 files / ~115 lines (well under the 500-line/10-file split threshold). All bullets removed per the template's instruction. -->
