### PR TITLE
fix(calendars): tolerate missing destination calendar after credential removal

### DIFF
--- a/packages/features/calendars/lib/getConnectedDestinationCalendars.ts
+++ b/packages/features/calendars/lib/getConnectedDestinationCalendars.ts
@@ -70,9 +70,9 @@ async function handleNoConnectedCalendars(user: UserWithCalendars) {
   log.debug(`No connected calendars, deleting destination calendar if it exists for user ${user.id}`);
 
   if (!user.destinationCalendar) return user;
-  await prisma.destinationCalendar.delete({
-    where: { userId: user.id },
-  });
+  // deleteMany so a stale session destinationCalendar (already cascade-deleted with the
+  // credential) does not throw Prisma P2025 and break connectedCalendars.
+  await DestinationCalendarRepository.deleteByUserId(user.id);
 
   return {
     ...user,
@@ -178,12 +178,21 @@ async function handleDestinationCalendarNotInConnectedCalendars({
     }
   }
 
-  user.destinationCalendar = await prisma.destinationCalendar.update({
+  // Upsert: the session may still reference a destination calendar that was already
+  // cascade-deleted with a failed/removed credential (Prisma P2025 on plain update).
+  user.destinationCalendar = await DestinationCalendarRepository.upsert({
     where: { userId: user.id },
-    data: {
+    update: {
       integration,
       externalId,
       primaryEmail,
+    },
+    create: {
+      userId: user.id,
+      integration,
+      externalId,
+      primaryEmail,
+      credentialId: null,
     },
   });
 

--- a/packages/features/calendars/repositories/DestinationCalendarRepository.test.ts
+++ b/packages/features/calendars/repositories/DestinationCalendarRepository.test.ts
@@ -1,0 +1,38 @@
+import { prisma } from "@calcom/prisma/__mocks__/prisma";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DestinationCalendarRepository } from "./DestinationCalendarRepository";
+
+vi.mock("@calcom/prisma", () => ({
+  prisma,
+}));
+
+describe("DestinationCalendarRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("deleteByUserId", () => {
+    it("uses deleteMany so a missing row does not throw", async () => {
+      prisma.destinationCalendar.deleteMany.mockResolvedValue({ count: 0 });
+
+      await expect(DestinationCalendarRepository.deleteByUserId(42)).resolves.toEqual({ count: 0 });
+
+      expect(prisma.destinationCalendar.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 42 },
+      });
+      expect(prisma.destinationCalendar.delete).not.toHaveBeenCalled();
+    });
+
+    it("deletes an existing destination calendar for the user", async () => {
+      prisma.destinationCalendar.deleteMany.mockResolvedValue({ count: 1 });
+
+      await expect(DestinationCalendarRepository.deleteByUserId(7)).resolves.toEqual({ count: 1 });
+
+      expect(prisma.destinationCalendar.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 7 },
+      });
+    });
+  });
+});

--- a/packages/features/calendars/repositories/DestinationCalendarRepository.ts
+++ b/packages/features/calendars/repositories/DestinationCalendarRepository.ts
@@ -70,6 +70,18 @@ export class DestinationCalendarRepository {
     });
   }
 
+  /**
+   * Idempotent delete — safe when the session still holds a stale destinationCalendar
+   * after the row was already removed (e.g. credential cascade delete).
+   */
+  static async deleteByUserId(userId: number) {
+    return await prisma.destinationCalendar.deleteMany({
+      where: {
+        userId,
+      },
+    });
+  }
+
   static async getByEventTypeId(eventTypeId: number) {
     return await prisma.destinationCalendar.findFirst({
       where: {
@@ -113,6 +125,8 @@ export class DestinationCalendarRepository {
       delegationCredentialId?: string | null;
     };
     create: {
+      userId?: number;
+      eventTypeId?: number;
       integration: string;
       externalId: string;
       credentialId: number | null;


### PR DESCRIPTION
## Summary
- Fixes Prisma `P2025` when `connectedCalendars` tries to delete a destination calendar that was already cascade-deleted with a removed/failed calendar credential (stale session reference).
- Uses idempotent `deleteMany` via `DestinationCalendarRepository.deleteByUserId`, and upserts when reassigning a destination calendar that may no longer exist.
- Adds unit coverage for the idempotent delete path.

Fixes #11336

## Context
Issue #25903 (managed event hidden toggle) already has an open competing PR (#29752) and child-event sync is currently stubbed in cal.diy, so this PR targets a smaller uncontested bug instead.

## Test plan
- [ ] Unit: `DestinationCalendarRepository.deleteByUserId` does not call `delete` and succeeds when count is 0
- [ ] Manually: connect a calendar with broken permissions, remove the calendar app, confirm settings/calendars loads without an internal server error
- [ ] Manually: with a normal connected calendar, destination calendar still creates/updates as before
