### PR TITLE
fix(timezone): strip leading zero from single-digit hours for all min…

### DIFF
--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOffset, filterBySearchText, addTimezonesToDropdown } from "./timezone";
+
+describe("timezone helper functions", () => {
+  describe("formatOffset", () => {
+    it("strips leading zero from single-digit whole-hour offsets", () => {
+      expect(formatOffset("+09:00")).toBe("+9:00");
+      expect(formatOffset("-04:00")).toBe("-4:00");
+    });
+
+    it("strips leading zero from single-digit fractional-hour offsets", () => {
+      expect(formatOffset("+05:30")).toBe("+5:30");
+      expect(formatOffset("-03:30")).toBe("-3:30");
+      expect(formatOffset("+05:45")).toBe("+5:45");
+      expect(formatOffset("+09:30")).toBe("+9:30");
+    });
+
+    it("preserves double-digit hour offsets unchanged", () => {
+      expect(formatOffset("+10:00")).toBe("+10:00");
+      expect(formatOffset("-11:00")).toBe("-11:00");
+      expect(formatOffset("+12:45")).toBe("+12:45");
+    });
+  });
+
+  describe("filterBySearchText", () => {
+    it("filters timezones by search text", () => {
+      const timezones = [
+        { label: "Asia/Kolkata", timezone: "Asia/Kolkata" },
+        { label: "America/New_York", timezone: "America/New_York" },
+      ];
+      expect(filterBySearchText("kolkata", timezones)).toHaveLength(1);
+      expect(filterBySearchText("kolkata", timezones)[0].label).toBe("Asia/Kolkata");
+    });
+  });
+
+  describe("addTimezonesToDropdown", () => {
+    it("converts timezone list into a dictionary", () => {
+      const timezones = [
+        { label: "Asia/Kolkata", timezone: "Asia/Kolkata" },
+      ];
+      const result = addTimezonesToDropdown(timezones);
+      expect(result).toEqual({ "Asia/Kolkata": "Asia/Kolkata" });
+    });
+  });
+});

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -24,8 +24,8 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
   );
 };
 
-const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+export const formatOffset = (offset: string) =>
+  offset.replace(/^([-+])0(\d:\d{2})$/, (_, sign, hourAndMinutes) => `${sign}${hourAndMinutes}`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
Fixes #29853

## Description

The `formatOffset` helper in `packages/lib/timezone.ts` was using a regex (`/^([-+])(0)(\d):00$/`) that matched only offsets ending in `:00`. As a result:

- Whole-hour single-digit offsets like `+09:00` had their leading zero stripped (`+9:00`).
- Fractional-hour single-digit offsets like `+05:30` (IST), `+09:30` (ACST), and `+05:45` (NPT) failed the regex match and retained the leading zero (`+05:30`).

This caused inconsistent timezone formatting in dropdowns where `+05:30` and `+9:00` appeared side-by-side.

## Changes Made

1. **`packages/lib/timezone.ts`**:
   - Updated `formatOffset` regex from `/^([-+])(0)(\d):00$/` to `/^([-+])0(\d:\d{2})$/`.
   - Now strips the leading zero for all single-digit hour offsets regardless of minute values (`+05:30` → `+5:30`, `+09:00` → `+9:00`, `-03:30` → `-3:30`).
   - Exported `formatOffset` for unit test coverage.
2. **`packages/lib/timezone.test.ts`**:
   - Added comprehensive unit tests for `formatOffset`, `filterBySearchText`, and `addTimezonesToDropdown`.

## How to Test

Run the new unit test suite:
```bash
pnpm test packages/lib/timezone.test.ts
