### PR TITLE
fix: declare booking field isDefault as boolean in OpenAPI schema

### DIFF
--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -118,6 +118,7 @@ export class EmailDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @IsOptional()
   @DocsPropertyOptional({
+    type: Boolean,
     description: `Can be set to false only for organization team event types and if you also pass booking field {type: "phone", slug: "attendeePhoneNumber", required: true, hidden: false, label: "whatever label"} of booking field type PhoneFieldInput_2024_06_14 - this is done
       to enable phone only bookings where during the booking attendee can provide only their phone number and not provide email, so you must pass to the email booking field {hidden: true, required: false}.
       If true show under event type settings but don't show this booking field in the Booker. If false show in both.`,

--- a/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/outputs/booking-fields.output.ts
@@ -30,6 +30,7 @@ import {
 export class NameDefaultFieldOutput_2024_06_14 extends NameDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -56,6 +57,7 @@ export class NameDefaultFieldOutput_2024_06_14 extends NameDefaultFieldInput_202
 export class SplitNameDefaultFieldOutput_2024_06_14 extends SplitNameDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -78,6 +80,7 @@ export class SplitNameDefaultFieldOutput_2024_06_14 extends SplitNameDefaultFiel
 export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -111,6 +114,7 @@ export class EmailDefaultFieldOutput_2024_06_14 extends EmailDefaultFieldInput_2
 export class LocationDefaultFieldOutput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -151,6 +155,7 @@ export class LocationDefaultFieldOutput_2024_06_14 {
 export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleReasonDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -204,6 +209,7 @@ export class RescheduleReasonDefaultFieldOutput_2024_06_14 extends RescheduleRea
 export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -257,6 +263,7 @@ export class TitleDefaultFieldOutput_2024_06_14 extends TitleDefaultFieldInput_2
 export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -310,6 +317,7 @@ export class NotesDefaultFieldOutput_2024_06_14 extends NotesDefaultFieldInput_2
 export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -363,6 +371,7 @@ export class GuestsDefaultFieldOutput_2024_06_14 extends GuestsDefaultFieldInput
 export class PhoneDefaultFieldOutput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always true because it's a default field",
     example: true,
     default: true,
@@ -416,6 +425,7 @@ export class PhoneDefaultFieldOutput_2024_06_14 {
 export class PhoneFieldOutput_2024_06_14 extends PhoneFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -433,6 +443,7 @@ export class PhoneFieldOutput_2024_06_14 extends PhoneFieldInput_2024_06_14 {
 export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -450,6 +461,7 @@ export class AddressFieldOutput_2024_06_14 extends AddressFieldInput_2024_06_14 
 export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -467,6 +479,7 @@ export class TextFieldOutput_2024_06_14 extends TextFieldInput_2024_06_14 {
 export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -484,6 +497,7 @@ export class UrlFieldOutput_2024_06_14 extends UrlFieldInput_2024_06_14 {
 export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -501,6 +515,7 @@ export class NumberFieldOutput_2024_06_14 extends NumberFieldInput_2024_06_14 {
 export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -518,6 +533,7 @@ export class TextAreaFieldOutput_2024_06_14 extends TextAreaFieldInput_2024_06_1
 export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -535,6 +551,7 @@ export class SelectFieldOutput_2024_06_14 extends SelectFieldInput_2024_06_14 {
 export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -552,6 +569,7 @@ export class MultiSelectFieldOutput_2024_06_14 extends MultiSelectFieldInput_202
 export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -569,6 +587,7 @@ export class MultiEmailFieldOutput_2024_06_14 extends MultiEmailFieldInput_2024_
 export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -586,6 +605,7 @@ export class CheckboxGroupFieldOutput_2024_06_14 extends CheckboxGroupFieldInput
 export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,
@@ -603,6 +623,7 @@ export class RadioGroupFieldOutput_2024_06_14 extends RadioGroupFieldInput_2024_
 export class BooleanFieldOutput_2024_06_14 extends BooleanFieldInput_2024_06_14 {
   @IsBoolean()
   @DocsProperty({
+    type: Boolean,
     description: "This property is always false because it's not default field but custom field",
     example: false,
     default: false,


### PR DESCRIPTION
## What does this PR do?

Fixes #29904

The generated OpenAPI doc says `isDefault` is `type: object`, but the same schema gives it `example: true` and `default: true`, and the API actually returns a boolean. So the spec contradicts itself, and validating a real response against it fails.

## Why it happens

These DTOs live in `packages/platform/types`, which builds with plain `tsc`. The `@nestjs/swagger` CLI plugin that normally infers property types is only configured for `apps/api/v2/src` in `nest-cli.json`, so it never runs on these files. Without it, `@ApiProperty` falls back to `emitDecoratorMetadata`, and TypeScript writes `design:type` based on the type annotation you actually typed, not the one it infers. A property with just an initializer has no annotation, so it gets recorded as `Object`.

You can see both cases in one class:

```ts
isDefault = true;      // no annotation -> Object  -> "type": "object"
hidden!: boolean;      // annotated     -> Boolean -> "type": "boolean"
```

Fix is to pass `type: Boolean` explicitly. `disableOnPrefill` in these same files already does this and documents correctly, so I followed that.

## Scope

The issue lists 7 schemas, but the same pattern is in every booking field output class, so I did all of them:

- 9 classes with `isDefault = true`
- 12 classes with `isDefault = false` (custom fields, same bug, not mentioned in the issue)
- `required = true` in `EmailDefaultFieldInput_2024_06_14`

I included `required` because the repro payload in the issue doesn't validate without it. The parent input class has an un-annotated `required = true`, and that wins over the annotated `required!: boolean` in the derived output class.

22 properties total.

## How should this be tested?

I generated the schemas straight from the compiled classes using `@nestjs/swagger`'s `SchemaObjectFactory` and checked the output:

- all 41 `isDefault` / `required` properties now come out as `"type": "boolean"`, none left as `object`
- the exact payload from the issue validates against `EmailDefaultFieldOutput_2024_06_14`
- running the same payload against the old schema fails with `must be object`, which matches the report

No env vars or test data needed, it's a type metadata change.

## Note on openapi.json

This changes source files only. `docs/api-reference/v2/openapi.json` still needs regenerating with `yarn generate-swagger`. I couldn't run it locally because it boots the whole Nest app and needs the full platform build chain plus a database. Happy to add the regenerated file here if a maintainer would rather it go in the same PR.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
