### PR TITLE
fix: honor maxLength in truncateOnWord

### DIFF
--- a/packages/lib/text.test.ts
+++ b/packages/lib/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { truncate } from "./text";
+import { truncate, truncateOnWord } from "./text";
 
 describe("Text util tests", () => {
   describe("fn: truncate", () => {
@@ -67,6 +67,21 @@ describe("Text util tests", () => {
 
         expect(result).toEqual(expected);
       }
+    });
+  });
+
+  describe("fn: truncateOnWord", () => {
+    it("should return the original text when it is shorter than the max length", () => {
+      expect(truncateOnWord("Hello world", 100)).toEqual("Hello world");
+    });
+
+    it("should truncate on a word boundary at the given max length", () => {
+      // Regression: previously ignored maxLength and always cut at 148 chars
+      expect(truncateOnWord("Hello world foo bar baz qux", 12)).toEqual("Hello world...");
+    });
+
+    it("should omit the ellipsis when ellipsis is false", () => {
+      expect(truncateOnWord("Hello world foo bar baz qux", 12, false)).toEqual("Hello world");
     });
   });
 });

--- a/packages/lib/text.ts
+++ b/packages/lib/text.ts
@@ -8,7 +8,7 @@ export const truncateOnWord = (text: string, maxLength: number, ellipsis = true)
   if (text.length <= maxLength) return text;
 
   // First split on maxLength chars
-  let truncatedText = text.substring(0, 148);
+  let truncatedText = text.substring(0, maxLength);
 
   // Then split on the last space, this way we split on the last word,
   // which looks just a bit nicer.


### PR DESCRIPTION
## What / Why

`truncateOnWord` in `packages/lib/text.ts` uses a hardcoded `text.substring(0, 148)` for the initial cut instead of the `maxLength` argument. As a result it ignores `maxLength` entirely (it is only used for the early `text.length <= maxLength` check) and always truncates near 148 characters. The inline comment already says "First split on maxLength chars", so this looks unintentional.

```ts
truncateOnWord("Hello world foo bar baz qux", 12)
// before: "Hello world foo bar baz..."  (maxLength ignored)
// after:  "Hello world..."
```

## Fix

Use `maxLength` for the initial cut so the function truncates to the requested length. The sibling `truncate` already respects `maxLength`.

## Tests

Added `truncateOnWord` cases to `packages/lib/text.test.ts` (short input unchanged, word-boundary truncation at maxLength, and the `ellipsis: false` variant).
