### PR TITLE
perf(app-store): dedupe location options in O(n) instead of O(n^2)

### DIFF
--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -27,6 +27,11 @@ export async function getLocationGroupedOptions(
     }[]
   > = {};
 
+  // Track which option values already exist per category so the dedupe in the
+  // integrations loop below is O(1) instead of re-scanning the whole category
+  // array for every credential, which is O(n^2) with many apps/credentials.
+  const seenOptionValuesByCategory: Record<string, Set<string>> = {};
+
   // don't default to {}, when you do TS no longer determines the right types.
   let idToSearchObject: Prisma.CredentialWhereInput;
   let user = null;
@@ -108,13 +113,13 @@ export async function getLocationGroupedOptions(
             ? { credentialId: app.credential.id, teamName: app.credential.team?.name ?? null }
             : {}),
         };
-        if (apps[groupByCategory]) {
-          const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
-          if (!existingOption) {
-            apps[groupByCategory] = [...apps[groupByCategory], option];
-          }
-        } else {
-          apps[groupByCategory] = [option];
+        if (!apps[groupByCategory]) {
+          apps[groupByCategory] = [];
+          seenOptionValuesByCategory[groupByCategory] = new Set();
+        }
+        if (!seenOptionValuesByCategory[groupByCategory].has(option.value)) {
+          seenOptionValuesByCategory[groupByCategory].add(option.value);
+          apps[groupByCategory].push(option);
         }
       }
     }


### PR DESCRIPTION
Fixes #29959.

`getLocationGroupedOptions` in `packages/app-store/server.ts` builds the per-category location options by looping over every integration credential and, for each one, checking the category array for a duplicate:

```ts
if (apps[groupByCategory]) {
  const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
  if (!existingOption) {
    apps[groupByCategory] = [...apps[groupByCategory], option];
  }
} else {
  apps[groupByCategory] = [option];
}
```

Both operations in that branch are O(n): the `.find` scans the whole category array, and `[...apps[groupByCategory], option]` copies it. Because this runs once per credential, the whole thing is O(n^2) in the number of options per category. On an account with many installed apps/credentials that adds up.

This keeps a `Set` of the values already added to each category, so the duplicate check is O(1) and the option is pushed in place instead of rebuilding the array. Net behavior is unchanged: the first occurrence of each value wins and order is preserved, exactly like the old `.find` did.

I checked the equivalence by running the old (find + spread) and new (Set + push) logic side by side over an input with heavy duplicates across and within categories, and the resulting `apps` object is byte-for-byte identical (same categories, same order, same dedupe). The surrounding `defaultLocations` loop is left as is since it runs over a small fixed list and is not part of the hot path.