### PR TITLE
fix(ci): repair i18n workflow broken by secrets check in job-level if

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -8,9 +8,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-api-key:
+    name: Check for lingo.dev API key
+    runs-on: ubuntu-latest
+    outputs:
+      has-api-key: ${{ steps.check.outputs.has-api-key }}
+    steps:
+      - name: Check CI_LINGO_DOT_DEV_API_KEY
+        id: check
+        env:
+          CI_LINGO_DOT_DEV_API_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
+        run: |
+          if [ -n "$CI_LINGO_DOT_DEV_API_KEY" ]; then
+            echo "has-api-key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-api-key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   i18n:
     name: Run i18n
-    if: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY != '' }}
+    needs: check-api-key
+    if: needs.check-api-key.outputs.has-api-key == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   check-api-key:
     name: Check for lingo.dev API key
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       has-api-key: ${{ steps.check.outputs.has-api-key }}


### PR DESCRIPTION
## What does this PR do?

The `Run i18n AI automation` workflow has failed on every push to `main` since April 1 (187 of the last 190 runs). #28704 added:

```yaml
if: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY != '' }}
```

but the `secrets` context isn't available in job-level `if` conditions ([context availability](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability)), so GitHub rejects the whole file at validation time. Every run since then fails with zero jobs ([example](https://github.com/calcom/cal.diy/actions/runs/30981642901)), and no automated translation PRs have been opened since — which probably explains #29353.

This PR moves the check into a small gate job (secrets *are* available in step `env`) and gates `i18n` on its output via `needs`. Same intent as #28704 — skip cleanly when the key is absent — but valid.

Verified on my fork:
- no key → [gate runs, `Run i18n` skipped, run green](https://github.com/Chyste/cal.diy/actions/runs/31128883382)
- dummy key → [`Run i18n` starts](https://github.com/Chyste/cal.diy/actions/runs/31128902519) (then fails on my fork's other missing secrets, as expected)

refs #28704

## Notes

- I can't tell from outside whether `CI_LINGO_DOT_DEV_API_KEY` still exists in this repo. If it was removed on purpose, this fix still turns the permanent red runs into green skips.
- `release-docker.yaml` has the same bug in its step-level `if`s (lines 109/120/157/168). Separate PR if you want it.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A — CI workflow change only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — validated with `actionlint` (fails on `main`, passes on this branch) plus the fork runs above.

## How should this be tested?

`actionlint .github/workflows/i18n.yml` fails on `main` and passes on this branch. After merge, the next push to `main` should show the gate job running and `Run i18n` either running or skipping — instead of the whole run failing with no jobs.
