### PR TITLE
fix(ci): stop using the secrets context in if conditions

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -8,9 +8,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-key:
+    name: Check for lingo.dev key
+    runs-on: ubuntu-latest
+    outputs:
+      has-key: ${{ steps.check.outputs.has-key }}
+    steps:
+      - id: check
+        env:
+          LINGO_KEY: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY }}
+        run: |
+          if [ -n "$LINGO_KEY" ]; then
+            echo "has-key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-key=false" >> "$GITHUB_OUTPUT"
+          fi
+
   i18n:
     name: Run i18n
-    if: ${{ secrets.CI_LINGO_DOT_DEV_API_KEY != '' }}
+    needs: check-key
+    if: needs.check-key.outputs.has-key == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+      SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -106,7 +107,7 @@ jobs:
           use-as-latest: "true"
 
       - name: Notify Slack on Success
-        if: success() && secrets.CI_SLACK_WEBHOOK_URL != ''
+        if: success() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
@@ -117,7 +118,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
 
       - name: Notify Slack on Failure
-        if: failure() && secrets.CI_SLACK_WEBHOOK_URL != ''
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
@@ -133,6 +134,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+      SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -154,7 +156,7 @@ jobs:
           push-image: ${{ (github.event_name == 'push' || inputs.PUSH_IMAGE) && 'true' || 'false' }}
 
       - name: Notify Slack on Success
-        if: success() && secrets.CI_SLACK_WEBHOOK_URL != ''
+        if: success() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |
@@ -165,7 +167,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
 
       - name: Notify Slack on Failure
-        if: failure() && secrets.CI_SLACK_WEBHOOK_URL != ''
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |


### PR DESCRIPTION
## What does this PR do?

Two workflows have not run since #28903 landed on 2026-04-15. Both use the `secrets` context inside an `if:` condition, which is not allowed, so GitHub rejects the workflow file at startup and creates no jobs at all.

| workflow | invalid `if:` | recent runs |
|---|---|---|
| `i18n.yml` | 1, job level | 20 of 20 failed |
| `release-docker.yaml` | 4, step level | 100 of 100 failed, 0 successes |

The Docker one is the reason this is worth fixing now: there has been no successful `Release Docker` run since 2026-04-15, so no image has been published from this workflow in about four months. Every one of those runs reports `jobs = 0`, which is the signature of a workflow that never parsed rather than a build that failed.

`secrets` is not one of the contexts available in `jobs.<id>.if` (which allows `github`, `needs`, `vars`, `inputs`) or in `jobs.<id>.steps.<id>.if` (which allows `github`, `needs`, `strategy`, `matrix`, `job`, `runner`, `env`, `vars`, `steps`, `inputs`). It is available in `env:` and `with:`, which is why the surrounding lines in these same files are fine.

I checked all 50 workflow files and these 5 lines are the only occurrences.

### The fix

`i18n.yml` evaluates the key in a small guard job and gates the real job on its output. `needs` is valid in a job-level `if`, and the job still skips entirely when the key is unset.

`release-docker.yaml` maps the webhook into the job-level `env` block each job already has, and the four conditions test `env.SLACK_WEBHOOK_URL` instead. `env` is valid in a step-level `if`. The existing step-level `env:` entries are untouched, since the Slack action reads them.

## Visual Demo (For contributors especially)

Workflow changes do not really have a screenshot, so instead here is a minimal reproduction with both broken patterns and both fixes, run on real Actions infrastructure:

https://github.com/tushardev-365/ci-context-probe

| workflow | pattern | result |
|---|---|---|
| `a-job-level.yml` | `secrets` in a job-level `if` | failed at startup, 0 jobs |
| `b-step-level.yml` | `secrets` in a step-level `if` | failed at startup, 0 jobs |
| `d-fix-guard-job.yml` | guard job plus `needs`, as used here for `i18n.yml` | passed, gated job correctly **skipped** |
| `e-fix-step-env.yml` | job `env` read by a step `if`, as used here for `release-docker.yaml` | passed, notify steps correctly **skipped** |

A and B reproduce the exact failure shape seen on `main`: the run shows up under its file path instead of its `name:`, because the file never parsed far enough to read the name. D and E confirm the replacements both parse and keep the original skip behaviour when the secret is absent.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, CI workflow only.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. — There is no test harness for workflow files in this repo, so instead both replacements were executed on Actions in the linked repro above, which is the closest equivalent I could give you. Both files also parse under `yaml.safe_load`.

## How should this be tested?

No environment variables or test data are needed.

The honest limitation is that I cannot run either workflow against this repo. `i18n.yml` is `push` to `main` only, and `release-docker.yaml` triggers on `v*` tags or `workflow_dispatch`, neither of which I can fire from a fork. Once this is on `main`, a `workflow_dispatch` of `Release Docker` is the fastest confirmation, and the thing to look for is simply that jobs get created at all, since today the run ends with zero.

Expected after merge, with the secrets set as they are now:

- `Release Docker` reaches `prepare`, `release-amd64` and `release-arm` instead of dying at startup.
- Slack notify steps run as before when `CI_SLACK_WEBHOOK_URL` is set, and skip when it is not.
- `i18n.yml` runs the `check-key` guard, then runs `Run i18n` if the lingo.dev key is set, and skips it if not.

One thing I noticed and deliberately left alone: `i18n.yml` passes `repositories: 'cal.com'` to the app token step. That may want to be `cal.diy` after the rename, but the redirect might well cover it, and it is a different concern from the parse error, so I did not want to fold an unverified change into this fix.

## Checklist

- My PR is small and touches only the two broken workflow files.
