### PR TITLE
feat: add collapsible desktop sidebar

### DIFF
--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -11,6 +11,7 @@ import { Logo } from "@calcom/ui/components/logo";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { ArrowLeftIcon, ArrowRightIcon } from "@coss/ui/icons";
+import { PanelLeftIcon } from "lucide-react";
 import { useState } from "react";
 import Link from "next/link";
 import type { User as UserAuth } from "next-auth";
@@ -67,21 +68,6 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
           "max-h-screen",
           isCollapsed ? "lg:w-14 lg:px-0" : "lg:w-56 lg:px-3"
         )}>
-          <Tooltip
-                side="right"
-                content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                className={classNames(!isCollapsed && "lg:hidden")}>
-                <button
-                  type="button"
-                  onClick={() => setIsCollapsed((collapsed) => !collapsed)}
-                  aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  className="hidden h-8 w-full items-center justify-center rounded-md text-subtle transition hover:bg-subtle hover:text-emphasis lg:flex">
-                  <Icon
-                    name={isCollapsed ? "chevrons-right" : "chevrons-left"}
-                    className="h-4 w-4"
-                  />
-                </button>
-              </Tooltip>
         <div className="flex h-full flex-col justify-between py-3 lg:pt-4">
           {/* Tablet sidebar header */}
           <div className="hidden flex-col items-center gap-2 md:flex lg:hidden">
@@ -221,6 +207,34 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
               </span>
             </Tooltip>
           ))}
+          <Tooltip
+            side="right"
+            content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className={classNames(!isCollapsed && "lg:hidden")}>
+            <button
+              type="button"
+              onClick={() => setIsCollapsed((collapsed) => !collapsed)}
+              aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              aria-expanded={!isCollapsed}
+              className={classNames(
+                "text-default hover:bg-subtle hover:text-emphasis hidden w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition lg:flex",
+                isCollapsed ? "justify-center" : "justify-start"
+              )}>
+              <PanelLeftIcon
+                className={classNames(
+                  "h-4 w-4 shrink-0",
+                  !isCollapsed && "ltr:mr-2 rtl:ml-2"
+                )}
+              />
+
+              {!isCollapsed && (
+                <span>
+                  Collapse sidebar
+                </span>
+              )}
+            </button>
+          </Tooltip>
+
           {!IS_VISUAL_REGRESSION_TESTING && !isCollapsed && <Credits />}
         </div>
       </aside>

--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -114,16 +114,9 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                   "todesktop:mt-4 w-full",
                   isCollapsed && "lg:mt-0 lg:flex lg:justify-center"
                 )}>
-                {/* Expanded desktop */}
-                <div className={classNames("hidden lg:block", isCollapsed && "lg:hidden")}>
-                  <UserDropdown />
+                <div className={classNames("hidden lg:block", isCollapsed && "lg:flex lg:justify-center")}>
+                  <UserDropdown iconOnly={isCollapsed} />
                 </div>
-                {/* Collapsed desktop */}
-                {isCollapsed && (
-                  <div className="hidden justify-center lg:flex">
-                    <UserDropdown iconOnly />
-                  </div>
-                )}
               </div>
             )}
             <div className={classNames(

--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -209,29 +209,20 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
           ))}
           <Tooltip
             side="right"
-            content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            content={isCollapsed ? t("expand_sidebar") : t("collapse_sidebar")}
             className={classNames(!isCollapsed && "lg:hidden")}>
             <button
               type="button"
               onClick={() => setIsCollapsed((collapsed) => !collapsed)}
-              aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              aria-label={isCollapsed ? t("expand_sidebar") : t("collapse_sidebar")}
               aria-expanded={!isCollapsed}
               className={classNames(
-                "text-default hover:bg-subtle hover:text-emphasis hidden w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition lg:flex",
-                isCollapsed ? "justify-center" : "justify-start"
-              )}>
-              <PanelLeftIcon
-                className={classNames(
-                  "h-4 w-4 shrink-0",
-                  !isCollapsed && "ltr:mr-2 rtl:ml-2"
-                )}
-              />
+              "hidden w-full items-center rounded-md px-2 py-1.5 font-medium text-default text-sm transition hover:bg-subtle hover:text-emphasis focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 lg:flex",
+              isCollapsed ? "justify-center" : "justify-start gap-2"
+            )}>
+              <PanelLeftIcon className="h-4 w-4 shrink-0" />
 
-              {!isCollapsed && (
-                <span>
-                  Collapse sidebar
-                </span>
-              )}
+              {!isCollapsed && <span>{t("collapse_sidebar")}</span>}
             </button>
           </Tooltip>
 

--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -83,16 +83,25 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                 </button>
               </Tooltip>
         <div className="flex h-full flex-col justify-between py-3 lg:pt-4">
-          {/* logo icon for tablet and collapsed desktop */}
-          <Link href="/event-types"   className={classNames(
-            "text-center md:inline lg:hidden",
-            isCollapsed && "lg:inline"
-          )}>
-            <Logo small icon />
-          </Link>
+          {/* Tablet sidebar header */}
+          <div className="hidden flex-col items-center gap-2 md:flex lg:hidden">
+            <Link href="/event-types" className="text-center">
+              <Logo small icon />
+            </Link>
+
+            {!user?.org && <UserDropdown iconOnly />}
+          </div>
+          
+
+          {/* Logo for collapsed desktop */}
+          {isCollapsed && (
+            <Link href="/event-types" className="hidden text-center lg:inline">
+              <Logo small icon />
+            </Link>
+          )}
           <header className={classNames(
             "todesktop:-mt-3 todesktop:flex-col-reverse items-center justify-between todesktop:[-webkit-app-region:drag] md:hidden lg:flex",
-            isCollapsed && "lg:flex-col lg:gap-3"
+            isCollapsed && "lg:flex-col lg:gap-1"
           )}>
             {user?.org ? (
               !ENABLE_PROFILE_SWITCHER ? (
@@ -116,19 +125,18 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                 data-testid="user-dropdown-trigger"
                 className={classNames(
                   "todesktop:mt-4 w-full",
-                  isCollapsed && "lg:flex lg:justify-center"
+                  isCollapsed && "lg:mt-0 lg:flex lg:justify-center"
                 )}>
+                {/* Expanded desktop */}
                 <div className={classNames("hidden lg:block", isCollapsed && "lg:hidden")}>
                   <UserDropdown />
                 </div>
-
-                <div
-                  className={classNames(
-                    "hidden md:flex md:justify-center lg:hidden",
-                    isCollapsed && "lg:flex"
-                  )}>
-                  <UserDropdown small />
-                </div>
+                {/* Collapsed desktop */}
+                {isCollapsed && (
+                  <div className="hidden justify-center lg:flex">
+                    <UserDropdown iconOnly />
+                  </div>
+                )}
               </div>
             )}
             <div className={classNames(
@@ -166,45 +174,51 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
             !isCollapsed && "lg:p-0"
           )}>
           {bottomNavItems.map((item, index) => (
-            <Tooltip side="right" content={t(item.name)} className={classNames(!isCollapsed && "lg:hidden")}
-            key={item.name}>
-              <ButtonOrLink
-                id={item.name}
-                href={item.href || undefined}
-                aria-label={t(item.name)}
-                target={item.target}
-                className={classNames(
-                  "text-left",
-                  "justify-right group flex items-center rounded-md px-2 py-1.5 font-medium text-default text-sm transition [&[aria-current='page']]:bg-emphasis",
-                  "mt-0.5 w-full text-sm [&[aria-current='page']]:text-emphasis",
-                  isLocaleReady ? "hover:bg-subtle hover:text-emphasis" : "",
-                  index === 0 && "mt-3"
-                )}
-                onClick={item.onClick}>
-                {!!item.icon && (
-                  <Icon
-                    name={item.isLoading ? "rotate-cw" : item.icon}
-                    className={classNames(
-                    "h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit",
-                    "md:mx-auto",
-                    !isCollapsed && "lg:mx-0 lg:ltr:mr-2 lg:rtl:ml-2",
-                    item.isLoading && "animate-spin"
+            <Tooltip
+              side="right"
+              content={t(item.name)}
+              className={classNames(!isCollapsed && "lg:hidden")}
+              key={item.name}>
+              <span className="flex w-full">
+                <ButtonOrLink
+                  id={item.name}
+                  href={item.href || undefined}
+                  aria-label={t(item.name)}
+                  target={item.target}
+                  className={classNames(
+                    "text-left",
+                    "justify-right group flex items-center rounded-md px-2 py-1.5 font-medium text-default text-sm transition [&[aria-current='page']]:bg-emphasis",
+                    "mt-0.5 w-full text-sm [&[aria-current='page']]:text-emphasis",
+                    isLocaleReady ? "hover:bg-subtle hover:text-emphasis" : "",
+                    index === 0 && "mt-3"
                   )}
-                    aria-hidden="true"
-                  />
-                )}
-                {isLocaleReady ? (
-                  <span
-                    className={classNames(
-                      "hidden w-full justify-between",
-                      !isCollapsed && "lg:flex"
-                    )}>
-                    <div className="flex">{t(item.name)}</div>
-                  </span>
-                ) : (
-                  <SkeletonText className="h-[20px] w-full" />
-                )}
-              </ButtonOrLink>
+                  onClick={item.onClick}>
+                  {!!item.icon && (
+                    <Icon
+                      name={item.isLoading ? "rotate-cw" : item.icon}
+                      className={classNames(
+                        "h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit",
+                        "md:mx-auto",
+                        !isCollapsed && "lg:mx-0 lg:ltr:mr-2 lg:rtl:ml-2",
+                        item.isLoading && "animate-spin"
+                      )}
+                      aria-hidden="true"
+                    />
+                  )}
+
+                  {isLocaleReady ? (
+                    <span
+                      className={classNames(
+                        "hidden w-full justify-between",
+                        !isCollapsed && "lg:flex"
+                      )}>
+                      <div className="flex">{t(item.name)}</div>
+                    </span>
+                  ) : (
+                    <SkeletonText className="h-[20px] w-full" />
+                  )}
+                </ButtonOrLink>
+              </span>
             </Tooltip>
           ))}
           {!IS_VISUAL_REGRESSION_TESTING && !isCollapsed && <Credits />}

--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -62,9 +62,10 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
   return (
     <div className="relative">
       <aside
+        id="app-sidebar"
         style={sidebarStylingAttributes}
         className={classNames(
-          "fixed left-0 hidden h-full w-14 flex-col overflow-y-auto overflow-x-hidden border-muted border-r bg-cal-muted md:sticky md:flex",
+          "fixed left-0 hidden h-full w-14 flex-col overflow-y-auto overflow-x-hidden border-muted border-r bg-cal-muted transition-[width] duration-200 md:sticky md:flex",
           "max-h-screen",
           isCollapsed ? "lg:w-14 lg:px-0" : "lg:w-56 lg:px-3"
         )}>
@@ -216,6 +217,7 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
               onClick={() => setIsCollapsed((collapsed) => !collapsed)}
               aria-label={isCollapsed ? t("expand_sidebar") : t("collapse_sidebar")}
               aria-expanded={!isCollapsed}
+              aria-controls="app-sidebar"
               className={classNames(
               "hidden w-full items-center rounded-md px-2 py-1.5 font-medium text-default text-sm transition hover:bg-subtle hover:text-emphasis focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 lg:flex",
               isCollapsed ? "justify-center" : "justify-start gap-2"

--- a/apps/web/modules/shell/SideBar.tsx
+++ b/apps/web/modules/shell/SideBar.tsx
@@ -11,6 +11,7 @@ import { Logo } from "@calcom/ui/components/logo";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
 import { ArrowLeftIcon, ArrowRightIcon } from "@coss/ui/icons";
+import { useState } from "react";
 import Link from "next/link";
 import type { User as UserAuth } from "next-auth";
 import { useSession } from "next-auth/react";
@@ -44,6 +45,8 @@ export function SideBarContainer({ bannersHeight }: SideBarContainerProps) {
 export function SideBar({ bannersHeight, user }: SideBarProps) {
   const { t, isLocaleReady } = useLocale();
 
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
   const publicPageUrl = `${WEBAPP_URL}/${user?.orgAwareUsername}`;
 
   const bottomNavItems = useBottomNavItems({
@@ -60,11 +63,37 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
       <aside
         style={sidebarStylingAttributes}
         className={classNames(
-          "fixed left-0 hidden h-full w-14 flex-col overflow-y-auto overflow-x-hidden border-muted border-r bg-cal-muted md:sticky md:flex lg:w-56 lg:px-3",
-          "max-h-screen"
+          "fixed left-0 hidden h-full w-14 flex-col overflow-y-auto overflow-x-hidden border-muted border-r bg-cal-muted md:sticky md:flex",
+          "max-h-screen",
+          isCollapsed ? "lg:w-14 lg:px-0" : "lg:w-56 lg:px-3"
         )}>
+          <Tooltip
+                side="right"
+                content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                className={classNames(!isCollapsed && "lg:hidden")}>
+                <button
+                  type="button"
+                  onClick={() => setIsCollapsed((collapsed) => !collapsed)}
+                  aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                  className="hidden h-8 w-full items-center justify-center rounded-md text-subtle transition hover:bg-subtle hover:text-emphasis lg:flex">
+                  <Icon
+                    name={isCollapsed ? "chevrons-right" : "chevrons-left"}
+                    className="h-4 w-4"
+                  />
+                </button>
+              </Tooltip>
         <div className="flex h-full flex-col justify-between py-3 lg:pt-4">
-          <header className="todesktop:-mt-3 todesktop:flex-col-reverse items-center justify-between todesktop:[-webkit-app-region:drag] md:hidden lg:flex">
+          {/* logo icon for tablet and collapsed desktop */}
+          <Link href="/event-types"   className={classNames(
+            "text-center md:inline lg:hidden",
+            isCollapsed && "lg:inline"
+          )}>
+            <Logo small icon />
+          </Link>
+          <header className={classNames(
+            "todesktop:-mt-3 todesktop:flex-col-reverse items-center justify-between todesktop:[-webkit-app-region:drag] md:hidden lg:flex",
+            isCollapsed && "lg:flex-col lg:gap-3"
+          )}>
             {user?.org ? (
               !ENABLE_PROFILE_SWITCHER ? (
                 <Link href="/settings/organizations/profile" className="w-full px-1.5">
@@ -83,16 +112,29 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                 <ProfileDropdown />
               )
             ) : (
-              <div data-testid="user-dropdown-trigger" className="todesktop:mt-4 w-full">
-                <span className="hidden lg:inline">
+              <div
+                data-testid="user-dropdown-trigger"
+                className={classNames(
+                  "todesktop:mt-4 w-full",
+                  isCollapsed && "lg:flex lg:justify-center"
+                )}>
+                <div className={classNames("hidden lg:block", isCollapsed && "lg:hidden")}>
                   <UserDropdown />
-                </span>
-                <span className="hidden md:inline lg:hidden">
+                </div>
+
+                <div
+                  className={classNames(
+                    "hidden md:flex md:justify-center lg:hidden",
+                    isCollapsed && "lg:flex"
+                  )}>
                   <UserDropdown small />
-                </span>
+                </div>
               </div>
             )}
-            <div className="flex w-full justify-end rtl:space-x-reverse">
+            <div className={classNames(
+              "flex w-full justify-end rtl:space-x-reverse",
+              isCollapsed && "lg:justify-center"
+            )}>
               <button
                 color="minimal"
                 onClick={() => window.history.back()}
@@ -111,18 +153,21 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                 </div>
               )}
               <KBarTrigger />
+              
             </div>
           </header>
-          {/* logo icon for tablet */}
-          <Link href="/event-types" className="text-center md:inline lg:hidden">
-            <Logo small icon />
-          </Link>
-          <Navigation />
+          
+          <Navigation isCollapsed={isCollapsed} />
         </div>
 
-        <div className="md:px-2 md:pb-4 lg:p-0">
+        <div
+          className={classNames(
+            "md:px-2 md:pb-4",
+            !isCollapsed && "lg:p-0"
+          )}>
           {bottomNavItems.map((item, index) => (
-            <Tooltip side="right" content={t(item.name)} className="lg:hidden" key={item.name}>
+            <Tooltip side="right" content={t(item.name)} className={classNames(!isCollapsed && "lg:hidden")}
+            key={item.name}>
               <ButtonOrLink
                 id={item.name}
                 href={item.href || undefined}
@@ -140,15 +185,20 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
                   <Icon
                     name={item.isLoading ? "rotate-cw" : item.icon}
                     className={classNames(
-                      "h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit",
-                      "ml-3 md:mx-auto lg:ltr:mr-2 lg:rtl:ml-2",
-                      item.isLoading && "animate-spin"
-                    )}
+                    "h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit",
+                    "md:mx-auto",
+                    !isCollapsed && "lg:mx-0 lg:ltr:mr-2 lg:rtl:ml-2",
+                    item.isLoading && "animate-spin"
+                  )}
                     aria-hidden="true"
                   />
                 )}
                 {isLocaleReady ? (
-                  <span className="hidden w-full justify-between lg:flex">
+                  <span
+                    className={classNames(
+                      "hidden w-full justify-between",
+                      !isCollapsed && "lg:flex"
+                    )}>
                     <div className="flex">{t(item.name)}</div>
                   </span>
                 ) : (
@@ -157,7 +207,7 @@ export function SideBar({ bannersHeight, user }: SideBarProps) {
               </ButtonOrLink>
             </Tooltip>
           ))}
-          {!IS_VISUAL_REGRESSION_TESTING && <Credits />}
+          {!IS_VISUAL_REGRESSION_TESTING && !isCollapsed && <Credits />}
         </div>
       </aside>
     </div>

--- a/apps/web/modules/shell/navigation/Navigation.tsx
+++ b/apps/web/modules/shell/navigation/Navigation.tsx
@@ -83,13 +83,17 @@ const useNavigationItems = () => {
   }, []);
 };
 
-export const Navigation = () => {
+type NavigationProps = {
+  isCollapsed: boolean;
+};
+
+export const Navigation = ({ isCollapsed }: NavigationProps) => {
   const { desktopNavigationItems } = useNavigationItems();
 
   return (
     <nav className="mt-2 flex-1 md:px-2 lg:mt-4 lg:px-0">
       {desktopNavigationItems.map((item) => (
-        <NavigationItem key={item.name} item={item} />
+        <NavigationItem key={item.name} item={item} isCollapsed={isCollapsed}/>
       ))}
       <div className="mt-0.5 text-subtle lg:hidden">
         <KBarTrigger />

--- a/apps/web/modules/shell/navigation/Navigation.tsx
+++ b/apps/web/modules/shell/navigation/Navigation.tsx
@@ -93,7 +93,11 @@ export const Navigation = ({ isCollapsed }: NavigationProps) => {
   return (
     <nav className="mt-2 flex-1 md:px-2 lg:mt-4 lg:px-0">
       {desktopNavigationItems.map((item) => (
-        <NavigationItem key={item.name} item={item} isCollapsed={isCollapsed}/>
+        <NavigationItem
+          key={item.name}
+          item={item}
+          isCollapsed={isCollapsed}
+        />
       ))}
       <div className="mt-0.5 text-subtle lg:hidden">
         <KBarTrigger />

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -2,7 +2,6 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useMediaQuery from "@calcom/lib/hooks/useMediaQuery";
 import { sessionStorage } from "@calcom/lib/webstorage";
 import classNames from "@calcom/ui/classNames";
-import { Badge } from "@calcom/ui/components/badge";
 import type { IconName } from "@calcom/ui/components/icon";
 import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
@@ -186,18 +185,12 @@ export const NavigationItem: React.FC<{
                 </span>
 
                 {item.child?.map((childItem) => {
-                  const childIsCurrent =
-                    typeof childItem.isCurrent === "function"
-                      ? childItem.isCurrent({
-                          isChild: true,
-                          item: childItem,
-                          pathname,
-                        })
-                      : defaultIsCurrent({
-                          isChild: true,
-                          item: childItem,
-                          pathname,
-                        });
+                  const resolveIsCurrent = childItem.isCurrent ?? defaultIsCurrent;
+                    const childIsCurrent = resolveIsCurrent({
+                      isChild: true,
+                      item: childItem,
+                      pathname,
+                    });
 
                   return (
                     <Link

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -7,6 +7,7 @@ import type { IconName } from "@calcom/ui/components/icon";
 import { Icon } from "@calcom/ui/components/icon";
 import { SkeletonText } from "@calcom/ui/components/skeleton";
 import { Tooltip } from "@calcom/ui/components/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "@calcom/ui/components/popover";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
@@ -71,8 +72,9 @@ export const NavigationItem: React.FC<{
   index?: number;
   item: NavigationItemType;
   isChild?: boolean;
+  isCollapsed?: boolean;
 }> = (props) => {
-  const { item, isChild } = props;
+  const { item, isChild, isCollapsed = false  } = props;
   const { t, isLocaleReady } = useLocale();
   const pathname = usePathname();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;
@@ -81,128 +83,140 @@ export const NavigationItem: React.FC<{
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
 
   const isTablet = useMediaQuery("(max-width: 1024px)");
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   if (!shouldDisplayNavigationItem) return null;
 
   const hasChildren = item.child && item.child.length > 0;
   const hasActiveChild =
     hasChildren && item.child?.some((child) => isCurrent({ isChild: true, item: child, pathname }));
-  const shouldShowChildren = isExpanded || hasActiveChild || isCurrent({ pathname, isChild, item });
+  const shouldShowChildren =
+  !isCollapsed && (isExpanded || hasActiveChild || isCurrent({ pathname, isChild, item })); 
   const shouldShowChevron = hasChildren && !hasActiveChild;
   const isParentNavigationItem = hasChildren && !isChild;
 
   return (
     <Fragment>
       {isParentNavigationItem ? (
-        <Tooltip
-          side="right"
-          open={isTooltipOpen}
-          content={
-            hasChildren ? (
-              <div className="stack-y-1 pointer-events-auto flex flex-col p-1">
-                <span className="text-subtle px-2 text-xs font-semibold uppercase tracking-wide">
-                  {t(item.name)}
-                </span>
-                <div className="flex flex-col gap-1">
-                  {item.child?.map((childItem) => {
-                    const childIsCurrent =
-                      typeof childItem.isCurrent === "function"
-                        ? childItem.isCurrent({
-                            isChild: true,
-                            item: childItem,
-                            pathname,
-                          })
-                        : defaultIsCurrent({
-                            isChild: true,
-                            item: childItem,
-                            pathname,
-                          });
-                    return (
-                      <Link
-                        key={childItem.name}
-                        href={childItem.href}
-                        aria-current={childIsCurrent ? "page" : undefined}
-                        onClick={() => {
-                          setIsTooltipOpen(false);
-                          trackNavigationClick(childItem.name, item.name);
-                        }}
-                        className={classNames(
-                          "group relative block rounded-md px-3 py-1 text-sm font-medium",
-                          childIsCurrent
-                            ? "bg-emphasis text-white"
-                            : "hover:bg-emphasis text-mute hover:text-emphasis"
-                        )}>
-                        {t(childItem.name)}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              t(item.name)
-            )
-          }
-          className="lg:hidden">
-          <button
-            data-test-id={item.name}
-            aria-label={t(item.name)}
-            aria-expanded={isExpanded}
-            aria-current={current ? "page" : undefined}
-            onClick={() => {
-              if (isTablet && hasChildren) {
-                setIsTooltipOpen(!isTooltipOpen);
-              } else {
-                setIsExpanded(!isExpanded);
-              }
-            }}
-            className={classNames(
-              "todesktop:py-[7px] text-default group relative flex w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
-              "aria-[aria-current='page']:bg-transparent!",
-              "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
-              "md:justify-center lg:justify-start",
-              isLocaleReady
-                ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
-                : ""
-            )}>
-            {item.icon && (
-              <div className="relative">
-                <Icon
-                  name={item.isLoading ? "rotate-cw" : item.icon}
-                  className={classNames(
-                    "todesktop:!text-blue-500 h-4 w-4 shrink-0 lg:ltr:mr-2 lg:rtl:ml-2",
-                    item.isLoading && "animate-spin"
-                  )}
-                  aria-hidden="true"
-                />
-                {shouldShowChevron && (
+        <Popover>
+          <Tooltip
+            side="right"
+            content={t(item.name)}
+            className={classNames(!isCollapsed && "lg:hidden")}>
+            <PopoverTrigger asChild>
+              <button
+                data-test-id={item.name}
+                aria-label={t(item.name)}
+                aria-expanded={isExpanded}
+                aria-current={current ? "page" : undefined}
+                onClick={() => {
+                  if (!isTablet && !isCollapsed) {
+                    setIsExpanded(!isExpanded);
+                  }
+                }}
+                className={classNames(
+                  "todesktop:py-[7px] text-default group relative flex w-full items-center rounded-md px-2 py-1.5 text-sm font-medium transition",
+                  "aria-[aria-current='page']:bg-transparent!",
+                  "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm",
+                  "md:justify-center",
+                  isCollapsed
+                    ? "lg:mx-auto lg:h-10 lg:w-10 lg:justify-center lg:px-0"
+                    : "lg:justify-start",
+                  isLocaleReady
+                    ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
+                    : ""
+                )}>
+                {item.icon && (
+                  <div className="relative">
+                    <Icon
+                      name={item.isLoading ? "rotate-cw" : item.icon}
+                      className={classNames(
+                        "todesktop:!text-blue-500 h-4 w-4 shrink-0",
+                        !isCollapsed && "lg:ltr:mr-2 lg:rtl:ml-2",
+                        item.isLoading && "animate-spin"
+                      )}
+                      aria-hidden="true"
+                    />
+
+                    {shouldShowChevron && (
+                      <Icon
+                        name={isExpanded ? "chevron-up" : "chevron-down"}
+                        className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-subtle p-0.5 lg:hidden"
+                      />
+                    )}
+                  </div>
+                )}
+
+                {isLocaleReady ? (
+                  <span
+                    className={classNames(
+                      "hidden w-full justify-between truncate text-ellipsis",
+                      !isCollapsed && "lg:flex"
+                    )}
+                    data-testid={`${item.name}-test`}>
+                    {t(item.name)}
+                    {item.badge && item.badge}
+                  </span>
+                ) : (
+                  <SkeletonText className="h-[20px] w-full" />
+                )}
+
+                {shouldShowChevron && !isCollapsed && (
                   <Icon
                     name={isExpanded ? "chevron-up" : "chevron-down"}
-                    className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-subtle p-0.5 lg:hidden"
+                    className="ml-auto hidden h-4 w-4 lg:block"
                   />
                 )}
+              </button>
+            </PopoverTrigger>
+          </Tooltip>
+
+          {(isTablet || isCollapsed) && (
+            <PopoverContent
+              side="right"
+              align="center"
+              sideOffset={8}
+              className="w-auto min-w-36 p-2">
+              <div className="flex flex-col">
+                <span className="text-subtle px-2 pb-1 text-xs font-semibold">
+                  {t(item.name)}
+                </span>
+
+                {item.child?.map((childItem) => {
+                  const childIsCurrent =
+                    typeof childItem.isCurrent === "function"
+                      ? childItem.isCurrent({
+                          isChild: true,
+                          item: childItem,
+                          pathname,
+                        })
+                      : defaultIsCurrent({
+                          isChild: true,
+                          item: childItem,
+                          pathname,
+                        });
+
+                  return (
+                    <Link
+                      key={childItem.name}
+                      href={childItem.href}
+                      aria-current={childIsCurrent ? "page" : undefined}
+                      onClick={() => trackNavigationClick(childItem.name, item.name)}
+                      className={classNames(
+                        "relative rounded-md px-2 py-1.5 text-sm font-medium",
+                        childIsCurrent
+                          ? "bg-emphasis text-emphasis"
+                          : "text-emphasis hover:bg-subtle"
+                      )}>
+                      {t(childItem.name)}
+                    </Link>
+                  );
+                })}
               </div>
-            )}
-            {isLocaleReady ? (
-              <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
-                data-testid={`${item.name}-test`}>
-                {t(item.name)}
-                {item.badge && item.badge}
-              </span>
-            ) : (
-              <SkeletonText className="h-[20px] w-full" />
-            )}
-            {shouldShowChevron && (
-              <Icon
-                name={isExpanded ? "chevron-up" : "chevron-down"}
-                className="ml-auto hidden h-4 w-4 lg:block"
-              />
-            )}
-          </button>
-        </Tooltip>
+            </PopoverContent>
+          )}
+        </Popover>
       ) : (
-        <Tooltip side="right" content={t(item.name)} className="lg:hidden">
+        <Tooltip side="right" content={t(item.name)} className={classNames(!isCollapsed && "lg:hidden")}>
           <Link
             data-test-id={item.name}
             onClick={() => trackNavigationClick(item.name)}
@@ -218,7 +232,12 @@ export const NavigationItem: React.FC<{
                 ? `[&[aria-current='page']]:text-emphasis [&[aria-current='page']]:bg-emphasis hidden h-8 pl-16 lg:flex lg:pl-11 ${
                     props.index === 0 ? "mt-0" : "mt-1  hover:mt-1 [&[aria-current='page']]:mt-1"
                   }`
-                : "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center lg:justify-start",
+                : classNames(
+                  "[&[aria-current='page']]:text-emphasis mt-0.5 text-sm md:justify-center",
+                  isCollapsed
+                    ? "lg:mx-auto lg:h-10 lg:w-10 lg:justify-center lg:px-0"
+                    : "lg:justify-start"
+                ),
               isLocaleReady
                 ? "hover:bg-subtle todesktop:[&[aria-current='page']]:bg-emphasis todesktop:hover:bg-transparent hover:text-emphasis"
                 : ""
@@ -228,7 +247,8 @@ export const NavigationItem: React.FC<{
               <Icon
                 name={item.isLoading ? "rotate-cw" : item.icon}
                 className={classNames(
-                  "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit lg:ltr:mr-2 lg:rtl:ml-2",
+                  "todesktop:!text-blue-500 h-4 w-4 shrink-0 aria-[aria-current='page']:text-inherit",
+                  !isCollapsed && "lg:ltr:mr-2 lg:rtl:ml-2",
                   item.isLoading && "animate-spin"
                 )}
                 aria-hidden="true"
@@ -237,7 +257,8 @@ export const NavigationItem: React.FC<{
             )}
             {isLocaleReady ? (
               <span
-                className="hidden w-full justify-between truncate text-ellipsis lg:flex"
+                className={classNames("hidden w-full justify-between truncate text-ellipsis",     !isCollapsed && "lg:flex"
+                  )}
                 data-testid={`${item.name}-test`}>
                 {t(item.name)}
                 {item.badge && item.badge}

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -74,7 +74,7 @@ export const NavigationItem: React.FC<{
   isChild?: boolean;
   isCollapsed?: boolean;
 }> = (props) => {
-  const { item, isChild, isCollapsed = false  } = props;
+  const { item, isChild, isCollapsed = false } = props;
   const { t, isLocaleReady } = useLocale();
   const pathname = usePathname();
   const isCurrent: NavigationItemType["isCurrent"] = item.isCurrent || defaultIsCurrent;

--- a/apps/web/modules/shell/navigation/NavigationItem.tsx
+++ b/apps/web/modules/shell/navigation/NavigationItem.tsx
@@ -81,6 +81,7 @@ export const NavigationItem: React.FC<{
   const current = isCurrent({ isChild: !!isChild, item, pathname });
   const shouldDisplayNavigationItem = useShouldDisplayNavigationItem(props.item);
   const [isExpanded, setIsExpanded] = usePersistedExpansionState(item.name);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const isTablet = useMediaQuery("(max-width: 1024px)");
 
@@ -93,11 +94,14 @@ export const NavigationItem: React.FC<{
   !isCollapsed && (isExpanded || hasActiveChild || isCurrent({ pathname, isChild, item })); 
   const shouldShowChevron = hasChildren && !hasActiveChild;
   const isParentNavigationItem = hasChildren && !isChild;
+  const shouldUsePopover = isTablet || isCollapsed;
 
   return (
     <Fragment>
       {isParentNavigationItem ? (
-        <Popover>
+        <Popover
+          open={shouldUsePopover && isPopoverOpen}
+          onOpenChange={setIsPopoverOpen}>
           <Tooltip
             side="right"
             content={t(item.name)}
@@ -106,10 +110,10 @@ export const NavigationItem: React.FC<{
               <button
                 data-test-id={item.name}
                 aria-label={t(item.name)}
-                aria-expanded={isExpanded}
+                aria-expanded={shouldUsePopover ? isPopoverOpen : isExpanded}
                 aria-current={current ? "page" : undefined}
                 onClick={() => {
-                  if (!isTablet && !isCollapsed) {
+                  if (!shouldUsePopover) {
                     setIsExpanded(!isExpanded);
                   }
                 }}
@@ -170,7 +174,7 @@ export const NavigationItem: React.FC<{
             </PopoverTrigger>
           </Tooltip>
 
-          {(isTablet || isCollapsed) && (
+          {shouldUsePopover && (
             <PopoverContent
               side="right"
               align="center"

--- a/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
+++ b/apps/web/modules/shell/user-dropdown/UserDropdown.tsx
@@ -46,9 +46,10 @@ type BeaconFunction = {
 
 interface UserDropdownProps {
   small?: boolean;
+  iconOnly?: boolean;
 }
 
-export function UserDropdown({ small }: UserDropdownProps) {
+export function UserDropdown({ small, iconOnly }: UserDropdownProps) {
   const { t } = useLocale();
   const { data: user, isPending } = useMeQuery();
 
@@ -114,18 +115,25 @@ export function UserDropdown({ small }: UserDropdownProps) {
           <button
             data-testid="user-dropdown-trigger-button"
             className={classNames(
-              "hover:bg-emphasis todesktop:!bg-transparent group mx-0 flex w-full cursor-pointer appearance-none items-center rounded-full text-left outline-none transition focus:outline-none focus:ring-0 md:rounded-none lg:rounded",
-              small ? "p-2" : "px-2 py-1.5"
+              "todesktop:!bg-transparent group flex cursor-pointer appearance-none items-center text-left outline-none transition focus:outline-none focus:ring-0",
+              iconOnly
+                ? "mx-auto size-9 justify-center rounded-full p-0 hover:bg-transparent"
+                : "hover:bg-emphasis mx-0 w-full rounded-full md:rounded-none lg:rounded",
+              !iconOnly && (small ? "p-2" : "px-2 py-1.5")
             )}
           />
         }>
         <span
           className={classNames(
-            small ? "h-4 w-4" : "h-5 w-5 ltr:mr-2 rtl:ml-2",
+            iconOnly
+              ? "h-6 w-6"
+              : small
+                ? "h-4 w-4"
+                : "h-5 w-5 ltr:mr-2 rtl:ml-2",
             "relative shrink-0 rounded-full"
           )}>
           <Avatar
-            size={small ? "xs" : "xsm"}
+            size={iconOnly ? "sm" : small ? "xs" : "xsm"}
             imageSrc={user?.avatarUrl ?? user?.avatar}
             alt={user?.username ? `${user.username} Avatar` : "Nameless User Avatar"}
             className="overflow-hidden"
@@ -137,7 +145,7 @@ export function UserDropdown({ small }: UserDropdownProps) {
             )}
           />
         </span>
-        {!small && (
+        {!small && !iconOnly && (
           <span className="flex grow items-center gap-2">
             <span className="w-24 shrink-0 text-sm leading-none">
               <span className="text-emphasis block truncate py-0.5 font-medium leading-normal">

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -301,6 +301,8 @@
   "view_notifications": "View notifications",
   "view_public_page": "View public page",
   "copy_public_page_link": "Copy public page link",
+  "collapse_sidebar": "Collapse sidebar",
+  "expand_sidebar": "Expand sidebar",
   "copy_referral_link": "Copy referral link",
   "sign_out": "Sign out",
   "add_another": "Add another",


### PR DESCRIPTION
## What does this PR do?

This PR adds support for collapsing the desktop sidebar while preserving the existing tablet and mobile navigation experience.

The collapse/expand toggle is placed in the bottom section of the sidebar alongside other secondary actions to keep the primary navigation area uncluttered.

In addition to the collapsible sidebar, this PR:
- Updates navigation items to support both expanded and collapsed layouts.
- Adds an icon-only user dropdown for the collapsed desktop sidebar.
- Preserves the existing tablet and mobile navigation layouts.
- Adds localized labels for the sidebar toggle.
- Improves accessibility with localized `aria-label` and `aria-expanded` attributes.
- Ensures the bottom navigation items display hover tooltips in the tablet sidebar.

- Fixes #29805

---

## Visual Demo (For contributors especially)

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

[Cal.diy:added_collapsible_sidebar.webm](https://github.com/user-attachments/assets/948c89bd-7354-4845-afc0-4a8607a27198)


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Start the application and sign in.
2. Verify the desktop sidebar is expanded by default.
3. Click the collapse toggle in the bottom section of the sidebar.
4. Verify:
   - The sidebar collapses correctly.
   - Navigation items switch to their icon-only layout.
   - Tooltips appear on hover in the collapsed state.
   - The user profile is displayed as an icon-only avatar.
5. Expand the sidebar again and verify the original layout is restored.
6. Resize the window to tablet width and verify:
   - Existing tablet navigation behavior is preserved.
   - Bottom navigation items display hover tooltips.
7. Verify keyboard navigation by tabbing to the sidebar toggle and activating it with Enter or Space.

Expected result:
- Desktop sidebar can be expanded and collapsed without affecting tablet or mobile navigation.
- Navigation, tooltips, localization, and accessibility behave correctly in both states.

---

## Checklist

- I have read the [contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my changes generate no new warnings
- My PR is under the recommended size limits (<500 changed lines and <10 modified files).
