### PR TITLE
feat: add OIDC identity provider enum value

### DIFF
--- a/packages/prisma/migrations/20260818150000_add_oidc_identity_provider/migration.sql
+++ b/packages/prisma/migrations/20260818150000_add_oidc_identity_provider/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "IdentityProvider" ADD VALUE 'OIDC';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -346,6 +346,7 @@ enum IdentityProvider {
   GOOGLE
   SAML
   AZUREAD
+  OIDC
 }
 
 model DestinationCalendar {


### PR DESCRIPTION
## Summary

- First of a small sequence of PRs implementing generic OIDC login for self-hosters (#29945): lets self-hosters point Cal.diy at any OIDC-compliant identity provider (Authentik, Keycloak, Authelia, Okta) via `.well-known/openid-configuration` discovery.
- This PR only adds `OIDC` to the `IdentityProvider` enum + migration. No application code references it yet, so it's safe to merge/deploy standalone ahead of the rest.
- Follow-up PRs: (2) NextAuth provider registration + signIn/account-linking wiring, (3) login/signup UI.

## Test plan

- [x] `yarn prisma generate` regenerates types successfully; `OIDC` present in generated enums
- [x] `tsc --noEmit` on `packages/trpc` (consumer of the enum) — 0 errors
- [x] Migration SQL matches this repo's existing pattern for additive enum values (`ALTER TYPE ... ADD VALUE`), no data rewrite