### PR TITLE
fix(timezone): normalize half-hour and quarter-hour GMT offsets in the picker

### DIFF
--- a/apps/web/test/lib/getTimezone.test.ts
+++ b/apps/web/test/lib/getTimezone.test.ts
@@ -106,4 +106,16 @@ describe("getTimezone", () => {
     vi.setSystemTime(new Date("2020-06-01"));
     expect(handleOptionLabel(option, [])).toMatchInlineSnapshot(`"America/Los Angeles GMT -7:00"`);
   });
+
+  it("strips the leading zero for half-hour offsets, not just whole-hour zones (#29853)", () => {
+    // Asia/Kolkata is +05:30 all year, so it must render like whole-hour zones (no padded zero).
+    const kolkataOption = {
+      value: "Asia/Kolkata",
+      label: "(GMT+5:30) Kolkata",
+      offset: 5.5,
+      abbrev: "IST",
+      altName: "India Standard Time",
+    };
+    expect(handleOptionLabel(kolkataOption, [])).toBe("Asia/Kolkata GMT +5:30");
+  });
 });

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -25,7 +25,7 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
 };
 
 const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+  offset.replace(/^([-+])(0)(\d):(\d{2})$/, (_, sign, _zero, hour, minutes) => `${sign}${hour}:${minutes}`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
Fixes #29853.

## What / why

`formatOffset()` in `packages/lib/timezone.ts` strips the padded leading zero from a GMT offset, but its regex only matches whole-hour zones (`:00`):

```ts
offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
```

So `+09:00` becomes `+9:00` while `+05:30` stays `+05:30`, and the timezone picker shows two formats side by side:

```
Berlin    GMT +1:00
Kolkata   GMT +05:30   <- inconsistent
Seoul     GMT +9:00
```

Every half/quarter-hour zone is affected — India, Nepal, Sri Lanka, Iran, Myanmar, parts of Australia, the Chatham Islands, Newfoundland.

## Fix

Widen the minutes match so the leading zero is stripped for any single-digit-hour offset, not only `:00`:

```ts
offset.replace(/^([-+])(0)(\d):(\d{2})$/, (_, sign, _zero, hour, minutes) => `${sign}${hour}:${minutes}`);
```

Two-digit-hour offsets (e.g. `+12:45`, `+10:30`) don't start with a `0`, so they're left untouched, exactly as before.

## Test

Added a case to `apps/web/test/lib/getTimezone.test.ts` asserting `Asia/Kolkata` (`+05:30`, already in the fixture) renders as `GMT +5:30`.
