### PR TITLE
fix(api-v2): make DestinationCalendarsOutputDto.userId nullable

### DIFF
--- a/apps/api/v2/src/modules/destination-calendars/outputs/destination-calendars.output.ts
+++ b/apps/api/v2/src/modules/destination-calendars/outputs/destination-calendars.output.ts
@@ -1,13 +1,15 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Expose, Type } from "class-transformer";
-import { IsInt, IsString, ValidateNested, IsEnum } from "class-validator";
+import { IsInt, IsOptional, IsString, ValidateNested, IsEnum } from "class-validator";
 
 import { ERROR_STATUS, SUCCESS_STATUS } from "@calcom/platform-constants";
 
 export class DestinationCalendarsOutputDto {
+  @IsOptional()
   @IsInt()
+  @ApiPropertyOptional({ type: Number, nullable: true })
   @Expose()
-  readonly userId!: number;
+  readonly userId!: number | null;
 
   @IsString()
   @Expose()


### PR DESCRIPTION
## What does this PR do?

The `DestinationCalendar` model in Prisma defines `userId` as `Int?` (nullable/optional). A destination calendar can belong to an event type rather than a user directly, in which case `userId` is `null`.

The `DestinationCalendarsOutputDto` was incorrectly declaring `userId` as a required non-nullable `number`, creating a type mismatch with the actual data returned from the database.

## Changes

- Added `@IsOptional()` decorator
- Changed `@ApiProperty` to `@ApiPropertyOptional` with `nullable: true`
- Updated type from `number` to `number | null`

## How to test?

1. Create a destination calendar on an event type (not tied to a user)
2. Call `GET /api/v2/destination-calendars`
3. Verify the response includes `userId: null` without type errors

Fixes #29531