### PR TITLE
fix(apps): sort event type duration badges numerically

### DIFF
--- a/apps/web/components/apps/installation/EventTypesStepCard.tsx
+++ b/apps/web/components/apps/installation/EventTypesStepCard.tsx
@@ -43,7 +43,7 @@ const EventTypeCard: FC<EventTypeCardProps> = ({
 
   const durations =
     multipleDuration.length > 0
-      ? [length, ...multipleDuration.filter((duration) => duration !== length)].sort()
+      ? [length, ...multipleDuration.filter((duration) => duration !== length)].sort((a, b) => a - b)
       : [length];
   return (
     <div


### PR DESCRIPTION
## What
Fixes duration badge ordering on the app-installation event-type picker (`EventTypeCard` in `EventTypesStepCard.tsx`).

## Why
`Array.prototype.sort()` with no comparator coerces every element to a string before comparing. For a number array like `[15, 30, 60, 90, 120]`, that produces lexicographic order — `120` sorts before `15` because `'1' < '2'` as characters. Concretely, an event type with those durations rendered its badges as:

```
120m 15m 30m 60m 90m
```

instead of the expected:

```
15m 30m 60m 90m 120m
```

## Fix
Pass an explicit numeric comparator: `.sort((a, b) => a - b)`. This matches the convention already used for sorting numbers elsewhere in the codebase (`getUserAvailability.ts`, `slots.ts`).

## Testing
Verified locally that `[15, 30, 60, 90, 120].sort()` produces `[120, 15, 30, 60, 90]` and `.sort((a,b) => a-b)` produces `[15, 30, 60, 90, 120]`. No behavior change for single-duration event types.
