### PR TITLE
fix(paypal): don't scale zero-decimal currency amounts on order creation

### DIFF
--- a/packages/app-store/paypal/lib/Paypal.test.ts
+++ b/packages/app-store/paypal/lib/Paypal.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "vitest-fetch-mock";
+
+import Paypal from "./Paypal";
+
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+  prisma: {},
+}));
+
+const ORDER_ENDPOINT = "/v2/checkout/orders";
+
+const createOrderWith = async ({
+  amount,
+  currency,
+}: {
+  amount: number;
+  currency: string;
+}): Promise<{ currency_code: string; value: string }> => {
+  fetchMock.resetMocks();
+  // First fetch is the OAuth token request, second is the order creation.
+  fetchMock.mockResponseOnce(JSON.stringify({ access_token: "test-token", expires_in: 3600 }));
+  fetchMock.mockResponseOnce(JSON.stringify({ id: "TEST_ORDER_ID" }));
+
+  const paypal = new Paypal({ clientId: "test-client-id", secretKey: "test-secret-key" });
+
+  await paypal.createOrder({
+    referenceId: "test-reference-id",
+    amount,
+    currency,
+    returnUrl: "https://example.com/return",
+    cancelUrl: "https://example.com/cancel",
+  });
+
+  const orderCall = fetchMock.mock.calls.find(([url]) => String(url).includes(ORDER_ENDPOINT));
+  if (!orderCall) throw new Error("Order creation request was never made");
+
+  return JSON.parse(String(orderCall[1]?.body)).purchase_units[0].amount;
+};
+
+describe("Paypal.createOrder", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // JPY is stored unscaled by `convertToSmallestCurrencyUnit`, so the stored amount is
+  // already the amount to charge. Scaling it down bills the attendee 1% of the price.
+  it("sends JPY amounts unscaled", async () => {
+    expect(await createOrderWith({ amount: 1000, currency: "JPY" })).toEqual({
+      currency_code: "JPY",
+      value: "1000",
+    });
+  });
+
+  // HUF and TWD also reject decimals at PayPal, but `convertToSmallestCurrencyUnit` stores
+  // them scaled, so they must keep going through the minor-unit conversion.
+  // https://developer.paypal.com/api/rest/reference/currency-codes/
+  it.each([
+    { currency: "USD", amount: 1000, expected: "10" },
+    { currency: "EUR", amount: 1050, expected: "10.5" },
+    { currency: "HUF", amount: 5000, expected: "50" },
+    { currency: "TWD", amount: 300, expected: "3" },
+  ])("converts $currency amounts from minor units", async ({ currency, amount, expected }) => {
+    expect(await createOrderWith({ amount, currency })).toEqual({
+      currency_code: currency,
+      value: expected,
+    });
+  });
+});

--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
 import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
@@ -85,7 +86,7 @@ class Paypal {
           reference_id: referenceId,
           amount: {
             currency_code: currency,
-            value: (amount / 100).toString(),
+            value: convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString(),
           },
         },
       ],


### PR DESCRIPTION
## What does this PR do?

- Fixes #29983

PayPal order creation divided every amount by 100 before sending it, regardless of currency:

```ts
value: (amount / 100).toString(),
```

JPY has no minor unit, so `convertToSmallestCurrencyUnit` stores a JPY price **unscaled**. Dividing it by 100 therefore corrupts the amount, and a ¥10,000 event asks PayPal to collect **¥100** — 1% of the price the attendee agreed to. It fails silently: the booking page shows ¥10,000, the `Payment` row records `10000`, and the booking is confirmed as paid.

The rest of the currency handling is already zero-decimal aware — the price input (`EventTypeAppSettingsInterface`), add-on pricing (`handlePayment`) and display (`formatPrice`) all route through `packages/lib/currencyConversions.ts`. Only the order-creation path did not, so the amount charged diverged from the amount stored and displayed. This change routes it through the same helper.

**Scope:** among PayPal's supported currencies, JPY is the only one affected, because it is the only currency that is both zero-decimal in `currencyConversions.ts` and supported by PayPal. HUF and TWD also reject decimals at PayPal but are stored scaled, so they must keep going through the minor-unit conversion — the added tests pin them, along with USD and EUR, to their existing behaviour. Both the on-booking (capture) and hold (authorize) options are fixed, since both create the order through this path.

As noted in the issue, adding capture-time validation that the captured amount matches the expected amount is **intentionally out of scope** here — it is a separate change, and this PR is deliberately limited to correcting the conversion.

## Visual Demo (For contributors especially)

There is no UI surface for this change: the incorrect amount is computed server-side in the outgoing PayPal order request body, and the Cal.diy booking page renders the *correct* price both before and after the fix. Screenshots of the UI would therefore look identical and prove nothing.

The equivalent evidence is the amount in the outgoing request, captured by the regression test.

**Before (fix reverted, test in place)** — the JPY case fails, every other currency passes:

```
 × sends JPY amounts unscaled
 ✓ converts 'USD' amounts from minor units
 ✓ converts 'EUR' amounts from minor units
 ✓ converts 'HUF' amounts from minor units
 ✓ converts 'TWD' amounts from minor units

 FAIL  Paypal.test.ts > Paypal.createOrder > sends JPY amounts unscaled
 AssertionError: expected { currency_code: 'JPY', value: '10' } to deeply equal { currency_code: 'JPY', value: '1000' }

 Test Files  1 failed (1)
```

**After (this PR)**:

```
 ✓ packages/app-store/paypal/lib/Paypal.test.ts (5 tests) 15ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

End-to-end, traced through the repository's own helpers:

| Organizer configures | Stored `price` | Booker is shown | Sent to PayPal (before) | Sent to PayPal (after) |
| --- | --- | --- | --- | --- |
| 10000 JPY | `10000` | ¥10,000 | `"100"` ❌ | `"10000"` ✅ |
| 50 USD | `5000` | $50.00 | `"50"` ✅ | `"50"` ✅ |

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, this is an internal currency-conversion fix with no documented behaviour change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or PayPal credentials are needed for the automated test:

```bash
TZ=UTC yarn vitest run packages/app-store/paypal/lib/Paypal.test.ts
```

The test mocks the OAuth token request and the order request, then asserts the `purchase_units[0].amount` of the outgoing body. To see it fail without the fix, revert the one-line change in `Paypal.ts` and re-run.

To verify manually against PayPal sandbox:

- **Minimal test data:** an event type with the PayPal app enabled, currency **JPY**, price **10000**.
- **Expected (happy path):** the PayPal checkout requests **¥10,000**, matching the booking page and the `Payment` row. Before this change it requested ¥100.
- Repeat with currency **USD** and price **50** to confirm unchanged behaviour: PayPal should request **$50.00**.
- A JPY price that is not a multiple of 100 (e.g. `1050`) previously produced `"10.5"`, which PayPal rejects because JPY does not support decimals; it now correctly sends `"1050"`.

## Checklist
