### PR TITLE
fix(eventTypes): replace always-true PermissionCheckService stub with real membership check

### DIFF
--- a/packages/trpc/server/routers/viewer/eventTypes/util.ts
+++ b/packages/trpc/server/routers/viewer/eventTypes/util.ts
@@ -13,8 +13,29 @@ import type { TUpdateInputSchema } from "./types";
 
 type PermissionString = string;
 class PermissionCheckService {
-  constructor(_prisma?: unknown) {}
-  async checkPermission(..._args: unknown[]) { return true; }
+  constructor(private readonly _prismaClient?: typeof prisma) {}
+  async checkPermission({
+    userId,
+    teamId,
+    fallbackRoles,
+  }: {
+    userId: number;
+    teamId: number;
+    permission: string;
+    fallbackRoles?: string[];
+  }): Promise<boolean> {
+    const client = this._prismaClient ?? prisma;
+    const membership = await client.membership.findFirst({
+      where: {
+        userId,
+        teamId,
+        accepted: true,
+        ...(fallbackRoles && fallbackRoles.length > 0 ? { role: { in: fallbackRoles as import("@calcom/prisma/enums").MembershipRole[] } } : {}),
+      },
+      select: { id: true },
+    });
+    return membership !== null;
+  }
   async hasPermission(..._args: unknown[]) { return true; }
   async getTeamIdsWithPermission(..._args: unknown[]): Promise<number[]> { return []; }
 }


### PR DESCRIPTION
createEventPbacProcedure gates team event-type mutations (update, delete). It delegates permission decisions to PermissionCheckService.checkPermission, but the implementation shipped as a stub that returns true unconditionally for every caller.

This means any authenticated user can delete or modify event types belonging to teams they are not a member of. The permission guard is present in the call path but has no effect.

The fix replaces the stub body with a real Prisma query: it looks up an accepted membership row for the calling user in the relevant team, optionally scoped to the required roles, and returns false if no row is found.

Closes #29955

harsh4vardhan