### PR TITLE
fix(caldav): make cancel/delete find objects on Stalwart-like servers

### DIFF
--- a/packages/lib/CalendarService.test.ts
+++ b/packages/lib/CalendarService.test.ts
@@ -1,6 +1,6 @@
 import { createEvent as createIcsEvent } from "ics";
 import { createCalendarObject, updateCalendarObject } from "tsdav";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("ics", () => ({
   createEvent: vi.fn(),
@@ -41,7 +41,11 @@ vi.mock("./CalEventParser", () => ({
 }));
 
 import type { CalendarServiceEvent } from "@calcom/types/Calendar";
-import BaseCalendarService from "./CalendarService";
+import BaseCalendarService, {
+  ensureTrailingSlash,
+  joinCalDavObjectUrl,
+  matchesCalDavBookingObject,
+} from "./CalendarService";
 
 const createMockEvent = (overrides: Partial<CalendarServiceEvent> = {}): CalendarServiceEvent => ({
   type: "caldav",
@@ -746,5 +750,202 @@ describe("CalendarService - SCHEDULE-AGENT injection", () => {
 
       await expect(service.createEvent(event, 1)).rejects.toThrow();
     });
+  });
+});
+
+describe("CalDAV collection URL normalization", () => {
+  it("ensureTrailingSlash appends a slash when missing", () => {
+    expect(ensureTrailingSlash("https://mail.example.com/dav/cal/user/default")).toBe(
+      "https://mail.example.com/dav/cal/user/default/"
+    );
+    expect(ensureTrailingSlash("https://mail.example.com/dav/cal/user/default/")).toBe(
+      "https://mail.example.com/dav/cal/user/default/"
+    );
+  });
+
+  it("joinCalDavObjectUrl matches tsdav createCalendarObject URL resolution", () => {
+    // Without normalization, `new URL(filename, collectionWithoutSlash)` would drop the last segment.
+    expect(joinCalDavObjectUrl("https://mail.example.com/dav/cal/user/default", "booking-uid.ics")).toBe(
+      "https://mail.example.com/dav/cal/user/default/booking-uid.ics"
+    );
+    expect(joinCalDavObjectUrl("https://mail.example.com/dav/cal/user/default/", "booking-uid.ics")).toBe(
+      "https://mail.example.com/dav/cal/user/default/booking-uid.ics"
+    );
+  });
+});
+
+describe("matchesCalDavBookingObject", () => {
+  const objectUrl = "https://mail.example.com/dav/cal/user/default/booking-uid.ics";
+
+  it("matches exact ICS UID", () => {
+    expect(matchesCalDavBookingObject({ uid: "booking-uid", url: objectUrl }, "booking-uid")).toBe(true);
+  });
+
+  it("matches iCalUID forms like bookingUid@Cal.diy", () => {
+    expect(
+      matchesCalDavBookingObject({ uid: "booking-uid@Cal.diy", url: objectUrl }, "booking-uid")
+    ).toBe(true);
+    expect(
+      matchesCalDavBookingObject({ uid: "booking-uid@example.com", url: objectUrl }, "booking-uid")
+    ).toBe(true);
+  });
+
+  it("matches by object pathname even when ICS UID differs", () => {
+    expect(
+      matchesCalDavBookingObject(
+        { uid: "totally-different-uid", url: objectUrl },
+        "booking-uid"
+      )
+    ).toBe(true);
+  });
+
+  it("does not match unrelated UIDs or substrings in the path", () => {
+    expect(
+      matchesCalDavBookingObject(
+        {
+          uid: "other@Cal.diy",
+          url: "https://mail.example.com/dav/cal/user/default/other-booking-uid.ics",
+        },
+        "booking-uid"
+      )
+    ).toBe(false);
+    expect(
+      matchesCalDavBookingObject(
+        {
+          uid: "prefix-booking-uid",
+          url: "https://mail.example.com/dav/cal/user/default/prefix-booking-uid.ics",
+        },
+        "booking-uid"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("CalDAV deleteEvent object lookup", () => {
+  const uid = "booking-uid-from-database-abc123";
+  const calendarWithoutSlash = "https://mail.example.com/dav/cal/user/default";
+  const expectedObjectUrl = `${calendarWithoutSlash}/${uid}.ics`;
+  const icsBody = `BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:${uid}\r\nDTSTART:20230615T150000Z\r\nDTEND:20230615T160000Z\r\nEND:VEVENT\r\nEND:VCALENDAR`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => icsBody,
+        headers: { get: (name: string) => (name.toLowerCase() === "etag" ? '"etag-1"' : null) },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs the object under the collection when externalId has no trailing slash", async () => {
+    const { deleteCalendarObject, fetchCalendarObjects } = await import("tsdav");
+    const service = new TestCalendarService();
+
+    vi.spyOn(service, "listCalendars").mockResolvedValue([
+      {
+        externalId: calendarWithoutSlash,
+        name: "Stalwart Calendar",
+        primary: true,
+        readOnly: false,
+        email: "paul@example.com",
+        integrationName: "caldav",
+        credentialId: 1,
+      },
+    ]);
+    vi.mocked(deleteCalendarObject).mockResolvedValue({ status: 204 } as never);
+
+    await service.deleteEvent(uid);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expectedObjectUrl,
+      expect.objectContaining({
+        method: "GET",
+      })
+    );
+    expect(fetchCalendarObjects).not.toHaveBeenCalled();
+    expect(deleteCalendarObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarObject: expect.objectContaining({
+          url: expectedObjectUrl,
+        }),
+      })
+    );
+  });
+
+  it("deletes when ICS UID is bookingUid@Cal.diy but filename uses booking uid", async () => {
+    const { deleteCalendarObject } = await import("tsdav");
+    const service = new TestCalendarService();
+    const icsWithDomainUid = `BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:${uid}@Cal.diy\r\nDTSTART:20230615T150000Z\r\nDTEND:20230615T160000Z\r\nEND:VEVENT\r\nEND:VCALENDAR`;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => icsWithDomainUid,
+        headers: { get: () => '"etag-2"' },
+      })
+    );
+
+    vi.spyOn(service, "listCalendars").mockResolvedValue([
+      {
+        externalId: `${calendarWithoutSlash}/`,
+        name: "Stalwart Calendar",
+        primary: true,
+        readOnly: false,
+        email: "paul@example.com",
+        integrationName: "caldav",
+        credentialId: 1,
+      },
+    ]);
+    vi.mocked(deleteCalendarObject).mockResolvedValue({ status: 204 } as never);
+
+    await service.deleteEvent(uid);
+
+    expect(deleteCalendarObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarObject: expect.objectContaining({
+          url: `${calendarWithoutSlash}/${uid}.ics`,
+        }),
+      })
+    );
+  });
+
+  it("skips delete when the object is not found", async () => {
+    const { deleteCalendarObject } = await import("tsdav");
+    const service = new TestCalendarService();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () => "",
+        headers: { get: () => null },
+      })
+    );
+
+    vi.spyOn(service, "listCalendars").mockResolvedValue([
+      {
+        externalId: `${calendarWithoutSlash}/`,
+        name: "Stalwart Calendar",
+        primary: true,
+        readOnly: false,
+        email: "paul@example.com",
+        integrationName: "caldav",
+        credentialId: 1,
+      },
+    ]);
+
+    await service.deleteEvent(uid);
+
+    expect(deleteCalendarObject).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/CalendarService.ts
+++ b/packages/lib/CalendarService.ts
@@ -38,6 +38,41 @@ import logger from "./logger";
 const TIMEZONE_FORMAT = "YYYY-MM-DDTHH:mm:ss[Z]";
 const DEFAULT_CALENDAR_TYPE = "caldav";
 
+/**
+ * CalDAV collection URLs must end with `/` so `new URL(filename, calendarUrl)`
+ * (used by tsdav's createCalendarObject) resolves under the collection instead of
+ * replacing the last path segment. Servers like Stalwart often omit the slash.
+ */
+export function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
+ * Build the object URL the same way tsdav does when creating (`new URL(filename, calendar.url)`),
+ * after normalizing the collection URL. Used by update/delete lookups via getEventsByUID.
+ */
+export function joinCalDavObjectUrl(calendarUrl: string, filename: string): string {
+  return new URL(filename.replace(/^\//, ""), ensureTrailingSlash(calendarUrl)).href;
+}
+
+/**
+ * Match a fetched CalDAV object to a cal.com booking uid.
+ * Accepts exact ICS UID, `uid@domain` iCalUID forms, or the standard `{uid}.ics` object path.
+ */
+export function matchesCalDavBookingObject(
+  event: Pick<CalendarEventType, "uid" | "url">,
+  bookingUid: string
+): boolean {
+  if (event.uid === bookingUid) return true;
+  if (typeof event.uid === "string" && event.uid.startsWith(`${bookingUid}@`)) return true;
+  try {
+    const { pathname } = new URL(event.url);
+    return pathname.endsWith(`/${bookingUid}.ics`);
+  } catch {
+    return false;
+  }
+}
+
 const CALENDSO_ENCRYPTION_KEY = process.env.CALENDSO_ENCRYPTION_KEY || "";
 
 type FetchObjectsWithOptionalExpandOptionsType = {
@@ -467,13 +502,14 @@ export default abstract class BaseCalendarService implements Calendar {
         calendars
           .filter((c) =>
             mainHostDestinationCalendar?.externalId
-              ? c.externalId === mainHostDestinationCalendar.externalId
+              ? ensureTrailingSlash(c.externalId) ===
+                ensureTrailingSlash(mainHostDestinationCalendar.externalId)
               : true
           )
           .map((calendar) =>
             createCalendarObject({
               calendar: {
-                url: calendar.externalId,
+                url: ensureTrailingSlash(calendar.externalId),
               },
               filename: `${uid}.ics`,
               iCalString: injectScheduleAgent(iCalStringWithTimezone),
@@ -542,7 +578,7 @@ export default abstract class BaseCalendarService implements Calendar {
         : "";
 
       let calendarEvent: CalendarEventType;
-      const eventsToUpdate = events.filter((e) => e.uid === uid);
+      const eventsToUpdate = events.filter((e) => matchesCalDavBookingObject(e, uid));
       return Promise.all(
         eventsToUpdate.map((eventItem) => {
           calendarEvent = eventItem;
@@ -591,7 +627,7 @@ export default abstract class BaseCalendarService implements Calendar {
     try {
       const events = await this.getEventsByUID(uid);
 
-      const eventsToDelete = events.filter((event) => event.uid === uid);
+      const eventsToDelete = events.filter((event) => matchesCalDavBookingObject(event, uid));
       await Promise.all(
         eventsToDelete.map((event) => {
           return deleteCalendarObject({
@@ -829,12 +865,13 @@ export default abstract class BaseCalendarService implements Calendar {
       return calendars.reduce<IntegrationCalendar[]>((newCalendars, calendar) => {
         if (!calendar.components?.includes("VEVENT")) return newCalendars;
         const [mainHostDestinationCalendar] = event?.destinationCalendar ?? [];
+        const calendarUrl = ensureTrailingSlash(calendar.url);
         newCalendars.push({
-          externalId: calendar.url,
+          externalId: calendarUrl,
           /** @url https://github.com/calcom/cal.diy/issues/7186 */
           name: typeof calendar.displayName === "string" ? calendar.displayName : "",
           primary: mainHostDestinationCalendar?.externalId
-            ? mainHostDestinationCalendar.externalId === calendar.url
+            ? ensureTrailingSlash(mainHostDestinationCalendar.externalId) === calendarUrl
             : false,
           integration: this.integrationName,
           email: this.credentials.username ?? "",
@@ -874,7 +911,7 @@ export default abstract class BaseCalendarService implements Calendar {
       const response = await fetchCalendarObjects({
         urlFilter: (url) => this.isValidFormat(url),
         calendar: {
-          url: sc.externalId,
+          url: ensureTrailingSlash(sc.externalId),
         },
         headers,
         expand: true,
@@ -892,7 +929,7 @@ export default abstract class BaseCalendarService implements Calendar {
             const responseWithoutExpand = await fetchCalendarObjects({
               urlFilter: (url) => this.isValidFormat(url),
               calendar: {
-                url: sc.externalId,
+                url: ensureTrailingSlash(sc.externalId),
               },
               headers,
               expand: false,
@@ -929,7 +966,7 @@ export default abstract class BaseCalendarService implements Calendar {
     try {
       const objects = await fetchCalendarObjects({
         calendar: {
-          url: calId,
+          url: ensureTrailingSlash(calId),
         },
         objectUrls: objectUrls ? objectUrls : undefined,
         timeRange:
@@ -942,68 +979,96 @@ export default abstract class BaseCalendarService implements Calendar {
         headers: this.headers,
       });
 
-      const events = objects
-        .filter((e) => !!e.data)
-        .map((object) => {
-          const jcalData = ICAL.parse(sanitizeCalendarObject(object));
-
-          const vcalendar = new ICAL.Component(jcalData);
-
-          const vevent = vcalendar.getFirstSubcomponent("vevent");
-          const event = new ICAL.Event(vevent);
-
-          const calendarTimezone =
-            vcalendar.getFirstSubcomponent("vtimezone")?.getFirstPropertyValue<string>("tzid") || "";
-
-          const startDate = calendarTimezone
-            ? dayjs.tz(event.startDate.toString(), calendarTimezone)
-            : new Date(event.startDate.toUnixTime() * 1000);
-
-          const endDate = calendarTimezone
-            ? dayjs.tz(event.endDate.toString(), calendarTimezone)
-            : new Date(event.endDate.toUnixTime() * 1000);
-
-          return {
-            uid: event.uid,
-            etag: object.etag,
-            url: object.url,
-            summary: event.summary,
-            description: event.description,
-            location: event.location,
-            sequence: event.sequence,
-            startDate,
-            endDate,
-            duration: {
-              weeks: event.duration.weeks,
-              days: event.duration.days,
-              hours: event.duration.hours,
-              minutes: event.duration.minutes,
-              seconds: event.duration.seconds,
-              isNegative: event.duration.isNegative,
-            },
-            organizer: event.organizer,
-            attendees: event.attendees.map((a) => a.getValues()),
-            recurrenceId: event.recurrenceId,
-            timezone: calendarTimezone,
-          };
-        });
-      return events;
+      return objects.filter((e) => !!e.data).map((object) => this.mapDavObjectToCalendarEvent(object));
     } catch (reason) {
       logger.error(reason);
       throw reason;
     }
   }
 
+  /**
+   * Fetch one calendar object by absolute URL via GET.
+   * Prefer this over tsdav `fetchCalendarObjects({ objectUrls })` for delete/update
+   * lookups: some servers (e.g. Stalwart) return empty multiget responses, and
+   * `expand: true` incorrectly widens the request to a full-collection query.
+   */
+  private async fetchCalendarObjectByUrl(objectUrl: string): Promise<CalendarEventType | null> {
+    try {
+      const response = await fetch(objectUrl, {
+        method: "GET",
+        headers: this.headers,
+      });
+      if (response.status === 404 || response.status === 410) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(`CalDAV GET ${objectUrl} failed with status ${response.status}`);
+      }
+      const data = await response.text();
+      if (!data) {
+        return null;
+      }
+      const etag = response.headers.get("etag") ?? "";
+      return this.mapDavObjectToCalendarEvent({ url: objectUrl, etag, data });
+    } catch (reason) {
+      logger.error(reason);
+      throw reason;
+    }
+  }
+
+  private mapDavObjectToCalendarEvent(object: DAVObject): CalendarEventType {
+    const jcalData = ICAL.parse(sanitizeCalendarObject(object));
+
+    const vcalendar = new ICAL.Component(jcalData);
+
+    const vevent = vcalendar.getFirstSubcomponent("vevent");
+    const event = new ICAL.Event(vevent);
+
+    const calendarTimezone =
+      vcalendar.getFirstSubcomponent("vtimezone")?.getFirstPropertyValue<string>("tzid") || "";
+
+    const startDate = calendarTimezone
+      ? dayjs.tz(event.startDate.toString(), calendarTimezone)
+      : new Date(event.startDate.toUnixTime() * 1000);
+
+    const endDate = calendarTimezone
+      ? dayjs.tz(event.endDate.toString(), calendarTimezone)
+      : new Date(event.endDate.toUnixTime() * 1000);
+
+    return {
+      uid: event.uid,
+      etag: object.etag,
+      url: object.url,
+      summary: event.summary,
+      description: event.description,
+      location: event.location,
+      sequence: event.sequence,
+      startDate,
+      endDate,
+      duration: {
+        weeks: event.duration.weeks,
+        days: event.duration.days,
+        hours: event.duration.hours,
+        minutes: event.duration.minutes,
+        seconds: event.duration.seconds,
+        isNegative: event.duration.isNegative,
+      },
+      organizer: event.organizer,
+      attendees: event.attendees.map((a) => a.getValues()),
+      recurrenceId: event.recurrenceId,
+      timezone: calendarTimezone,
+    };
+  }
+
   private async getEventsByUID(uid: string): Promise<CalendarEventType[]> {
-    type EventsType = Awaited<ReturnType<typeof this.getEvents>>;
-    const events: EventsType = [];
+    const events: CalendarEventType[] = [];
     const calendars = await this.listCalendars();
 
     for (const cal of calendars) {
-      const calEvents = await this.getEvents(cal.externalId, null, null, [`${cal.externalId}${uid}.ics`]);
-
-      for (const ev of calEvents) {
-        events.push(ev);
+      const objectUrl = joinCalDavObjectUrl(cal.externalId, `${uid}.ics`);
+      const event = await this.fetchCalendarObjectByUrl(objectUrl);
+      if (event && matchesCalDavBookingObject(event, uid)) {
+        events.push(event);
       }
     }
 


### PR DESCRIPTION
## Summary
- Normalize CalDAV collection URLs with a trailing `/` so create/update/delete resolve object paths the same way (servers like Stalwart often omit the slash; without it, `{collection}{uid}.ics` can become `…/defaultuid.ics`).
- Look up objects for cancel/update via a direct HTTP GET of `{uid}.ics` instead of `fetchCalendarObjects({ objectUrls })` — Stalwart returns empty multiget responses, and tsdav’s `expand: true` path runs a full-collection `calendarQuery` and ignores `objectUrls`.
- Match booking UIDs strictly (exact ICS UID, `uid@domain` iCalUID forms, or `/{uid}.ics` pathname) and cover that with unit tests.

## Test plan
- [x] Unit tests in `packages/lib/CalendarService.test.ts` (trailing slash join, matcher cases, delete via GET mock, 404 skip)
- [x] Live against Stalwart (`mail.maxin.one`): book via `/api/book/event` → object `200` on CalDAV → cancel via `/api/cancel` → object `404`
- [ ] Confirm Google / other CalDAV destinations still create and cancel as before (no intentional change to availability/`getEvents` time-range path)