### PR TITLE
fix(platform-types): declare initialized booking-field booleans as Boolean in OpenAPI

### DIFF
--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -8160,7 +8160,7 @@
             "type": "string"
           },
           "required": {
-            "type": "object",
+            "type": "boolean",
             "description": "Can be set to false only for organization team event types and if you also pass booking field {type: \"phone\", slug: \"attendeePhoneNumber\", required: true, hidden: false, label: \"whatever label\"} of booking field type PhoneFieldInput_2024_06_14 - this is done\n      to enable phone only bookings where during the booking attendee can provide only their phone number and not provide email, so you must pass to the email booking field {hidden: true, required: false}.\n      If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "hidden": {
@@ -8916,7 +8916,7 @@
             "type": "string"
           },
           "required": {
-            "type": "object",
+            "type": "boolean",
             "description": "Can be set to false only for organization team event types and if you also pass booking field {type: \"phone\", slug: \"attendeePhoneNumber\", required: true, hidden: false, label: \"whatever label\"} of booking field type PhoneFieldInput_2024_06_14 - this is done\n      to enable phone only bookings where during the booking attendee can provide only their phone number and not provide email, so you must pass to the email booking field {hidden: true, required: false}.\n      If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "hidden": {
@@ -8931,7 +8931,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&email=bob@gmail.com`,      the email field will be prefilled with this value and disabled. In case of Booker atom need to pass 'email' to defaultFormValues prop with the desired value e.g. `defaultFormValues={{email: 'bob@gmail.com'}}`. See guide https://cal.com/docs/platform/guides/booking-field"
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -8963,7 +8963,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&name=bob`,      the name field will be prefilled with this value and disabled. In case of Booker atom need to pass 'name' to defaultFormValues prop with the desired value e.g. `defaultFormValues={{name: 'bob'}}`. See guide https://cal.com/docs/platform/guides/booking-fields"
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -8982,7 +8982,7 @@
         "type": "object",
         "properties": {
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -9036,7 +9036,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&rescheduleReason=busy`,      the reschedule reason field will be prefilled with this value and disabled."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -9075,7 +9075,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&title=masterclass`,      the title field will be prefilled with this value and disabled."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -9114,7 +9114,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&notes=hello`,      the notes field will be prefilled with this value and disabled."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -9153,7 +9153,7 @@
             "description": "Disable this booking field if the URL contains query parameter with key equal to the slug and prefill it with the provided value.      For example, if URL contains query parameter `&guests=lauris@cal.com`,      the guests field will be prefilled with this value and disabled."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always true because it's a default field",
             "example": true,
             "default": true
@@ -9198,7 +9198,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9235,7 +9235,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9279,7 +9279,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9320,7 +9320,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9364,7 +9364,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9405,7 +9405,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9446,7 +9446,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9485,7 +9485,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9529,7 +9529,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9577,7 +9577,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9618,7 +9618,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false
@@ -9659,7 +9659,7 @@
             "description": "If true show under event type settings but don't show this booking field in the Booker. If false show in both."
           },
           "isDefault": {
-            "type": "object",
+            "type": "boolean",
             "description": "This property is always false because it's not default field but custom field",
             "example": false,
             "default": false

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -118,6 +118,7 @@ export class EmailDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @IsOptional()
   @DocsPropertyOptional({
+    type: Boolean,
     description: `Can be set to false only for organization team event types and if you also pass booking field {type: "phone", slug: "attendeePhoneNumber", required: true, hidden: false, label: "whatever label"} of booking field type PhoneFieldInput_2024_06_14 - this is done
       to enable phone only bookings where during the booking attendee can provide only their phone number and not provide email, so you must pass to the email booking field {hidden: true, required: false}.
       If true show under event type settings but don't show this booking field in the Booker. If false show in both.`,

--- a/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
@@ -30,6 +30,7 @@ import {
 export class NameDefaultFieldOutput_2024_06_14 extends NameDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -56,6 +57,7 @@ export class NameDefaultFieldOutput_2024_06_14 extends NameDefaultFieldInput_202
 export class SplitNameDefaultFieldOutput_2024_06_14 extends SplitNameDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -78,6 +80,7 @@ export class SplitNameDefaultFieldOutput_2024_06_14 extends SplitNameDefaultFiel
 export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -111,6 +114,7 @@ export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2
 export class LocationDefaultFieldOutput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -151,6 +155,7 @@ export class LocationDefaultFieldOutput_2024_06_14 {
 export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleReasonDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -204,6 +209,7 @@ export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleRea
 export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -257,6 +263,7 @@ export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2
 export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -310,6 +317,7 @@ export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2
 export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -363,6 +371,7 @@ export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput
 export class PhoneDefaultFieldOutput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -416,6 +425,7 @@ export class PhoneDefaultFieldOutput_2024_06_14 {
 export class PhoneFieldOutput_2024_06_14 extends PhoneFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -433,6 +443,7 @@ export class PhoneFieldOutput_2024_06_14 extends PhoneFieldInput_2024_06_14 {
 export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -450,6 +461,7 @@ export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 
 export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -467,6 +479,7 @@ export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
 export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -484,6 +497,7 @@ export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
 export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -501,6 +515,7 @@ export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
 export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -518,6 +533,7 @@ export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_1
 export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -535,6 +551,7 @@ export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
 export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -552,6 +569,7 @@ export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_202
 export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -569,6 +587,7 @@ export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_
 export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -586,6 +605,7 @@ export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput
 export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -603,6 +623,7 @@ export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_
 export class BooleanFieldOutput_2024_06_14 extends BooleanFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,


### PR DESCRIPTION
## What does this PR do?

Fixes #29904

Seven default booking-field output schemas documented `isDefault` as `type: object` while describing it as always `true` and giving it boolean `example`/`default` values, so the published contract contradicted itself and rejected the responses the API actually returns.

### Root cause

`emitDecoratorMetadata` derives `design:type` from the property's **type annotation**. A property declared with only an initializer has no annotation, so the reflected type is `Object` and `@ApiProperty` falls back to `type: "object"`.

`EmailDefaultFieldInput_2024_06_14` shows both halves of this in one class:

```ts
required = true;        // no annotation -> design:type = Object -> "type": "object"
hidden?: boolean;       // annotated     -> design:type = Boolean -> "type": "boolean"
```

### Scope

The issue lists the seven `isDefault = true` outputs and notes that explicit `type: Boolean` "should be evaluated across every default-field variant, including variants that already generate correctly". Auditing the two booking-field files for the pattern turned up **22 affected properties**, not 7:

| Property | Classes | Previously |
|---|---|---|
| `isDefault = true` | 9 default-field outputs | `type: object` |
| `isDefault = false` | 12 custom-field outputs | `type: object` |
| `required = true` | `EmailDefaultFieldInput_2024_06_14` | `type: object` |

`required` is included because the issue's own reproduction payload does not validate without it — after fixing only `isDefault`, `jsonschema` still rejects the payload with `True is not of type 'object'` on `required`. It is the same defect from the same cause, and the output class inherits it from the input base class.

All of these now declare `type: Boolean` explicitly, matching how `disableOnPrefill` is already documented in the same files. Descriptions, `example` and `default` values are unchanged.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have updated the generated OpenAPI document to match

## How should this be tested?

**1. The reporter's reproduction now passes.** Validating the issue's payload against `EmailDefaultFieldOutput_2024_06_14` from `docs/api-reference/v2/openapi.json` with `jsonschema==4.26.0`:

```
BEFORE -> INVALID (2 errors)
    $.isDefault : True is not of type 'object'
    $.required  : True is not of type 'object'
AFTER  -> VALID
```

**2. The generated schema is boolean at the source.** Building the schemas directly with NestJS's own `SchemaObjectFactory` (the same component that produces the published document) over every booking-field output class:

```
BEFORE -> checked: 9,  not boolean: 9
AFTER  -> checked: 41, not boolean: 0
```

**3. No other `isDefault` remains mistyped** anywhere in the document — 22 occurrences, all `boolean`.

**4. Checks run:** `tsc --noEmit` on `@calcom/platform-types` passes. `biome check` on both changed files reports identical counts before and after (2 errors / 6 warnings / 11 infos, all pre-existing and unrelated to these lines).

### Note for reviewers

The same defect class appears on a few unrelated DTOs outside this issue's scope, which I have left alone to keep this PR focused:

- `PlatformOAuthClientDto.logo` (`type: object`, string example)
- `status` on `BookingReferencesOutput_2024_08_13`, `CalendarLinksOutput_2024_08_13`, `StripCredentialsCheckOutputResponseDto`

Happy to follow up on those separately if useful.
