### PR TITLE
fix(og-images): pass numeric dimensions to Satori in OG_ASSETS to fix…

### DIFF
--- a/packages/lib/OgImages.tsx
+++ b/packages/lib/OgImages.tsx
@@ -51,23 +51,23 @@ const makeAbsoluteUrl = (url: string) => (/^https?:\/\//.test(url) ? url : `${CA
 
 const OG_ASSETS = {
   meeting: {
-    id: "meeting-og-image-v1", // Bump version when changing Meeting component structure/styling
+    id: "meeting-og-image-v2", // Bump version when changing Meeting component structure/styling
     logo: LOGO,
-    logoWidth: "350",
-    avatarSize: "160",
+    logoWidth: 350,
+    avatarSize: 160,
     variant: "dark" as const,
   },
   app: {
-    id: "app-og-image-v1", // Bump version when changing App component structure/styling
+    id: "app-og-image-v2", // Bump version when changing App component structure/styling
     logo: LOGO,
-    logoWidth: "150",
-    iconSize: "172",
+    logoWidth: 150,
+    iconSize: 172,
     variant: "light" as const,
   },
   generic: {
-    id: "generic-og-image-v1", // Bump version when changing Generic component structure/styling
+    id: "generic-og-image-v2", // Bump version when changing Generic component structure/styling
     logo: LOGO_DARK,
-    logoWidth: "350",
+    logoWidth: 350,
     variant: "light" as const,
   },
 };
@@ -166,8 +166,8 @@ const Wrapper = ({ children, variant = "light", rotateBackground }: WrapperProps
       style={rotateBackground ? { transform: "rotate(180deg)" } : undefined}
       src={`${WEBAPP_URL}/social-bg-${variant}-lines.jpg`}
       alt="background"
-      width="1200"
-      height="600"
+      width={1200}
+      height={600}
     />
     <div tw="flex flex-col w-full h-full px-[80px] py-[70px] items-start justify-center">{children}</div>
   </div>


### PR DESCRIPTION
Fixes #29895

## Description

Every generated OG social share image (`meeting`, `app`, `generic`) was failing to render its logo and meeting avatars because `OG_ASSETS` in `packages/lib/OgImages.tsx` declared image dimensions as strings (e.g., `"350"`, `"160"`, `"150"`, `"172"`). 

When passed to Satori's JSX renderer, Satori rejects string values for `width`/`height` attributes with the error:
`Invalid value "350" for "width". Expected a number, "auto", or a percentage value (e.g. "50%").`

As a result, Satori ignored logo/avatar `<img>` elements entirely, rendering OG images without logos or profile avatars.

## Changes Made

1. **`packages/lib/OgImages.tsx`**:
   - Converted `logoWidth`, `avatarSize`, and `iconSize` in `OG_ASSETS` from string literals (`"350"`) to numbers (`350`).
   - Updated `<img width={1200} height={600} />` in `Wrapper` to pass numeric dimensions.
   - Bumped `OG_ASSETS` version identifiers (`meeting-og-image-v2`, `app-og-image-v2`, `generic-og-image-v2`) to invalidate cached OG image versions as requested by component guidelines.

## How to Test

1. Generate an OG image URL (e.g. `/api/social/og/image?type=meeting&title=Test&meetingProfileName=Jane+Doe&names=Jane+Doe&usernames=jane`).
2. Verify that Satori logs no width/height string warnings and the generated PNG includes both the logo and profile avatar.
