### PR TITLE
feat: track when seated attendee joined booking

### DIFF
--- a/apps/api/v2/src/platform/bookings/2024-08-13/controllers/e2e/seated-bookings.e2e-spec.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/controllers/e2e/seated-bookings.e2e-spec.ts
@@ -211,9 +211,11 @@ describe("Bookings Endpoints 2024-08-13", () => {
                 ...body.bookingFieldsResponses,
               },
               metadata: body.metadata,
+              createdAt: expect.any(String)
             });
             expect(data.location).toBeDefined();
             expect(data.absentHost).toEqual(false);
+            expect(data.attendees[0].createdAt).toBeDefined();
             createdSeatedBooking = data;
           } else {
             throw new Error(
@@ -511,6 +513,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
               expect(data.attendees[0].email).toEqual(emailAttendeeThree);
               expect(data.attendees[0].name).toEqual(nameAttendeeThree);
               expect(data.attendees[0].seatUid).toEqual(secondAttendeeSeatUid);
+              expect(data.attendees[0].createdAt).toBeDefined();
             } else {
               throw new Error("Invalid response data - expected seated booking");
             }
@@ -609,9 +612,11 @@ describe("Bookings Endpoints 2024-08-13", () => {
                 ...attendee?.bookingFieldsResponses,
               },
               metadata: attendee?.metadata,
+              createdAt: expect.any(String)
             });
             expect(data.location).toBeDefined();
             expect(data.absentHost).toEqual(false);
+            expect(data.attendees[0].createdAt).toBeDefined();
             createdSeatedBooking = data;
           } else {
             throw new Error("Invalid response data - expected booking but received array response");
@@ -876,6 +881,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
               expect(data.attendees[0].name).toEqual(nameAttendeeOne);
               expect(data.attendees[0].language).toEqual("it");
               expect(data.attendees[0].seatUid).toBeDefined();
+              expect(data.attendees[0].createdAt).toBeDefined();
               expect(data.location).toBeDefined();
               expect(data.absentHost).toEqual(false);
               booking = data;
@@ -919,6 +925,7 @@ describe("Bookings Endpoints 2024-08-13", () => {
               expect(data.attendees[0].name).toEqual(nameAttendeeOne);
               expect(data.attendees[0].language).toEqual("it");
               expect(data.attendees[0].seatUid).toBeDefined();
+              expect(data.attendees[0].createdAt).toBeDefined();
               expect(data.location).toBeDefined();
               expect(data.absentHost).toEqual(false);
               await bookingsRepositoryFixture.deleteById(data.id);
@@ -1034,9 +1041,11 @@ describe("Bookings Endpoints 2024-08-13", () => {
                     ...body.bookingFieldsResponses,
                   },
                   metadata: body.metadata,
+                  createdAt: expect.any(String)
                 });
                 expect(data.location).toBeDefined();
                 expect(data.absentHost).toEqual(false);
+                expect(data.attendees[0].createdAt).toBeDefined()
                 createdSeatedBooking2 = data;
               } else {
                 throw new Error(

--- a/apps/api/v2/src/platform/bookings/2024-08-13/services/output.service.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/services/output.service.ts
@@ -80,6 +80,7 @@ type DatabaseBooking = Booking & {
     phoneNumber?: string | null;
     noShow: boolean | null;
     bookingSeat?: BookingSeat | null;
+    createdAt?: Date | null
   }[];
   user: DatabaseUser | null;
   createdAt: Date;
@@ -389,6 +390,7 @@ export class OutputBookingsService_2024_08_13 {
             absent: !!attendee.noShow,
             seatUid: attendee.bookingSeat?.referenceUid,
             bookingFieldsResponses: {},
+            createdAt: attendee.createdAt,
           };
           const attendeeParsed = plainToClass(SeatedAttendee, attendeeData, { strategy: "excludeAll" });
           attendeeParsed.bookingFieldsResponses = responses || {};

--- a/apps/api/v2/src/platform/bookings/2024-08-13/services/output.service.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/services/output.service.ts
@@ -390,7 +390,7 @@ export class OutputBookingsService_2024_08_13 {
             absent: !!attendee.noShow,
             seatUid: attendee.bookingSeat?.referenceUid,
             bookingFieldsResponses: {},
-            createdAt: attendee.createdAt,
+            createdAt: attendee.createdAt ? attendee.createdAt.toISOString() : null,
           };
           const attendeeParsed = plainToClass(SeatedAttendee, attendeeData, { strategy: "excludeAll" });
           attendeeParsed.bookingFieldsResponses = responses || {};
@@ -520,6 +520,7 @@ export class OutputBookingsService_2024_08_13 {
             absent: !!attendee.noShow,
             seatUid: attendee.bookingSeat?.referenceUid,
             bookingFieldsResponses: {},
+            createdAt: attendee.createdAt ? attendee.createdAt.toISOString() : null,
           };
           const attendeeParsed = plainToClass(SeatedAttendee, attendeeData, { strategy: "excludeAll" });
           attendeeParsed.bookingFieldsResponses = responses || {};

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -75,7 +75,6 @@ import type {
   AdditionalInformation,
   AppsStatus,
   CalEventResponses,
-  CalendarEvent,
 } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
 import type { EventResult, PartialReference } from "@calcom/types/EventManager";
@@ -1526,6 +1525,7 @@ async function handler(
           id: 0,
           email: bookerEmail,
           name: fullName,
+          createdAt: Date.now(),
           timeZone: reqBody.timeZone,
           locale: null,
           phoneNumber: null,

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -1525,7 +1525,7 @@ async function handler(
           id: 0,
           email: bookerEmail,
           name: fullName,
-          createdAt: Date.now(),
+          createdAt: new Date(),
           timeZone: reqBody.timeZone,
           locale: null,
           phoneNumber: null,

--- a/packages/features/bookings/repositories/AttendeeRepository.ts
+++ b/packages/features/bookings/repositories/AttendeeRepository.ts
@@ -10,6 +10,7 @@ const safeSelect = {
   phoneNumber: true,
   bookingId: true,
   noShow: true,
+  createdAt: true
 };
 
 /**
@@ -101,6 +102,7 @@ export class AttendeeRepository implements IAttendeeRepository {
       phoneNumber: string | null;
       bookingId: number | null;
       noShow: boolean | null;
+      createdAt: Date | null;
     }[]
   > {
     return this.prismaClient.attendee.findMany({

--- a/packages/features/bookings/repositories/BookingSeatRepository.ts
+++ b/packages/features/bookings/repositories/BookingSeatRepository.ts
@@ -34,6 +34,7 @@ export class BookingSeatRepository {
             email: true,
             locale: true,
             timeZone: true,
+            createdAt: true,
           },
         },
       },

--- a/packages/features/tasker/tasks/triggerNoShow/triggerGuestNoShow.ts
+++ b/packages/features/tasker/tasks/triggerNoShow/triggerGuestNoShow.ts
@@ -18,6 +18,7 @@ type UpdatedAttendee = {
   phoneNumber: string | null;
   bookingId: number | null;
   noShow: boolean | null;
+  createdAt: Date | null;
 };
 
 const markGuestAsNoshowInBooking = async ({

--- a/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
@@ -82,6 +82,16 @@ export class SeatedAttendee extends BookingAttendee {
   @IsOptional()
   @Expose()
   metadata?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    type: String,
+    example: "2024-08-13T15:30:00Z",
+    description: "The date and time when the attendee joined the seated booking.",
+  })
+  @IsDateString()
+  @IsOptional()
+  @Expose()
+  createdAt?: string;
 }
 
 class BookingHost {

--- a/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
+++ b/packages/platform/types/bookings/2024-08-13/outputs/booking.output.ts
@@ -85,13 +85,14 @@ export class SeatedAttendee extends BookingAttendee {
 
   @ApiPropertyOptional({
     type: String,
+    nullable: true,
     example: "2024-08-13T15:30:00Z",
     description: "The date and time when the attendee joined the seated booking.",
   })
   @IsDateString()
   @IsOptional()
   @Expose()
-  createdAt?: string;
+  createdAt?: string | null;
 }
 
 class BookingHost {

--- a/packages/prisma/migrations/20260812210054_add_attendee_created_at/migration.sql
+++ b/packages/prisma/migrations/20260812210054_add_attendee_created_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Attendee" ADD COLUMN     "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;

--- a/packages/prisma/migrations/20260812210054_add_attendee_created_at/migration.sql
+++ b/packages/prisma/migrations/20260812210054_add_attendee_created_at/migration.sql
@@ -1,2 +1,3 @@
 -- AlterTable
-ALTER TABLE "public"."Attendee" ADD COLUMN     "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "public"."Attendee" ADD COLUMN "createdAt" TIMESTAMP(3);
+ALTER TABLE "public"."Attendee" ALTER COLUMN "createdAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -834,6 +834,7 @@ model Attendee {
   bookingId   Int?
   bookingSeat BookingSeat?
   noShow      Boolean?     @default(false)
+  createdAt   DateTime?    @default(now())
 
   @@index([email])
   @@index([bookingId])

--- a/packages/testing/src/lib/bookingScenario/bookingScenario.ts
+++ b/packages/testing/src/lib/bookingScenario/bookingScenario.ts
@@ -2183,11 +2183,12 @@ export function getMockBookingReference(
 }
 
 export function getMockBookingAttendee(
-  attendee: Omit<Attendee, "bookingId" | "phoneNumber" | "email" | "noShow"> & {
+  attendee: Omit<Attendee, "bookingId" | "phoneNumber" | "email" | "noShow" | "createdAt"> & {
     bookingSeat?: AttendeeBookingSeatInput;
     phoneNumber?: string | null;
     email: string;
     noShow?: boolean;
+    createdAt?: Date | null;
   }
 ) {
   return {
@@ -2199,6 +2200,7 @@ export function getMockBookingAttendee(
     bookingSeat: attendee.bookingSeat || null,
     phoneNumber: attendee.phoneNumber ?? undefined,
     noShow: attendee.noShow ?? false,
+    createdAt: attendee.createdAt ?? null,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a `createdAt` timestamp to the `Attendee` model so we can tell when an attendee joined a seated booking, and exposes it on the `SeatedAttendee` output in API v2 (2024-08-13).

- Fixes #27785  (GitHub issue number)


#### Image Demo (if applicable):

DB schema of Attendee after changes

<img width="1401" height="207" alt="Screenshot from 2026-08-13 21-27-35" src="https://github.com/user-attachments/assets/51995bd0-8f1b-49d2-bf45-1fbbe4c748df" />


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.