### PR TITLE
fix(bookings): add overlap check before confirming pending booking to prevent double-booking

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -182,6 +182,29 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Booking already confirmed" });
   }
 
+  // Check for conflicting accepted bookings before confirming a pending booking.
+  // Without this check, two concurrent confirmations of PENDING bookings for the
+  // same time slot can both succeed, creating a double-booking.
+  if (confirmed && booking.status === BookingStatus.PENDING && booking.userId) {
+    const conflictingBooking = await prisma.booking.findFirst({
+      where: {
+        userId: booking.userId,
+        status: BookingStatus.ACCEPTED,
+        id: { not: bookingId },
+        startTime: { lt: booking.endTime },
+        endTime: { gt: booking.startTime },
+      },
+      select: { id: true, uid: true },
+    });
+
+    if (conflictingBooking) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: "A confirmed booking already exists that overlaps with this time slot",
+      });
+    }
+  }
+
   // If booking requires payment and is not paid, we don't allow confirmation
   if (confirmed && booking.payment.length > 0 && !booking.paid) {
     await prisma.booking.update({

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -182,9 +182,10 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Booking already confirmed" });
   }
 
-  // Check for conflicting accepted bookings before confirming a pending booking.
-  // Without this check, two concurrent confirmations of PENDING bookings for the
-  // same time slot can both succeed, creating a double-booking.
+  // Guard against double-booking: reject if an accepted booking already overlaps.
+  // Note: the check and the handleConfirmation status update are not fully atomic
+  // (full atomicity requires a DB-level unique constraint or advisory lock). This
+  // closes the most common race window without requiring a schema migration.
   if (confirmed && booking.status === BookingStatus.PENDING && booking.userId) {
     const conflictingBooking = await prisma.booking.findFirst({
       where: {
@@ -194,7 +195,7 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
         startTime: { lt: booking.endTime },
         endTime: { gt: booking.startTime },
       },
-      select: { id: true, uid: true },
+      select: { id: true },
     });
 
     if (conflictingBooking) {
@@ -205,16 +206,22 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     }
   }
 
-  // If booking requires payment and is not paid, we don't allow confirmation
+  // If booking requires payment and is not paid, update status atomically with
+  // a conditional write so a concurrent confirmation cannot race past the check.
   if (confirmed && booking.payment.length > 0 && !booking.paid) {
-    await prisma.booking.update({
+    const updated = await prisma.booking.updateMany({
       where: {
         id: bookingId,
+        status: BookingStatus.PENDING,
       },
       data: {
         status: BookingStatus.ACCEPTED,
       },
     });
+
+    if (updated.count === 0) {
+      throw new TRPCError({ code: "CONFLICT", message: "Booking was already confirmed by another request" });
+    }
 
     return { message: "Booking confirmed", status: BookingStatus.ACCEPTED };
   }

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -182,48 +182,64 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Booking already confirmed" });
   }
 
-  // Guard against double-booking: reject if an accepted booking already overlaps.
-  // Note: the check and the handleConfirmation status update are not fully atomic
-  // (full atomicity requires a DB-level unique constraint or advisory lock). This
-  // closes the most common race window without requiring a schema migration.
-  if (confirmed && booking.status === BookingStatus.PENDING && booking.userId) {
-    const conflictingBooking = await prisma.booking.findFirst({
-      where: {
-        userId: booking.userId,
-        status: BookingStatus.ACCEPTED,
-        id: { not: bookingId },
-        startTime: { lt: booking.endTime },
-        endTime: { gt: booking.startTime },
-      },
-      select: { id: true },
-    });
+  // Atomically claim the booking and guard against double-booking.
+  // A per-user advisory lock serializes concurrent confirmations so the overlap check
+  // and the compare-and-swap status write cannot interleave: a second request waits
+  // until the first transaction commits before reading, and will then see the ACCEPTED row.
+  if (confirmed && booking.status === BookingStatus.PENDING) {
+    const userId = booking.userId;
+    if (userId) {
+      await prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT pg_advisory_xact_lock(${BigInt(userId)})`;
 
-    if (conflictingBooking) {
-      throw new TRPCError({
-        code: "CONFLICT",
-        message: "A confirmed booking already exists that overlaps with this time slot",
+        const conflictingBooking = await tx.booking.findFirst({
+          where: {
+            userId,
+            status: BookingStatus.ACCEPTED,
+            id: { not: bookingId },
+            startTime: { lt: booking.endTime },
+            endTime: { gt: booking.startTime },
+          },
+          select: { id: true },
+        });
+
+        if (conflictingBooking) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "A confirmed booking already exists that overlaps with this time slot",
+          });
+        }
+
+        const updated = await tx.booking.updateMany({
+          where: { id: bookingId, status: BookingStatus.PENDING },
+          data: { status: BookingStatus.ACCEPTED },
+        });
+
+        if (updated.count === 0) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Booking was already confirmed or rejected by another request",
+          });
+        }
       });
+
+      if (booking.payment.length > 0 && !booking.paid) {
+        // Payment path: status already ACCEPTED; return early.
+        return { message: "Booking confirmed", status: BookingStatus.ACCEPTED };
+      }
+      // Non-payment path: falls through to handleConfirmation below, which writes
+      // status=ACCEPTED again (idempotent) and attaches calendar references and metadata.
+    } else if (booking.payment.length > 0 && !booking.paid) {
+      // No userId: payment path without overlap check.
+      const updated = await prisma.booking.updateMany({
+        where: { id: bookingId, status: BookingStatus.PENDING },
+        data: { status: BookingStatus.ACCEPTED },
+      });
+      if (updated.count === 0) {
+        throw new TRPCError({ code: "CONFLICT", message: "Booking was already confirmed by another request" });
+      }
+      return { message: "Booking confirmed", status: BookingStatus.ACCEPTED };
     }
-  }
-
-  // If booking requires payment and is not paid, update status atomically with
-  // a conditional write so a concurrent confirmation cannot race past the check.
-  if (confirmed && booking.payment.length > 0 && !booking.paid) {
-    const updated = await prisma.booking.updateMany({
-      where: {
-        id: bookingId,
-        status: BookingStatus.PENDING,
-      },
-      data: {
-        status: BookingStatus.ACCEPTED,
-      },
-    });
-
-    if (updated.count === 0) {
-      throw new TRPCError({ code: "CONFLICT", message: "Booking was already confirmed by another request" });
-    }
-
-    return { message: "Booking confirmed", status: BookingStatus.ACCEPTED };
   }
 
   // Cache translations to avoid requesting multiple times.

--- a/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/confirm.handler.ts
@@ -182,6 +182,13 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Booking already confirmed" });
   }
 
+  if (confirmed && booking.status !== BookingStatus.PENDING) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Only pending bookings can be confirmed",
+    });
+  }
+
   // Atomically claim the booking and guard against double-booking.
   // A per-user advisory lock serializes concurrent confirmations so the overlap check
   // and the compare-and-swap status write cannot interleave: a second request waits
@@ -407,17 +414,28 @@ export const confirmHandler = async ({ ctx, input }: ConfirmOptions) => {
     );
     evt.conferenceCredentialId = conferenceCredentialId.conferenceCredentialId;
 
-    await handleConfirmation({
-      user: { ...user, credentials: allCredentials },
-      evt,
-      recurringEventId,
-      prisma,
-      bookingId,
-      booking,
-      emailsEnabled,
-      platformClientParams,
-      traceContext,
-    });
+    try {
+      await handleConfirmation({
+        user: { ...user, credentials: allCredentials },
+        evt,
+        recurringEventId,
+        prisma,
+        bookingId,
+        booking,
+        emailsEnabled,
+        platformClientParams,
+        traceContext,
+      });
+    } catch (err) {
+      // If we pre-claimed ACCEPTED via the advisory lock path and handleConfirmation
+      // fails, restore the booking to PENDING so the confirmation can be retried.
+      // When the booking was not pre-claimed this updateMany matches 0 rows (no-op).
+      await prisma.booking.updateMany({
+        where: { id: bookingId, status: BookingStatus.ACCEPTED },
+        data: { status: BookingStatus.PENDING },
+      });
+      throw err;
+    }
   } else {
     evt.rejectionReason = rejectionReason;
     let rejectedBookings: {


### PR DESCRIPTION
Issue #29958 identifies three gaps that together allow double-booking on requiresConfirmation events:

1. **Availability check gap** — `getBusyTimes` only considers `ACCEPTED` bookings as busy, so `PENDING` bookings are invisible to the slot-availability query.
2. **Idempotency key gap** — the idempotency key unique constraint is not applied when a booking transitions from `PENDING` to `ACCEPTED`.
3. **Confirm handler race** — two concurrent confirm requests can both read `PENDING`, pass the status check, and both write `ACCEPTED`.

**This PR closes gap #3.** The confirm handler now:
- Rejects confirmation of already-`ACCEPTED` bookings immediately.
- Rejects confirmation of non-`PENDING` bookings when `confirmed=true`.
- Acquires a per-user PostgreSQL advisory lock inside a transaction, re-checks for an overlapping `ACCEPTED` booking, then uses `updateMany` with `WHERE status = PENDING` as a compare-and-swap so only one concurrent request wins.
- On the payment path (no advisory lock needed), also uses `updateMany` with `WHERE status = PENDING` to catch races.
- Rolls back the booking to `PENDING` if `handleConfirmation` fails after the status was written.

Gaps #1 and #2 require changes to `getBusyTimes` and the booking creation path respectively and will be addressed in follow-up PRs to keep each change reviewable in isolation.

Closes #29958

harsh4vardhan