### PR TITLE
fix(api-v2): give deprecated singular calendar event routes their own operation IDs

### DIFF
--- a/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.spec.ts
+++ b/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.spec.ts
@@ -414,6 +414,59 @@ describe("CalUnifiedCalendarsController", () => {
     });
   });
 
+  describe("deprecated singular /event/ path aliases", () => {
+    it("getCalendarEventDetailsByDeprecatedPath should behave like the plural path", async () => {
+      const transformedEvent = {
+        eventId: "event-uid",
+        status: "confirmed",
+        title: "Test Meeting",
+        start: { time: "2024-01-15T10:00:00Z", timeZone: "UTC" },
+        end: { time: "2024-01-15T11:00:00Z", timeZone: "UTC" },
+      };
+      mockUnifiedCalendarService.getEventDetails.mockResolvedValue(transformedEvent);
+
+      const result = await controller.getCalendarEventDetailsByDeprecatedPath(GOOGLE_CALENDAR, "event-uid");
+
+      expect(result.status).toBe(SUCCESS_STATUS);
+      expect(result.data).toBeDefined();
+      expect(mockUnifiedCalendarService.getEventDetails).toHaveBeenCalledWith(GOOGLE_CALENDAR, "event-uid");
+    });
+
+    it("updateCalendarEventByDeprecatedPath should behave like the plural path", async () => {
+      const updateData = { title: "Updated" };
+      const transformedEvent = {
+        eventId: "event-uid",
+        title: "Updated",
+        start: { time: "2024-01-15T10:00:00Z", timeZone: "UTC" },
+        end: { time: "2024-01-15T11:00:00Z", timeZone: "UTC" },
+      };
+      mockUnifiedCalendarService.updateEventDetails.mockResolvedValue(transformedEvent);
+
+      const result = await controller.updateCalendarEventByDeprecatedPath(
+        GOOGLE_CALENDAR,
+        "event-uid",
+        updateData
+      );
+
+      expect(result.status).toBe(SUCCESS_STATUS);
+      expect(mockUnifiedCalendarService.updateEventDetails).toHaveBeenCalledWith(
+        GOOGLE_CALENDAR,
+        "event-uid",
+        updateData
+      );
+    });
+
+    it("should propagate errors from the deprecated aliases", async () => {
+      mockUnifiedCalendarService.getEventDetails.mockRejectedValue(
+        new BadRequestException("Meeting details is currently only available for Google Calendar.")
+      );
+
+      await expect(
+        controller.getCalendarEventDetailsByDeprecatedPath("office365", "event-uid")
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
   describe("listCalendarEvents (user-scoped)", () => {
     it("should list events for Google Calendar", async () => {
       mockUnifiedCalendarService.listEvents.mockResolvedValue([]);

--- a/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
+++ b/apps/api/v2/src/modules/cal-unified-calendars/controllers/cal-unified-calendars.controller.ts
@@ -238,14 +238,14 @@ export class CalUnifiedCalendarsController {
       "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
     type: String,
   })
-  @Get(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
+  @Get("/:calendar/events/:eventUid")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({
     summary: "Get meeting details from calendar",
     description:
-      "Returns detailed information about a meeting including attendance metrics. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
+      "Returns detailed information about a meeting including attendance metrics. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
   })
   async getCalendarEventDetails(
     @Param("calendar") calendar: string,
@@ -266,14 +266,42 @@ export class CalUnifiedCalendarsController {
       "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
     type: String,
   })
-  @Patch(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
+  @Get("/:calendar/event/:eventUid")
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ApiAuthGuard, PermissionsGuard)
+  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiOperation({
+    deprecated: true,
+    summary: "Get meeting details from calendar (deprecated path)",
+    description:
+      "Deprecated singular alias of GET /v2/calendars/{calendar}/events/{eventUid} \u2014 use the plural /events/ path instead.",
+  })
+  async getCalendarEventDetailsByDeprecatedPath(
+    @Param("calendar") calendar: string,
+    @Param("eventUid") eventUid: string
+  ): Promise<GetUnifiedCalendarEventOutput> {
+    return this.getCalendarEventDetails(calendar, eventUid);
+  }
+
+  @ApiParam({
+    name: "calendar",
+    enum: [GOOGLE_CALENDAR],
+    type: String,
+  })
+  @ApiParam({
+    name: "eventUid",
+    description:
+      "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+    type: String,
+  })
+  @Patch("/:calendar/events/:eventUid")
   @HttpCode(HttpStatus.OK)
   @UseGuards(ApiAuthGuard, PermissionsGuard)
   @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
   @ApiOperation({
     summary: "Update meeting details in calendar",
     description:
-      "Updates event information in the specified calendar provider. The singular /event/ path is deprecated \u2014 use /events/ (plural) instead. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
+      "Updates event information in the specified calendar provider. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
   })
   async updateCalendarEvent(
     @Param("calendar") calendar: string,
@@ -282,6 +310,35 @@ export class CalUnifiedCalendarsController {
   ): Promise<GetUnifiedCalendarEventOutput> {
     const data = await this.unifiedCalendarService.updateEventDetails(calendar, eventUid, updateData);
     return { status: SUCCESS_STATUS, data };
+  }
+
+  @ApiParam({
+    name: "calendar",
+    enum: [GOOGLE_CALENDAR],
+    type: String,
+  })
+  @ApiParam({
+    name: "eventUid",
+    description:
+      "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For user events: GET /v2/bookings/{bookingUid}/references",
+    type: String,
+  })
+  @Patch("/:calendar/event/:eventUid")
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ApiAuthGuard, PermissionsGuard)
+  @ApiHeader(API_KEY_OR_ACCESS_TOKEN_HEADER)
+  @ApiOperation({
+    deprecated: true,
+    summary: "Update meeting details in calendar (deprecated path)",
+    description:
+      "Deprecated singular alias of PATCH /v2/calendars/{calendar}/events/{eventUid} \u2014 use the plural /events/ path instead.",
+  })
+  async updateCalendarEventByDeprecatedPath(
+    @Param("calendar") calendar: string,
+    @Param("eventUid") eventUid: string,
+    @Body() updateData: UpdateUnifiedCalendarEventInput
+  ): Promise<GetUnifiedCalendarEventOutput> {
+    return this.updateCalendarEvent(calendar, eventUid, updateData);
   }
 
   @ApiParam({ name: "calendar", enum: UNIFIED_CALENDAR_PARAM, type: String })

--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -1949,7 +1949,7 @@
       "get": {
         "operationId": "CalUnifiedCalendarsController_getCalendarEventDetails",
         "summary": "Get meeting details from calendar",
-        "description": "Returns detailed information about a meeting including attendance metrics. The singular /event/ path is deprecated — use /events/ (plural) instead. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
+        "description": "Returns detailed information about a meeting including attendance metrics. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
         "parameters": [
           {
             "name": "calendar",
@@ -1996,7 +1996,7 @@
       "patch": {
         "operationId": "CalUnifiedCalendarsController_updateCalendarEvent",
         "summary": "Update meeting details in calendar",
-        "description": "Updates event information in the specified calendar provider. The singular /event/ path is deprecated — use /events/ (plural) instead. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
+        "description": "Updates event information in the specified calendar provider. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
         "parameters": [
           {
             "name": "calendar",
@@ -2093,9 +2093,10 @@
     },
     "/v2/calendars/{calendar}/event/{eventUid}": {
       "get": {
-        "operationId": "CalUnifiedCalendarsController_getCalendarEventDetails",
-        "summary": "Get meeting details from calendar",
-        "description": "Returns detailed information about a meeting including attendance metrics. The singular /event/ path is deprecated — use /events/ (plural) instead. For connection-scoped access use GET /connections/{connectionId}/events/{eventId}.",
+        "operationId": "CalUnifiedCalendarsController_getCalendarEventDetailsByDeprecatedPath",
+        "summary": "Get meeting details from calendar (deprecated path)",
+        "deprecated": true,
+        "description": "Deprecated singular alias of GET /v2/calendars/{calendar}/events/{eventUid} — use the plural /events/ path instead.",
         "parameters": [
           {
             "name": "calendar",
@@ -2140,9 +2141,10 @@
         "tags": ["Cal Unified Calendars"]
       },
       "patch": {
-        "operationId": "CalUnifiedCalendarsController_updateCalendarEvent",
-        "summary": "Update meeting details in calendar",
-        "description": "Updates event information in the specified calendar provider. The singular /event/ path is deprecated — use /events/ (plural) instead. For connection-scoped access use PATCH /connections/{connectionId}/events/{eventId}.",
+        "operationId": "CalUnifiedCalendarsController_updateCalendarEventByDeprecatedPath",
+        "summary": "Update meeting details in calendar (deprecated path)",
+        "deprecated": true,
+        "description": "Deprecated singular alias of PATCH /v2/calendars/{calendar}/events/{eventUid} — use the plural /events/ path instead.",
         "parameters": [
           {
             "name": "calendar",


### PR DESCRIPTION
## What does this PR do?

Fixes #29903

Two calendar endpoints registered a plural and a singular path from one handler:

```ts
@Get(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
@Patch(["/:calendar/events/:eventUid", "/:calendar/event/:eventUid"])
```

Swagger derives `operationId` from `Controller_method`, so one handler serving two paths publishes **the same operation ID twice**. That makes the document invalid, and client generators can collide or silently overwrite the generated method.

These were the only two duplicated operation IDs in the document, and the only two route arrays in API v2 — so this is the complete set.

### Approach

Split the deprecated singular aliases into their own handlers that delegate to the canonical plural ones. Each path now gets a distinct operation ID, and the aliases carry `deprecated: true`, so the deprecation lives in the contract rather than only in prose inside a shared description.

| Path | Operation ID | Deprecated |
|---|---|---|
| `GET /v2/calendars/{calendar}/events/{eventUid}` | `…_getCalendarEventDetails` | — |
| `GET /v2/calendars/{calendar}/event/{eventUid}` | `…_getCalendarEventDetailsByDeprecatedPath` | ✅ |
| `PATCH /v2/calendars/{calendar}/events/{eventUid}` | `…_updateCalendarEvent` | — |
| `PATCH /v2/calendars/{calendar}/event/{eventUid}` | `…_updateCalendarEventByDeprecatedPath` | ✅ |

Behaviour is unchanged — both paths still resolve, with identical parameters, guards, request bodies and responses. The "singular path is deprecated" sentence moved out of the shared description onto the deprecated operations themselves, so the plural path's description no longer documents a caveat that does not apply to it.

I used separate handlers rather than an explicit `operationId` because `@ApiOperation` is per-method: with a path array both paths inherit the same metadata, so an explicit ID would still be duplicated. This also keeps the file idiomatic — API v2 sets no explicit `operationId` anywhere and does not use `applyDecorators`.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I have added tests covering the new handlers
- [x] I have updated the generated OpenAPI document to match

## How should this be tested?

**1. The reporter's validator.** `openapi-spec-validator==0.9.0` against `docs/api-reference/v2/openapi.json`:

```
BEFORE -> Validation Error: Operation ID 'CalUnifiedCalendarsController_getCalendarEventDetails'
          for 'get' in '/v2/calendars/{calendar}/event/{eventUid}' is not unique
AFTER  -> that error is gone
```

**2. No duplicates remain.** All 121 operations in the document now have unique IDs (was 2 collisions).

**3. Unit tests.** `cal-unified-calendars.controller.spec.ts` — 30 passed (27 existing, unchanged, plus 3 new covering the deprecated aliases and confirming they delegate to the same service calls).

**4. Spec entries were generated, not hand-written.** I built the document with NestJS's own `SwaggerModule.createDocument` over this controller and copied the emitted operations, so the committed JSON matches what `yarn generate-swagger` produces (including key ordering).

**5. Type-check.** `tsc --noEmit` on `apps/api/v2` reports the same single pre-existing error as `main` (`test/mocks/calendars-service-mock.ts`), unrelated to this change. `biome check` on both changed files reports identical counts before and after.

### Note for reviewers

Once this lands, the validator advances to the next blocker in the document, which is #29904 (`isDefault` documented as `type: object`). I have a PR open for that one at #29947 — with both applied, `openapi-spec-validator` reports `OK` for the whole document. The two changes are independent and can merge in either order.
