### PR TITLE
feat(app-store): add Proton Calendar sync provider integration

### DIFF
--- a/packages/app-store/apps.metadata.generated.ts
+++ b/packages/app-store/apps.metadata.generated.ts
@@ -75,6 +75,7 @@ import pipedream_config_json from "./pipedream/config.json";
 import pipedrive_crm_config_json from "./pipedrive-crm/config.json";
 import plausible_config_json from "./plausible/config.json";
 import posthog_config_json from "./posthog/config.json";
+import { metadata as proton__metadata_ts } from "./proton/_metadata";
 import qr_code_config_json from "./qr_code/config.json";
 import raycast_config_json from "./raycast/config.json";
 import retell_ai_config_json from "./retell-ai/config.json";
@@ -188,6 +189,7 @@ export const appStoreMetadata = {
   "pipedrive-crm": pipedrive_crm_config_json,
   plausible: plausible_config_json,
   posthog: posthog_config_json,
+  proton: proton__metadata_ts,
   qr_code: qr_code_config_json,
   raycast: raycast_config_json,
   "retell-ai": retell_ai_config_json,

--- a/packages/app-store/apps.server.generated.ts
+++ b/packages/app-store/apps.server.generated.ts
@@ -55,6 +55,7 @@ export const apiHandlers = {
   "pipedrive-crm": import("./pipedrive-crm/api"),
   plausible: import("./plausible/api"),
   posthog: import("./posthog/api"),
+  proton: import("./proton/api"),
   qr_code: import("./qr_code/api"),
   riverside: import("./riverside/api"),
   roam: import("./roam/api"),

--- a/packages/app-store/calendar.services.generated.ts
+++ b/packages/app-store/calendar.services.generated.ts
@@ -16,5 +16,7 @@ export const CalendarServiceMap =
         "ics-feedcalendar": import("./ics-feedcalendar/lib/CalendarService"),
         larkcalendar: import("./larkcalendar/lib/CalendarService"),
         office365calendar: import("./office365calendar/lib/CalendarService"),
+        proton: import("./proton/lib/CalendarService"),
         zohocalendar: import("./zohocalendar/lib/CalendarService"),
       };
+

--- a/packages/app-store/proton/DESCRIPTION.md
+++ b/packages/app-store/proton/DESCRIPTION.md
@@ -1,0 +1,3 @@
+# Proton Calendar
+
+Sync your Cal.com bookings seamlessly with Proton Calendar via CalDAV.

--- a/packages/app-store/proton/_metadata.ts
+++ b/packages/app-store/proton/_metadata.ts
@@ -1,0 +1,22 @@
+import type { AppMeta } from "@calcom/types/App";
+
+export const metadata = {
+  name: "Proton Calendar",
+  description:
+    "Proton Calendar is a privacy-focused calendar service. Sync your Cal.com bookings seamlessly with Proton Calendar via CalDAV.",
+  installed: true,
+  type: "proton_calendar",
+  title: "Proton Calendar",
+  variant: "calendar",
+  category: "calendar",
+  categories: ["calendar"],
+  logo: "icon.svg",
+  publisher: "Cal.com",
+  slug: "proton-calendar",
+  url: "https://proton.me/calendar",
+  email: "help@cal.com",
+  dirName: "proton",
+  isOAuth: false,
+} as AppMeta;
+
+export default metadata;

--- a/packages/app-store/proton/api/add.ts
+++ b/packages/app-store/proton/api/add.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { symmetricDecrypt, symmetricEncrypt } from "@calcom/lib/crypto";
+import logger from "@calcom/lib/logger";
+import prisma from "@calcom/prisma";
+
+import getInstalledAppPath from "../../_utils/getInstalledAppPath";
+import { BuildCalendarService } from "../lib";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    const { username, password, url = "https://caldav.proton.me" } = req.body;
+    // Get user
+    const user = await prisma.user.findFirstOrThrow({
+      where: {
+        id: req.session?.user?.id,
+      },
+      select: {
+        email: true,
+        id: true,
+        credentials: {
+          where: {
+            type: "proton_calendar",
+          },
+        },
+      },
+    });
+
+    let credentialExistsWithInputPassword = false;
+
+    const credentialExistsWithUsername = user.credentials.find((credential) => {
+      const decryptedCredential = JSON.parse(
+        symmetricDecrypt(credential.key?.toString() || "", process.env.CALENDSO_ENCRYPTION_KEY || "")
+      );
+
+      if (decryptedCredential.username === username) {
+        if (decryptedCredential.password === password) {
+          credentialExistsWithInputPassword = true;
+        }
+        return true;
+      }
+    });
+
+    if (credentialExistsWithInputPassword) return res.status(409).json({ message: "account_already_linked" });
+
+    const data = {
+      type: "proton_calendar",
+      key: symmetricEncrypt(
+        JSON.stringify({ username, password, url }),
+        process.env.CALENDSO_ENCRYPTION_KEY || ""
+      ),
+      userId: user.id,
+      teamId: null,
+      appId: "proton-calendar",
+      invalid: false,
+      delegationCredentialId: null,
+    };
+
+    try {
+      const dav = BuildCalendarService({
+        id: 0,
+        ...data,
+        user: { email: user.email },
+        encryptedKey: null,
+      });
+      await dav?.listCalendars();
+      await prisma.credential.upsert({
+        where: {
+          id: credentialExistsWithUsername?.id ?? -1,
+        },
+        create: data,
+        update: data,
+      });
+    } catch (reason) {
+      logger.error("Could not add this proton calendar account", reason);
+      return res.status(500).json({ message: "unable_to_add_proton_calendar" });
+    }
+
+    return res
+      .status(200)
+      .json({ url: getInstalledAppPath({ variant: "calendar", slug: "proton-calendar" }) });
+  }
+
+  if (req.method === "GET") {
+    return res.status(200).json({ url: "/apps/proton-calendar/setup" });
+  }
+}

--- a/packages/app-store/proton/api/index.ts
+++ b/packages/app-store/proton/api/index.ts
@@ -1,0 +1,1 @@
+export { default as add } from "./add";

--- a/packages/app-store/proton/index.ts
+++ b/packages/app-store/proton/index.ts
@@ -1,0 +1,3 @@
+export * as api from "./api";
+export * as lib from "./lib";
+export { metadata } from "./_metadata";

--- a/packages/app-store/proton/lib/CalendarService.ts
+++ b/packages/app-store/proton/lib/CalendarService.ts
@@ -1,0 +1,18 @@
+import BaseCalendarService from "@calcom/lib/CalendarService";
+import type { Calendar } from "@calcom/types/Calendar";
+import type { CredentialPayload } from "@calcom/types/Credential";
+
+class ProtonCalendarService extends BaseCalendarService {
+  constructor(credential: CredentialPayload) {
+    super(credential, "proton_calendar", "https://caldav.proton.me");
+  }
+}
+
+/**
+ * Factory function that creates a Proton Calendar service instance.
+ * This is exported instead of the class to prevent internal types
+ * from leaking into the emitted .d.ts file.
+ */
+export default function BuildCalendarService(credential: CredentialPayload): Calendar {
+  return new ProtonCalendarService(credential);
+}

--- a/packages/app-store/proton/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/proton/lib/__tests__/CalendarService.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { symmetricEncrypt } from "@calcom/lib/crypto";
+import type { CredentialPayload } from "@calcom/types/Credential";
+
+import BuildCalendarService from "../CalendarService";
+
+describe("Proton CalendarService", () => {
+  it("should initialize ProtonCalendarService correctly with credential", () => {
+    const encryptedKey = symmetricEncrypt(
+      JSON.stringify({
+        username: "testuser@proton.me",
+        password: "testpassword",
+        url: "https://caldav.proton.me",
+      }),
+      process.env.CALENDSO_ENCRYPTION_KEY || ""
+    );
+
+    const credential: CredentialPayload = {
+      id: 1,
+      type: "proton_calendar",
+      key: encryptedKey,
+      userId: 1,
+      teamId: null,
+      appId: "proton-calendar",
+      invalid: false,
+      user: {
+        email: "testuser@proton.me",
+      },
+    };
+
+    const calendarService = BuildCalendarService(credential);
+    expect(calendarService).toBeDefined();
+    expect(typeof calendarService.listCalendars).toBe("function");
+    expect(typeof calendarService.createEvent).toBe("function");
+    expect(typeof calendarService.updateEvent).toBe("function");
+    expect(typeof calendarService.deleteEvent).toBe("function");
+    expect(typeof calendarService.getAvailability).toBe("function");
+  });
+});

--- a/packages/app-store/proton/lib/index.ts
+++ b/packages/app-store/proton/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as BuildCalendarService } from "./CalendarService";

--- a/packages/app-store/proton/package.json
+++ b/packages/app-store/proton/package.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "name": "@calcom/proton",
+  "version": "0.0.0",
+  "main": "./index.ts",
+  "description": "Proton Calendar integration for Cal.com via CalDAV.",
+  "dependencies": {
+    "@calcom/lib": "workspace:*",
+    "@calcom/prisma": "workspace:*",
+    "@calcom/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-hook-form": "^7.0.0"
+  },
+  "devDependencies": {
+    "@calcom/types": "workspace:*"
+  }
+}

--- a/packages/app-store/proton/static/icon.svg
+++ b/packages/app-store/proton/static/icon.svg
@@ -1,0 +1,19 @@
+<svg width="106" height="86" viewBox="0 0 106 86" fill="none" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M 83.4613,16.1551 V 86 h 11.578 C 101.094,86 106,81.026 106,74.9015 V 2.47101 c 0,-2.09261199 -2.404,-3.23204199 -3.997,-1.89540199 z" fill="url(#paint0_linear_proton)" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M 67.3128,29.7407 46.1604,48.6618 c -3.6066,3.2211 -8.9895,3.2978 -12.6827,0.1862 L 0,20.6691 V 2.482 C 0,0.38939001 2.40441,-0.76099599 3.99653,0.57564301 L 45.998,35.8761 c 4.0615,3.4183 9.9534,3.4183 14.0149,0 z" fill="url(#paint1_linear_proton)" />
+  <path d="m 83.4613,16.1661 -16.1485,13.5746 0.0108,-10e-5 -21.1632,18.9212 c -3.6066,3.2211 -8.9895,3.2978 -12.6827,0.1862 L 0,20.6691 V 74.9015 C 0,81.0259 4.9063,86 10.9607,86 h 72.5006 z" fill="url(#paint2_radial_proton)" />
+  <defs>
+    <linearGradient id="paint0_linear_proton" x1="265.97501" y1="141.754" x2="244.3" y2="-73.404099" gradientUnits="userSpaceOnUse">
+      <stop offset="0.271" stop-color="#E3D9FF" />
+      <stop offset="1" stop-color="#7341FF" />
+    </linearGradient>
+    <linearGradient id="paint1_linear_proton" x1="62.634602" y1="86.798401" x2="18.552999" y2="-87.2799" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E3D9FF" />
+      <stop offset="1" stop-color="#7341FF" />
+    </linearGradient>
+    <radialGradient id="paint2_radial_proton" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(123.614,0,0,125.045,105.538,10.5272)">
+      <stop offset="0.5561" stop-color="#6D4AFF" />
+      <stop offset="0.9944" stop-color="#AA8EFF" />
+    </radialGradient>
+  </defs>
+</svg>

--- a/packages/platform/constants/apps.ts
+++ b/packages/platform/constants/apps.ts
@@ -9,7 +9,9 @@ export const ICS_CALENDAR = "ics-feed";
 export const ICS_CALENDAR_ID = "ics-feed";
 export const APPLE_CALENDAR_TYPE = "apple_calendar";
 export const ICS_CALENDAR_TYPE = "ics-feed_calendar";
+export const PROTON_CALENDAR_TYPE = "proton_calendar";
 export const APPLE_CALENDAR_ID = "apple-calendar";
+export const PROTON_CALENDAR_ID = "proton-calendar";
 export const CALENDARS = [GOOGLE_CALENDAR, OFFICE_365_CALENDAR, APPLE_CALENDAR] as const;
 export const CREDENTIAL_CALENDARS = [APPLE_CALENDAR] as const;
 
@@ -31,6 +33,8 @@ export const APPS_TYPE_ID_MAPPING = {
   [GOOGLE_CALENDAR_TYPE]: GOOGLE_CALENDAR_ID,
   [OFFICE_365_CALENDAR_TYPE]: OFFICE_365_CALENDAR_ID,
   [APPLE_CALENDAR_TYPE]: APPLE_CALENDAR_ID,
+  [PROTON_CALENDAR_TYPE]: PROTON_CALENDAR_ID,
   [ICS_CALENDAR_TYPE]: ICS_CALENDAR_ID,
   [GOOGLE_MEET_TYPE]: GOOGLE_MEET_ID,
 } as const;
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,6 +2989,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@calcom/proton@workspace:packages/app-store/proton":
+  version: 0.0.0-use.local
+  resolution: "@calcom/proton@workspace:packages/app-store/proton"
+  dependencies:
+    "@calcom/lib": "workspace:*"
+    "@calcom/prisma": "workspace:*"
+    "@calcom/types": "workspace:*"
+    "@calcom/ui": "workspace:*"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    react-hook-form: ^7.0.0
+  languageName: unknown
+  linkType: soft
+
 "@calcom/qr_code@workspace:packages/app-store/qr_code":
   version: 0.0.0-use.local
   resolution: "@calcom/qr_code@workspace:packages/app-store/qr_code"


### PR DESCRIPTION
### Summary
Adds Proton Calendar (`@calcom/proton`) to the Cal.com app-store as a first-class sync calendar provider using standard CalDAV integrations.

### Key Changes
- **Package Implementation** (`packages/app-store/proton`):
  - Added `ProtonCalendarService` extending `BaseCalendarService` targeting `https://caldav.proton.me`.
  - Added API route handler `api/add.ts` for verifying credentials and storing encrypted tokens.
- **Global App Registration**:
  - Registered `proton` across `calendar.services.generated.ts`, `apps.server.generated.ts`, `apps.metadata.generated.ts`, and `packages/platform/constants/apps.ts`.
- **Testing**:
  - Added unit test in `lib/__tests__/CalendarService.test.ts`.