### PR TITLE
fix(bookings): preserve delegation credential and recurring event ids on reschedule

### DIFF
--- a/packages/features/bookings/lib/EventManager.ts
+++ b/packages/features/bookings/lib/EventManager.ts
@@ -652,6 +652,8 @@ export default class EventManager {
             meetingUrl: true,
             externalCalendarId: true,
             credentialId: true,
+            delegationCredentialId: true,
+            thirdPartyRecurringEventId: true,
           },
         },
         destinationCalendar: true,

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -1771,6 +1771,132 @@ describe("handleNewBooking", () => {
         );
       });
 
+      test(
+        `should preserve delegationCredentialId and thirdPartyRecurringEventId on the booking references of the rescheduled booking
+          1. Should cancel the existing booking
+          2. Should create a new booking in the database with the same references including delegationCredentialId and thirdPartyRecurringEventId
+    `,
+        async () => {
+          const handleNewBooking = getNewBookingHandler();
+          const booker = getBooker({
+            email: "booker@example.com",
+            name: "Booker",
+          });
+
+          const organizer = getOrganizer({
+            name: "Organizer",
+            email: "organizer@example.com",
+            id: 101,
+            schedules: [TestData.schedules.IstWorkHours],
+            credentials: [getGoogleCalendarCredential()],
+            selectedCalendars: [TestData.selectedCalendars.google],
+          });
+
+          const { dateString: plus1DateString } = getDate({ dateIncrement: 1 });
+          const uidOfBookingToBeRescheduled = "n5Wv3eHgconAED2j4gcVhP";
+          const iCalUID = `${uidOfBookingToBeRescheduled}@Cal.diy`;
+          await createBookingScenario(
+            getScenarioData({
+              eventTypes: [
+                {
+                  id: 1,
+                  slotInterval: 15,
+                  length: 15,
+                  users: [
+                    {
+                      id: 101,
+                    },
+                  ],
+                },
+              ],
+              bookings: [
+                {
+                  uid: uidOfBookingToBeRescheduled,
+                  eventTypeId: 1,
+                  status: BookingStatus.ACCEPTED,
+                  startTime: `${plus1DateString}T05:00:00.000Z`,
+                  endTime: `${plus1DateString}T05:15:00.000Z`,
+                  metadata: {
+                    videoCallUrl: "https://existing-daily-video-call-url.example.com",
+                  },
+                  references: [
+                    {
+                      type: appStoreMetadata.dailyvideo.type,
+                      uid: "MOCK_ID",
+                      meetingId: "MOCK_ID",
+                      meetingPassword: "MOCK_PASS",
+                      meetingUrl: "http://mock-dailyvideo.example.com",
+                      credentialId: null,
+                    },
+                    {
+                      type: appStoreMetadata.googlecalendar.type,
+                      uid: "MOCK_ID",
+                      meetingId: "MOCK_ID",
+                      meetingPassword: "MOCK_PASSWORD",
+                      meetingUrl: "https://UNUSED_URL",
+                      externalCalendarId: "MOCK_EXTERNAL_CALENDAR_ID",
+                      credentialId: undefined,
+                      delegationCredentialId: "delegation-credential-abc",
+                      thirdPartyRecurringEventId: "third-party-recurring-xyz",
+                    },
+                  ],
+                  iCalUID,
+                },
+              ],
+              organizer,
+              apps: [TestData.apps["google-calendar"], TestData.apps["daily-video"]],
+            })
+          );
+
+          mockSuccessfulVideoMeetingCreation({
+            metadataLookupKey: "dailyvideo",
+          });
+
+          await mockCalendarToHaveNoBusySlots("googlecalendar", {
+            create: {
+              uid: "MOCK_ID",
+            },
+            update: {
+              uid: "UPDATED_MOCK_ID",
+              iCalUID,
+            },
+          });
+
+          const mockBookingData = getMockRequestDataForBooking({
+            data: {
+              eventTypeId: 1,
+              rescheduleUid: uidOfBookingToBeRescheduled,
+              start: `${plus1DateString}T04:00:00.000Z`,
+              end: `${plus1DateString}T04:15:00.000Z`,
+              responses: {
+                email: booker.email,
+                name: booker.name,
+                location: { optionValue: "", value: BookingLocations.CalVideo },
+              },
+              rescheduledBy: organizer.email,
+            },
+          });
+
+          const createdBooking = await handleNewBooking({
+            bookingData: mockBookingData,
+          });
+
+          // References of the rescheduled booking must retain the delegation credential and third-party recurring event ids
+          await expectBookingToBeInDatabase({
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            uid: createdBooking.uid!,
+            references: [
+              {
+                type: appStoreMetadata.googlecalendar.type,
+                delegationCredentialId: "delegation-credential-abc",
+                thirdPartyRecurringEventId: "third-party-recurring-xyz",
+              },
+            ],
+          });
+        },
+        timeout
+      );
+
       describe("Paid event type - attendee reschedule", () => {
         test(
           `when event type does NOT require confirmation, attendee reschedule of paid event creates a PENDING booking (payment handling removed)


### PR DESCRIPTION
## What does this PR do?

When a booking is rescheduled, `EventManager.reschedule()` reloads the original booking's references with a Prisma `select` that omitted `delegationCredentialId` and `thirdPartyRecurringEventId`. On a plain reschedule (same host, same location) those references are copied verbatim onto the newly-created booking, so both columns landed as `NULL` on the new booking.

Because those two fields are exactly what calendar credential/event resolution relies on later, the rescheduled booking lost the link back to the delegation credential that owns the calendar event (Google Workspace domain-wide delegation, where `credentialId = NULL` and `delegationCredentialId` is set) and to the third-party recurring event id used when deleting an occurrence of a recurring series. The next cancel/reschedule could then no longer resolve the delegation credential and left a ghost calendar event.

This PR adds the two fields to the `references` select in `reschedule()` so they are carried over to the rescheduled booking, and adds a regression test that reschedules a booking whose google-calendar reference carries both fields and asserts they survive on the new booking.

- Fixes #29811

## Visual Demo (For contributors especially)

N/A - this is a backend data-integrity fix with no user-visible UI change. The corrected behavior is covered by the automated regression test below.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

The fix is covered by a new regression test in `packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts`:

`should preserve delegationCredentialId and thirdPartyRecurringEventId on the booking references of the rescheduled booking`

- No environment variables required; the test uses the standard mocked booking scenario.
- Minimal test data: a booking whose google-calendar reference carries `delegationCredentialId` and `thirdPartyRecurringEventId`, rescheduled to a new time with the same host and location.
- Expected: the rescheduled booking's references still carry both fields.

Commands run locally:

```
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts   # 19 passed (18 pre-existing + 1 new)
TZ=UTC yarn vitest run packages/features/bookings/lib/handleNewBooking/test packages/features/bookings/lib/service  # 132 passed | 1 skipped | 2 todo
yarn type-check:ci --force   # 9/9 tasks successful
```

Verified the new test fails before the fix (`delegationCredentialId: null`, `thirdPartyRecurringEventId: null`) and passes after.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas (why-comments only)
- My changes generate no new warnings
- My PR is small and focused (2 files, ~130 lines, one concern)

---

_Automated by pr-pipeline (com.ashutosh.prpipeline)._
