### PR TITLE
fix(webhooks): restore no-show delay inputs and keep them on toggle

### DIFF
--- a/apps/web/modules/webhooks/components/WebhookForm.tsx
+++ b/apps/web/modules/webhooks/components/WebhookForm.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
-
 import SectionBottomActions from "@calcom/features/settings/SectionBottomActions";
 import customTemplate, { hasTemplateIntegration } from "@calcom/features/webhooks/lib/integrationTemplate";
 import { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
@@ -11,15 +8,18 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { TimeUnit, WebhookTriggerEvents } from "@calcom/prisma/enums";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
-import { Select } from "@calcom/ui/components/form";
-import { TextArea } from "@calcom/ui/components/form";
-import { ToggleGroup } from "@calcom/ui/components/form";
-import { Form } from "@calcom/ui/components/form";
-import { Label } from "@calcom/ui/components/form";
-import { TextField } from "@calcom/ui/components/form";
-import { Switch } from "@calcom/ui/components/form";
-
-
+import {
+  Form,
+  Input,
+  Label,
+  Select,
+  Switch,
+  TextArea,
+  TextField,
+  ToggleGroup,
+} from "@calcom/ui/components/form";
+import { useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import WebhookTestDisclosure from "./WebhookTestDisclosure";
 
 export type TWebhook = RouterOutputs["viewer"]["webhook"]["list"][number];
@@ -294,6 +294,13 @@ const WebhookForm = (props: {
   const time = formMethods.watch("time");
   const timeUnit = formMethods.watch("timeUnit");
 
+  const TIME_UNITS = [TimeUnit.MINUTE, TimeUnit.HOUR, TimeUnit.DAY] as const;
+  const timeUnitOptions = TIME_UNITS.map((unit) => ({
+    value: unit,
+    label: t(`${unit.toLowerCase()}_timeUnit`),
+  }));
+  const selectedTimeUnit = timeUnitOptions.find((option) => option.value === timeUnit) ?? timeUnitOptions[0];
+
   const isCreating = !props?.webhook?.id;
   const needsTime = triggers.some(
     (t) =>
@@ -339,9 +346,9 @@ const WebhookForm = (props: {
     : formMethods.formState.isDirty || changeSecret;
 
   useEffect(() => {
-    if (isCreating && needsTime && !time && !timeUnit) {
-      formMethods.setValue("time", 5, { shouldDirty: true });
-      formMethods.setValue("timeUnit", TimeUnit.MINUTE, { shouldDirty: true });
+    if (needsTime && !time && !timeUnit) {
+      formMethods.setValue("time", 5, { shouldDirty: isCreating });
+      formMethods.setValue("timeUnit", TimeUnit.MINUTE, { shouldDirty: isCreating });
     }
   }, [isCreating, needsTime, time, timeUnit, formMethods]);
 
@@ -432,8 +439,8 @@ const WebhookForm = (props: {
                         shouldDirty: true,
                       });
                     } else {
-                      formMethods.setValue("time", undefined, { shouldDirty: true });
-                      formMethods.setValue("timeUnit", undefined, { shouldDirty: true });
+                      formMethods.setValue("time", null, { shouldDirty: true });
+                      formMethods.setValue("timeUnit", null, { shouldDirty: true });
                     }
                   }}
                 />
@@ -444,8 +451,38 @@ const WebhookForm = (props: {
 
         {showTimeSection && (
           <div className="mt-5">
-            <Label>{t("how_long_after_user_no_show_minutes")}</Label>
-            <div />
+            <Label className="font-sm text-emphasis font-medium">
+              {t("how_long_after_user_no_show_minutes")}
+            </Label>
+            <div className="flex items-center">
+              <Input
+                type="number"
+                min={0}
+                required
+                data-testid="webhook-time"
+                className="m-0! block w-16 rounded-r-none border-default border-r-0 text-sm [appearance:textfield] focus:z-10 focus:border-r"
+                value={time ?? 5}
+                onChange={(e) => {
+                  const next = Number(e.target.value);
+                  formMethods.setValue("time", Number.isFinite(next) ? next : 5, { shouldDirty: true });
+                }}
+              />
+              <Select
+                grow={false}
+                isSearchable={false}
+                options={timeUnitOptions}
+                value={selectedTimeUnit}
+                data-testid="webhook-time-unit"
+                className="block w-auto"
+                innerClassNames={{
+                  control: "rounded-l-none max-h-4 px-3 bg-subtle py-1",
+                }}
+                onChange={(option) => {
+                  if (!option) return;
+                  formMethods.setValue("timeUnit", option.value, { shouldDirty: true });
+                }}
+              />
+            </div>
           </div>
         )}
 

--- a/apps/web/modules/webhooks/components/WebhookListItem.tsx
+++ b/apps/web/modules/webhooks/components/WebhookListItem.tsx
@@ -90,9 +90,22 @@ export default function WebhookListItem(props: {
       await utils.viewer.eventTypes.get.invalidate();
     },
     onError() {
+      setActive(webhook.active);
       toastManager.add({ title: t("something_went_wrong"), type: "error" });
     },
   });
+
+  const toggleWebhookActive = (checked: boolean) => {
+    setActive(checked);
+    toggleWebhook.mutate({
+      id: webhook.id,
+      active: checked,
+      payloadTemplate: webhook.payloadTemplate,
+      eventTypeId: webhook.eventTypeId || undefined,
+      time: webhook.time,
+      timeUnit: webhook.timeUnit,
+    });
+  };
 
   return (
     <ListItem data-testid="webhook-list-item" className="*:px-4">
@@ -186,15 +199,7 @@ export default function WebhookListItem(props: {
                       checked={active}
                       data-testid="webhook-switch"
                       disabled={toggleWebhook.isPending}
-                      onCheckedChange={(checked) => {
-                        setActive(checked);
-                        toggleWebhook.mutate({
-                          id: webhook.id,
-                          active: checked,
-                          payloadTemplate: webhook.payloadTemplate,
-                          eventTypeId: webhook.eventTypeId || undefined,
-                        });
-                      }}
+                      onCheckedChange={toggleWebhookActive}
                     />
                   }
                 />
@@ -285,15 +290,7 @@ export default function WebhookListItem(props: {
                 <MenuCheckboxItem
                   checked={active}
                   disabled={toggleWebhook.isPending}
-                  onCheckedChange={(checked) => {
-                    setActive(checked);
-                    toggleWebhook.mutate({
-                      id: webhook.id,
-                      active: checked,
-                      payloadTemplate: webhook.payloadTemplate,
-                      eventTypeId: webhook.eventTypeId || undefined,
-                    });
-                  }}
+                  onCheckedChange={toggleWebhookActive}
                   variant="switch"
                 >
                   {t("enable_webhook")}

--- a/apps/web/modules/webhooks/views/webhook-edit-view.tsx
+++ b/apps/web/modules/webhooks/views/webhook-edit-view.tsx
@@ -4,7 +4,7 @@ import { WEBHOOK_TRIGGER_EVENTS } from "@calcom/features/webhooks/lib/constants"
 import type { WebhookVersion } from "@calcom/features/webhooks/lib/interface/IWebhookRepository";
 import { subscriberUrlReserved } from "@calcom/features/webhooks/lib/subscriberUrlReserved";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
-import type { WebhookTriggerEvents } from "@calcom/prisma/enums";
+import type { TimeUnit, WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { revalidateWebhooksList } from "@calcom/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/webhooks/(with-loader)/actions";
 import { toastManager } from "@coss/ui/components/toast";
@@ -26,6 +26,8 @@ type WebhookProps = {
   secret: string | null;
   platform: boolean;
   version: WebhookVersion;
+  time: number | null;
+  timeUnit: TimeUnit | null;
 };
 
 export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
@@ -97,8 +99,8 @@ export function EditWebhookView({ webhook }: { webhook?: WebhookProps }) {
           active: values.active,
           payloadTemplate: values.payloadTemplate,
           secret: values.secret,
-          time: values.time,
-          timeUnit: values.timeUnit,
+          time: values.time ?? null,
+          timeUnit: values.timeUnit ?? null,
           version: values.version,
         });
       }}

--- a/packages/trpc/server/routers/viewer/webhook/edit.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/webhook/edit.handler.test.ts
@@ -1,0 +1,111 @@
+import { TimeUnit } from "@calcom/prisma/enums";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockFindUnique,
+  mockUpdate,
+  mockUpdateTriggerForExistingBookings,
+  mockDeleteWebhookScheduledTriggers,
+  mockCancelNoShowTasksForBooking,
+} = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockUpdateTriggerForExistingBookings: vi.fn(),
+  mockDeleteWebhookScheduledTriggers: vi.fn(),
+  mockCancelNoShowTasksForBooking: vi.fn(),
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  prisma: {
+    webhook: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+  },
+}));
+
+vi.mock("@calcom/lib/ssrfProtection", () => ({
+  validateUrlForSSRFSync: vi.fn(() => ({ isValid: true })),
+}));
+
+vi.mock("@calcom/features/webhooks/lib/scheduleTrigger", () => ({
+  updateTriggerForExistingBookings: mockUpdateTriggerForExistingBookings,
+  deleteWebhookScheduledTriggers: mockDeleteWebhookScheduledTriggers,
+  cancelNoShowTasksForBooking: mockCancelNoShowTasksForBooking,
+}));
+
+import { editHandler } from "./edit.handler";
+
+const existingWebhook = {
+  id: "webhook-1",
+  userId: 4,
+  teamId: null,
+  eventTypeId: null,
+  subscriberUrl: "https://example.com/hook",
+  payloadTemplate: null,
+  active: true,
+  eventTriggers: ["AFTER_HOSTS_CAL_VIDEO_NO_SHOW"],
+  secret: null,
+  platform: false,
+  time: 5,
+  timeUnit: TimeUnit.MINUTE,
+  version: "2021-10-20",
+};
+
+describe("editHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue(existingWebhook);
+    mockUpdate.mockImplementation(async ({ data }) => ({
+      ...existingWebhook,
+      ...data,
+    }));
+    mockUpdateTriggerForExistingBookings.mockResolvedValue(undefined);
+    mockDeleteWebhookScheduledTriggers.mockResolvedValue(undefined);
+    mockCancelNoShowTasksForBooking.mockResolvedValue(undefined);
+  });
+
+  it("does not clear time/timeUnit when a partial toggle omits them", async () => {
+    await editHandler({
+      ctx: { user: { id: 4, role: "USER" } },
+      input: {
+        id: existingWebhook.id,
+        active: false,
+        payloadTemplate: null,
+      },
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: existingWebhook.id },
+      data: {
+        active: false,
+        payloadTemplate: null,
+      },
+    });
+    expect(mockUpdate.mock.calls[0][0].data).not.toHaveProperty("time");
+    expect(mockUpdate.mock.calls[0][0].data).not.toHaveProperty("timeUnit");
+  });
+
+  it("still writes explicit time/timeUnit when the form sends them", async () => {
+    await editHandler({
+      ctx: { user: { id: 4, role: "USER" } },
+      input: {
+        id: existingWebhook.id,
+        active: true,
+        payloadTemplate: null,
+        time: 15,
+        timeUnit: "HOUR",
+      },
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: existingWebhook.id },
+      data: {
+        active: true,
+        payloadTemplate: null,
+        time: 15,
+        timeUnit: "HOUR",
+      },
+    });
+  });
+});

--- a/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
+++ b/packages/trpc/server/routers/viewer/webhook/edit.handler.ts
@@ -49,15 +49,11 @@ export const editHandler = async ({ input, ctx }: EditOptions) => {
     }
   }
 
-  const updatedWebhook= await prisma.webhook.update({
+  const updatedWebhook = await prisma.webhook.update({
     where: {
       id,
     },
-    data: {
-      ...data,
-      time: data.time ?? null,
-      timeUnit: data.timeUnit ?? null,
-    },
+    data,
   });
 
   if (data.active) {


### PR DESCRIPTION
The form asked how long to wait after a Cal Video no-show, but there was no input. Toggling the webhook also deleted the saved delay. This puts the number + mins/hours/days field back and stops the toggle from clearing it.

## What does this PR do?

The no-show delay question was visible on the webhook form, but there was no number/unit field, so you could not set the delay. Create still saved a hidden `time: 5`. Toggling the webhook on/off sent a partial edit and wiped `time` / `timeUnit` to `null`, so no-show webhooks would not schedule.

This restores the compact delay control (same pattern as the event-type notice field) and leaves `time` / `timeUnit` unchanged when the client does not send them.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):
### Before

<img width="1692" height="897" alt="Screenshot 2026-08-17 at 12 23 13 AM" src="https://github.com/user-attachments/assets/ff34fb1a-ef7e-45a2-8e24-aa7cac8e114b" />

### After 

<img width="1692" height="897" alt="Screenshot 2026-08-17 at 12 17 40 AM" src="https://github.com/user-attachments/assets/2be63582-3fc8-4911-a8c0-415981dc6851" />

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A no developer docs change
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Go to Settings → Developer → Webhooks → New
2. Keep "After hosts didn't join cal video" / "After guests didn't join cal video"
3. Confirm the delay field shows (`5` + `mins`)
4. Change to `10` and `hours`, create
5. Network create response should have `"time": 10`, `"timeUnit": "HOUR"`
6. Toggle the webhook off, then on
7. Network edit response should still have `"time": 10` (not `null`)
8. Open the webhook again. field should still show 10 hours