### PR TITLE
fix: prevent layout shift on Refer and earn page load

### DIFF
--- a/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
+++ b/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
@@ -8,6 +8,8 @@ import { IS_DUB_REFERRALS_ENABLED } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { showToast } from "@calcom/ui/components/toast";
 
+import Loading from "./loading";
+
 const fetchReferralsToken = async () => {
   try {
     const response = await fetch("/api/user/referrals-token");
@@ -47,8 +49,12 @@ export const DubReferralsPage = () => {
     getToken();
   }, [t]);
 
-  if (!IS_DUB_REFERRALS_ENABLED || !token) {
+  if (!IS_DUB_REFERRALS_ENABLED) {
     return null;
+  }
+
+  if (!token) {
+    return <Loading />;
   }
 
   const theme = resolvedTheme === "dark" ? "dark" : "light";

--- a/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
+++ b/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
@@ -32,6 +32,7 @@ const fetchReferralsToken = async () => {
 // The enabled referrals page implementation
 export const DubReferralsPage = () => {
   const [token, setToken] = useState<string | null>(null);
+  const [hasFetchFailed, setHasFetchFailed] = useState(false);
   const { t } = useLocale();
   const { resolvedTheme } = useTheme();
 
@@ -39,10 +40,15 @@ export const DubReferralsPage = () => {
     const getToken = async () => {
       try {
         const publicToken = await fetchReferralsToken();
-        setToken(publicToken);
+        if (publicToken) {
+          setToken(publicToken);
+        } else {
+          setHasFetchFailed(true);
+        }
       } catch (err) {
         console.error("Error fetching referrals token:", err);
         showToast(t("unexpected_error_try_again"), "error");
+        setHasFetchFailed(true);
       }
     };
 
@@ -53,6 +59,10 @@ export const DubReferralsPage = () => {
     return null;
   }
 
+  if (hasFetchFailed) {
+    return null;
+  }
+  
   if (!token) {
     return <Loading />;
   }


### PR DESCRIPTION
Fixes #29950

## What does this PR do?
The "Refer and earn" settings page returned `null` while the Dub referral token was being fetched client-side. This caused the page to collapse to zero height right after the route's loading skeleton unmounted, then "pop" back to full size once the DubEmbed widget mounted , producing the jarring bounce/layout-shift described in the issue.

This PR reuses the existing route `Loading` skeleton while the token fetch is in progress, instead of rendering nothing. The page now holds a consistent height through both the server-suspense phase and the client-side fetch phase, so there's no visible collapse or pop.

The change is minimal , only the null-check branch in `DubReferralsPage.tsx` is modified; no other logic touched.

## Visual Demo
Note: I don't have a real Dub API key in my local environment, so the token fetch ultimately fails locally — the videos below show the loading transition itself rather than the final loaded embed. That's the relevant part for this fix: before, the page visibly collapsed to blank right after the skeleton disappeared; after the fix, the skeleton holds steady with no layout shift until the fetch resolves
(or fails).

#### Video Demo:
**Before fix:**

https://github.com/user-attachments/assets/a4726f83-0edd-4b29-8c77-e04a03895f67

**After fix:**

https://github.com/user-attachments/assets/e459fa75-8052-4d55-b002-7f22a9b634f9


## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. — N/A, this is a UI-only fix with no doc-relevant changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1. Set `NEXT_PUBLIC_DUB_PROGRAM_ID` to any non-empty value in `.env` (this flag gates the whole feature; without a real Dub account the embed itself won't load, but the loading-state fix is still fully visible).
2. Run the app locally, log in as any seeded user (e.g. `pro@example.com`).
3. Open DevTools → Network tab → throttle to "Slow 3G" (makes the transition visible instead of instant).
4. Click your profile name at the bottom of the sidebar → "Refer and earn".
5. Expected: the loading skeleton stays visible and consistently sized for the duration of the fetch — no visible collapse, jump, or bounce.