### PR TITLE
fix(bookings): validate team membership before allowing updateWrongAssignmentReportStatus (IDOR)

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
@@ -31,6 +31,21 @@ export const updateWrongAssignmentReportStatusHandler = async ({
     });
   }
 
+  const membership = await prisma.membership.findFirst({
+    where: {
+      userId: user.id,
+      teamId: report.teamId,
+      accepted: true,
+    },
+    select: { id: true },
+  });
+
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You must be a member of the team that owns this report",
+    });
+  }
 
   const updatedReport = await repo.updateStatus({
     id: reportId,


### PR DESCRIPTION
`updateWrongAssignmentReportStatus` accepts a `reportId` from the caller and updates the booking it belongs to, but never verifies that the caller is actually a member of the team that owns the booking. Any authenticated user who knows a report ID can approve or reject wrong-assignment reports for bookings they should have no access to.

This adds a `prisma.membership.findFirst` check after the report is fetched: if the calling user is not an accepted member of the associated team the handler throws FORBIDDEN before making any changes.

Closes #29958

harsh4vardhan