### PR TITLE
fix(stripe): avoid duplicate customer creation on lookup errors

### DIFF
--- a/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
@@ -1,0 +1,121 @@
+jest.mock(
+  "@calcom/platform-libraries",
+  () => ({
+    CreationSource: { API_V2: "API_V2" },
+    credentialForCalendarServiceSelect: {},
+  }),
+  { virtual: true }
+);
+
+import type { Prisma, User } from "@calcom/prisma/client";
+import { createMock } from "@golevelup/ts-jest";
+import { ConfigService } from "@nestjs/config";
+import Stripe from "stripe";
+import { StripeService } from "./stripe.service";
+import { AppsRepository } from "@/modules/apps/apps.repository";
+import { CredentialsRepository } from "@/modules/credentials/credentials.repository";
+import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
+import { UsersRepository } from "@/modules/users/users.repository";
+
+describe("StripeService", () => {
+  let service: StripeService;
+  let mockUsersRepository: ReturnType<typeof createMock<UsersRepository>>;
+  let mockCustomersList: jest.Mock<
+    Promise<Stripe.Response<Stripe.ApiList<Stripe.Customer>>>,
+    [Stripe.CustomerListParams]
+  >;
+  let mockCustomersCreate: jest.Mock<
+    Promise<Stripe.Response<Stripe.Customer>>,
+    [Stripe.CustomerCreateParams]
+  >;
+
+  const user: Pick<User, "email" | "name" | "metadata"> = {
+    email: "user@example.com",
+    name: "Test User",
+    metadata: {
+      existing: "value",
+    } satisfies Prisma.JsonObject,
+  };
+
+  beforeEach(() => {
+    mockCustomersList = jest.fn();
+    mockCustomersCreate = jest.fn();
+    mockUsersRepository = createMock<UsersRepository>();
+    const mockConfigService = createMock<ConfigService>({
+      get: jest.fn().mockReturnValue(""),
+    });
+    service = new StripeService(
+      mockConfigService,
+      mockConfigService,
+      createMock<AppsRepository>(),
+      createMock<CredentialsRepository>(),
+      createMock<MembershipsRepository>(),
+      mockUsersRepository
+    );
+    jest.spyOn(service, "getStripe").mockReturnValue({
+      customers: {
+        list: mockCustomersList,
+        create: mockCustomersCreate,
+      },
+    } as unknown as Stripe);
+  });
+
+  describe("createStripeCustomerId", () => {
+    it("reuses an existing Stripe customer when lookup finds one", async () => {
+      mockCustomersList.mockResolvedValue(createCustomerSearchResult([createCustomer("cus_existing")]));
+
+      await expect(service.createStripeCustomerId(user)).resolves.toBe("cus_existing");
+
+      expect(mockCustomersCreate).not.toHaveBeenCalled();
+      expect(mockUsersRepository.updateByEmail).toHaveBeenCalledWith(user.email, {
+        metadata: {
+          existing: "value",
+          stripeCustomerId: "cus_existing",
+        },
+      });
+    });
+
+    it("creates a Stripe customer when lookup returns no customers", async () => {
+      mockCustomersList.mockResolvedValue(createCustomerSearchResult([]));
+      mockCustomersCreate.mockResolvedValue(createCustomer("cus_new"));
+
+      await expect(service.createStripeCustomerId(user)).resolves.toBe("cus_new");
+
+      expect(mockCustomersCreate).toHaveBeenCalledWith({ email: user.email });
+      expect(mockUsersRepository.updateByEmail).toHaveBeenCalledWith(user.email, {
+        metadata: {
+          existing: "value",
+          stripeCustomerId: "cus_new",
+        },
+      });
+    });
+
+    it("propagates Stripe lookup errors without creating duplicate customers", async () => {
+      const stripeError = new Error("Stripe lookup failed");
+      mockCustomersList.mockRejectedValue(stripeError);
+
+      await expect(service.createStripeCustomerId(user)).rejects.toThrow(stripeError);
+
+      expect(mockCustomersCreate).not.toHaveBeenCalled();
+      expect(mockUsersRepository.updateByEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  function createCustomer(id: string): Stripe.Response<Stripe.Customer> {
+    return createMock<Stripe.Response<Stripe.Customer>>({
+      id,
+      object: "customer",
+    });
+  }
+
+  function createCustomerSearchResult(
+    customers: Stripe.Customer[]
+  ): Stripe.Response<Stripe.ApiList<Stripe.Customer>> {
+    return createMock<Stripe.Response<Stripe.ApiList<Stripe.Customer>>>({
+      object: "list",
+      data: customers,
+      has_more: false,
+      url: "/v1/customers",
+    });
+  }
+});

--- a/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
@@ -66,6 +66,7 @@ describe("StripeService", () => {
 
       await expect(service.createStripeCustomerId(user)).resolves.toBe("cus_existing");
 
+      expect(mockCustomersList).toHaveBeenCalledWith({ email: user.email, limit: 1 });
       expect(mockCustomersCreate).not.toHaveBeenCalled();
       expect(mockUsersRepository.updateByEmail).toHaveBeenCalledWith(user.email, {
         metadata: {
@@ -81,6 +82,7 @@ describe("StripeService", () => {
 
       await expect(service.createStripeCustomerId(user)).resolves.toBe("cus_new");
 
+      expect(mockCustomersList).toHaveBeenCalledWith({ email: user.email, limit: 1 });
       expect(mockCustomersCreate).toHaveBeenCalledWith({ email: user.email });
       expect(mockUsersRepository.updateByEmail).toHaveBeenCalledWith(user.email, {
         metadata: {
@@ -96,6 +98,7 @@ describe("StripeService", () => {
 
       await expect(service.createStripeCustomerId(user)).rejects.toThrow(stripeError);
 
+      expect(mockCustomersList).toHaveBeenCalledWith({ email: user.email, limit: 1 });
       expect(mockCustomersCreate).not.toHaveBeenCalled();
       expect(mockUsersRepository.updateByEmail).not.toHaveBeenCalled();
     });

--- a/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.spec.ts
@@ -10,7 +10,7 @@ jest.mock(
 import type { Prisma, User } from "@calcom/prisma/client";
 import { createMock } from "@golevelup/ts-jest";
 import { ConfigService } from "@nestjs/config";
-import Stripe from "stripe";
+import type Stripe from "stripe";
 import { StripeService } from "./stripe.service";
 import { AppsRepository } from "@/modules/apps/apps.repository";
 import { CredentialsRepository } from "@/modules/credentials/credentials.repository";

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -11,12 +11,12 @@ import { ConfigService } from "@nestjs/config";
 import Stripe from "stripe";
 import { z } from "zod";
 import { stripeKeysResponseSchema } from "./utils/stripeDataSchemas";
-import { AppConfig } from "@/config/type";
+import type { AppConfig } from "@/config/type";
 import { AppsRepository } from "@/modules/apps/apps.repository";
 import { CredentialsRepository } from "@/modules/credentials/credentials.repository";
 import { MembershipsRepository } from "@/modules/memberships/memberships.repository";
 import { stripeInstance } from "@/modules/stripe/utils/newStripeInstance";
-import { StripeData } from "@/modules/stripe/utils/stripeDataSchemas";
+import type { StripeData } from "@/modules/stripe/utils/stripeDataSchemas";
 import { UsersRepository } from "@/modules/users/users.repository";
 
 import stringify = require("qs-stringify");

--- a/apps/api/v2/src/modules/stripe/stripe.service.ts
+++ b/apps/api/v2/src/modules/stripe/stripe.service.ts
@@ -1,3 +1,16 @@
+import { SUCCESS_STATUS } from "@calcom/platform-constants";
+import type { Credential, Prisma, User } from "@calcom/prisma/client";
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import Stripe from "stripe";
+import { z } from "zod";
+import { stripeKeysResponseSchema } from "./utils/stripeDataSchemas";
 import { AppConfig } from "@/config/type";
 import { AppsRepository } from "@/modules/apps/apps.repository";
 import { CredentialsRepository } from "@/modules/credentials/credentials.repository";
@@ -5,21 +18,6 @@ import { MembershipsRepository } from "@/modules/memberships/memberships.reposit
 import { stripeInstance } from "@/modules/stripe/utils/newStripeInstance";
 import { StripeData } from "@/modules/stripe/utils/stripeDataSchemas";
 import { UsersRepository } from "@/modules/users/users.repository";
-import {
-  Injectable,
-  NotFoundException,
-  BadRequestException,
-  UnauthorizedException,
-  InternalServerErrorException,
-} from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import Stripe from "stripe";
-import { z } from "zod";
-
-import { SUCCESS_STATUS } from "@calcom/platform-constants";
-import type { Prisma, Credential, User } from "@calcom/prisma/client";
-
-import { stripeKeysResponseSchema } from "./utils/stripeDataSchemas";
 
 import stringify = require("qs-stringify");
 
@@ -236,14 +234,15 @@ export class StripeService {
     let customerId: string;
 
     const stripe = this.getStripe();
-    try {
-      const customersResponse = await stripe.customers.list({
-        email: user.email,
-        limit: 1,
-      });
+    const customersResponse = await stripe.customers.list({
+      email: user.email,
+      limit: 1,
+    });
 
-      customerId = customersResponse.data[0].id;
-    } catch (error) {
+    const existingCustomer = customersResponse.data[0];
+    if (existingCustomer) {
+      customerId = existingCustomer.id;
+    } else {
       const customer = await stripe.customers.create({ email: user.email });
       customerId = customer.id;
     }


### PR DESCRIPTION
## Summary

- Distinguish an empty Stripe customer lookup from a failed lookup.
- Propagate lookup errors instead of creating a potentially duplicate customer.
- Add focused coverage for existing, empty, and failed customer lookups.

## Testing

- `yarn workspace @calcom/api-v2 exec jest src/modules/stripe/stripe.service.spec.ts --runInBand`

Supersedes #29528, which was closed automatically as stale.