### PR TITLE
fix: verify team membership before updating wrong assignment report status

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.test.ts
+++ b/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.test.ts
@@ -1,0 +1,143 @@
+import { WrongAssignmentReportStatus } from "@calcom/prisma/enums";
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateWrongAssignmentReportStatusHandler } from "./updateWrongAssignmentReportStatus.handler";
+
+const mockFindTeamIdById = vi.fn();
+const mockUpdateStatus = vi.fn();
+
+const { mockGetAdminOrOwnerMembership } = vi.hoisted(() => ({
+  mockGetAdminOrOwnerMembership: vi.fn(),
+}));
+
+vi.mock("@calcom/features/bookings/repositories/WrongAssignmentReportRepository", () => {
+  return {
+    WrongAssignmentReportRepository: class MockWrongAssignmentReportRepository {
+      findTeamIdById = mockFindTeamIdById;
+      updateStatus = mockUpdateStatus;
+    },
+  };
+});
+vi.mock("@calcom/features/membership/repositories/MembershipRepository", () => {
+  return {
+    MembershipRepository: {
+      getAdminOrOwnerMembership: mockGetAdminOrOwnerMembership,
+    },
+  };
+});
+vi.mock("@calcom/prisma", () => ({
+  default: {},
+}));
+
+describe("updateWrongAssignmentReportStatusHandler", () => {
+  const mockUser = {
+    id: 1,
+    email: "reviewer@example.com",
+    name: "Reviewer User",
+  };
+
+  const mockInput = {
+    reportId: "report-uuid-123",
+    status: WrongAssignmentReportStatus.RESOLVED,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws NOT_FOUND when the report doesn't exist", async () => {
+    mockFindTeamIdById.mockResolvedValue(null);
+
+    await expect(
+      updateWrongAssignmentReportStatusHandler({
+        ctx: { user: mockUser },
+        input: mockInput,
+      })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Report not found",
+    });
+
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("throws FORBIDDEN when the report has no teamId", async () => {
+    mockFindTeamIdById.mockResolvedValue({ id: mockInput.reportId, teamId: null });
+
+    await expect(
+      updateWrongAssignmentReportStatusHandler({
+        ctx: { user: mockUser },
+        input: mockInput,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "You don't have permission to update this report",
+    });
+
+    expect(mockGetAdminOrOwnerMembership).not.toHaveBeenCalled();
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("throws FORBIDDEN when the caller is not an admin/owner of the report's team", async () => {
+    mockFindTeamIdById.mockResolvedValue({ id: mockInput.reportId, teamId: 5 });
+    mockGetAdminOrOwnerMembership.mockResolvedValue(null);
+
+    await expect(
+      updateWrongAssignmentReportStatusHandler({
+        ctx: { user: mockUser },
+        input: mockInput,
+      })
+    ).rejects.toThrow(TRPCError);
+
+    expect(mockGetAdminOrOwnerMembership).toHaveBeenCalledWith(mockUser.id, 5);
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it("updates the report status when the caller is an admin/owner of the report's team", async () => {
+    mockFindTeamIdById.mockResolvedValue({ id: mockInput.reportId, teamId: 5 });
+    mockGetAdminOrOwnerMembership.mockResolvedValue({ id: "membership-1" });
+    mockUpdateStatus.mockResolvedValue({
+      id: mockInput.reportId,
+      status: mockInput.status,
+      reviewedById: mockUser.id,
+      reviewedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const result = await updateWrongAssignmentReportStatusHandler({
+      ctx: { user: mockUser },
+      input: mockInput,
+    });
+
+    expect(mockUpdateStatus).toHaveBeenCalledWith({
+      id: mockInput.reportId,
+      status: mockInput.status,
+      reviewedById: mockUser.id,
+    });
+    expect(result).toEqual({
+      success: true,
+      report: {
+        id: mockInput.reportId,
+        status: mockInput.status,
+        reviewedById: mockUser.id,
+        reviewedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+  });
+
+  it("does not let a member from a different team update the report (IDOR check)", async () => {
+    mockFindTeamIdById.mockResolvedValue({ id: mockInput.reportId, teamId: 5 });
+    mockGetAdminOrOwnerMembership.mockResolvedValue(null);
+
+    await expect(
+      updateWrongAssignmentReportStatusHandler({
+        ctx: { user: { ...mockUser, id: 999 } },
+        input: mockInput,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+
+    expect(mockGetAdminOrOwnerMembership).toHaveBeenCalledWith(999, 5);
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
@@ -1,10 +1,9 @@
 import { WrongAssignmentReportRepository } from "@calcom/features/bookings/repositories/WrongAssignmentReportRepository";
+import { MembershipRepository } from "@calcom/features/membership/repositories/MembershipRepository";
 import prisma from "@calcom/prisma";
-import { MembershipRole } from "@calcom/prisma/enums";
 import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 import { TRPCError } from "@trpc/server";
 import type { TUpdateWrongAssignmentReportStatusInputSchema } from "./updateWrongAssignmentReportStatus.schema";
-
 
 type UpdateWrongAssignmentReportStatusOptions = {
   ctx: {
@@ -31,6 +30,18 @@ export const updateWrongAssignmentReportStatusHandler = async ({
     });
   }
 
+  // Reports for non-team bookings have no teamId to authorize against, so deny by default.
+  let membership = null;
+  if (report.teamId) {
+    membership = await MembershipRepository.getAdminOrOwnerMembership(user.id, report.teamId);
+  }
+
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You don't have permission to update this report",
+    });
+  }
 
   const updatedReport = await repo.updateStatus({
     id: reportId,


### PR DESCRIPTION
## Summary

- Fixes an IDOR in `updateWrongAssignmentReportStatus` (#29957): the handler fetched a report's `teamId` but never checked it against the caller, so any authenticated user could change the status of any team's wrong-assignment reports.
- The handler now requires the caller to be an admin/owner of the report's team (`MembershipRepository.getAdminOrOwnerMembership`) before allowing the update, and denies by default when the report has no team.

## Test plan

- [x] Added unit tests covering: report not found, no team on report, non-admin caller, cross-team caller, and the happy path
- [x] `yarn vitest run packages/trpc/server/routers/viewer/bookings/` — 40/40 passing, no regressions
- [x] `tsc --noEmit` on `packages/trpc` — 0 errors
- [x] Verified the new tests fail against the original vulnerable code and pass against the fix