### PR TITLE
feat: add OIDC login button to login and signup pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,7 @@ OUTLOOK_LOGIN_ENABLED=false
 #    and redirect URI: {WEBAPP_URL}/api/auth/callback/oidc
 # 2. Set OIDC_CLIENT_ID / OIDC_CLIENT_SECRET from that application
 # 3. Set OIDC_ISSUER to your IdP's issuer URL, e.g. https://authentik.example.com/application/o/cal-diy/
-#    Cal.diy appends /.well-known/openid-configuration to discover endpoints automatically (RFC 8414),
+#    Cal.diy appends /.well-known/openid-configuration to discover endpoints automatically (OpenID Connect Discovery 1.0),
 #    and always uses PKCE + state for the authorization code flow.
 # 4. Set OIDC_PROVIDER_NAME to whatever you want the login button to display, e.g. "Authentik"
 # 5. Set OIDC_LOGIN_ENABLED to `true`

--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,25 @@ NEXT_PUBLIC_FRESHCHAT_HOST=
 # Microsoft OAuth credentials
 OUTLOOK_LOGIN_ENABLED=false
 
+# Generic OIDC login (Authentik, Keycloak, Authelia, Okta, etc.)
+# To enable login via any OIDC-compliant identity provider:
+# 1. Register an OAuth/OIDC application in your IdP with a confidential client
+#    and redirect URI: {WEBAPP_URL}/api/auth/callback/oidc
+# 2. Set OIDC_CLIENT_ID / OIDC_CLIENT_SECRET from that application
+# 3. Set OIDC_ISSUER to your IdP's issuer URL, e.g. https://authentik.example.com/application/o/cal-diy/
+#    Cal.diy appends /.well-known/openid-configuration to discover endpoints automatically (RFC 8414),
+#    and always uses PKCE + state for the authorization code flow.
+# 4. Set OIDC_PROVIDER_NAME to whatever you want the login button to display, e.g. "Authentik"
+# 5. Set OIDC_LOGIN_ENABLED to `true`
+# Note: only one OIDC provider can be configured at a time.
+# Your IdP must include the `email_verified` claim (standard for Authentik/Keycloak/Okta) -
+# without it, OIDC logins are rejected rather than trusted implicitly.
+OIDC_LOGIN_ENABLED=false
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_ISSUER=
+OIDC_PROVIDER_NAME=
+
 
 # For holiday feature:
 # Step-by-step: Get a Google Calendar API Key

--- a/apps/web/lib/signup/getServerSideProps.tsx
+++ b/apps/web/lib/signup/getServerSideProps.tsx
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { IS_OIDC_LOGIN_ENABLED, OIDC_PROVIDER_NAME } from "@calcom/features/auth/lib/oidc";
 import { getOrgUsernameFromEmail } from "@calcom/features/auth/signup/utils/getOrgUsernameFromEmail";
 import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import { IS_SELF_HOSTED, WEBAPP_URL } from "@calcom/lib/constants";
@@ -56,6 +57,8 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const props = {
     redirectUrl,
     isGoogleLoginEnabled: IS_GOOGLE_LOGIN_ENABLED,
+    isOidcLoginEnabled: IS_OIDC_LOGIN_ENABLED,
+    oidcProviderName: OIDC_PROVIDER_NAME,
 
     prepopulateFormValues: undefined,
     emailVerificationEnabled,

--- a/apps/web/modules/auth/hooks/useLastUsed.tsx
+++ b/apps/web/modules/auth/hooks/useLastUsed.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect } from "react";
-
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { localStorage } from "@calcom/lib/webstorage";
 import classNames from "@calcom/ui/classNames";
+import { useEffect, useState } from "react";
 
-type LoginType = "saml" | "google" | "microsoft" | "credentials";
+type LoginType = "saml" | "google" | "microsoft" | "oidc" | "credentials";
 
 export function useLastUsed() {
   const [lastUsed, setLastUsed] = useState<LoginType>();

--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import process from "node:process";
 import { ErrorCode } from "@calcom/features/auth/lib/ErrorCode";
 import { HOSTED_CAL_FEATURES, WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
 import { emailRegex } from "@calcom/lib/emailSchema";
@@ -36,13 +37,9 @@ interface LoginValues {
   csrfToken: string;
 }
 
-const MicrosoftIcon = () => (
-  <img className="size-4" src="/microsoft-logo.svg" alt="" />
-);
+const MicrosoftIcon = () => <img className="size-4" src="/microsoft-logo.svg" alt="" />;
 
-const GoogleIcon = () => (
-  <img className="size-4" src="/google-icon-colored.svg" alt="" />
-);
+const GoogleIcon = () => <img className="size-4" src="/google-icon-colored.svg" alt="" />;
 
 function BackgroundGrid() {
   const rows = 9;
@@ -105,6 +102,8 @@ export default function Login({
   csrfToken,
   isGoogleLoginEnabled,
   isOutlookLoginEnabled,
+  isOidcLoginEnabled,
+  oidcProviderName,
   totpEmail,
 }: PageProps) {
   const searchParams = useCompatSearchParams();
@@ -170,7 +169,7 @@ export default function Login({
     else setErrorMessage(errorMessages[res.error] || t("something_went_wrong"));
   };
 
-  const showSocialLogin = isGoogleLoginEnabled || isOutlookLoginEnabled;
+  const showSocialLogin = isGoogleLoginEnabled || isOutlookLoginEnabled || isOidcLoginEnabled;
   const showSignupLink =
     process.env.NEXT_PUBLIC_DISABLE_SIGNUP !== "true" && searchParams?.get("register") !== "false";
 
@@ -228,6 +227,24 @@ export default function Login({
                       <MicrosoftIcon />
                       <span>{t("signin_with_microsoft")}</span>
                       {lastUsed === "microsoft" && <LastUsed />}
+                    </Button>
+                  )}
+                  {isOidcLoginEnabled && (
+                    <Button
+                      variant="outline"
+                      className="w-full py-1"
+                      disabled={formState.isSubmitting}
+                      data-testid="oidc"
+                      onClick={async (e) => {
+                        e.preventDefault();
+                        setLastUsed("oidc");
+                        await signIn("oidc", {
+                          callbackUrl,
+                        });
+                      }}>
+                      <Icon name="key" className="size-4" />
+                      <span>{t("continue_with_oidc", { providerName: oidcProviderName })}</span>
+                      {lastUsed === "oidc" && <LastUsed />}
                     </Button>
                   )}
                 </div>

--- a/apps/web/modules/signup-view.tsx
+++ b/apps/web/modules/signup-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import process from "node:process";
 import getStripe from "@calcom/app-store/stripepayment/lib/client";
 import { getPremiumPlanPriceValue } from "@calcom/app-store/stripepayment/lib/utils";
 import {
@@ -22,6 +23,7 @@ import {
 } from "@calcom/lib/constants";
 import { isENVDev } from "@calcom/lib/env";
 import { fetchUsername } from "@calcom/lib/fetchUsername";
+import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { pushGTMEvent } from "@calcom/lib/gtm";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 import { useDebounce } from "@calcom/lib/hooks/useDebounce";
@@ -195,6 +197,8 @@ export default function Signup({
   orgSlug,
   isGoogleLoginEnabled,
   isOutlookLoginEnabled,
+  isOidcLoginEnabled,
+  oidcProviderName,
   orgAutoAcceptEmail,
   redirectUrl,
   emailVerificationEnabled,
@@ -205,6 +209,7 @@ export default function Signup({
   const [usernameTaken, setUsernameTaken] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false);
+  const [isOidcLoading, setIsOidcLoading] = useState(false);
   const [accountUnderReview, setAccountUnderReview] = useState(false);
   const [displayEmailForm, setDisplayEmailForm] = useState(token);
   const [turnstileKey, setTurnstileKey] = useState(0);
@@ -511,15 +516,8 @@ export default function Signup({
                           setPremium={(value) => setPremiumUsername(value)}
                           addOnLeading={
                             orgSlug
-                              ? truncateDomain(
-                                  `${WEBAPP_URL.replace(
-                                    URL_PROTOCOL_REGEX,
-                                    ""
-                                  )}/`
-                                )
-                              : truncateDomain(
-                                  `${WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`
-                                )
+                              ? truncateDomain(`${WEBAPP_URL.replace(URL_PROTOCOL_REGEX, "")}/`)
+                              : truncateDomain(`${WEBSITE_URL.replace(URL_PROTOCOL_REGEX, "")}/`)
                           }
                         />
                       ) : null}
@@ -700,7 +698,44 @@ export default function Signup({
                       </div>
                     )}
 
-                    {(isGoogleLoginEnabled || isOutlookLoginEnabled) && (
+                    {isOidcLoginEnabled && (
+                      <div className="flex flex-col gap-2 md:flex-row">
+                        <Button
+                          color="secondary"
+                          loading={isOidcLoading}
+                          disabled={isGoogleLoading || isMicrosoftLoading}
+                          CustomStartIcon={
+                            <Icon
+                              name="key"
+                              className={classNames(
+                                "mr-2 size-4 text-subtle",
+                                premiumUsername && "opacity-50"
+                              )}
+                            />
+                          }
+                          className={classNames("w-full justify-center rounded-md text-center")}
+                          data-testid="continue-with-oidc-button"
+                          onClick={async () => {
+                            posthog.capture("signup_oidc_button_clicked", {
+                              has_token: !!token,
+                              is_org_invite: isOrgInviteByLink,
+                              org_slug: orgSlug,
+                              has_prepopulated_username: !!prepopulateFormValues?.username,
+                            });
+                            setIsOidcLoading(true);
+                            const callbackUrlParam = searchParams?.get("callbackUrl");
+                            const callbackUrl =
+                              getSafeRedirectUrl(
+                                callbackUrlParam ? `${WEBAPP_URL}/${callbackUrlParam}` : undefined
+                              ) ?? undefined;
+                            await signIn("oidc", { callbackUrl });
+                          }}>
+                          {t("continue_with_oidc", { providerName: oidcProviderName })}
+                        </Button>
+                      </div>
+                    )}
+
+                    {(isGoogleLoginEnabled || isOutlookLoginEnabled || isOidcLoginEnabled) && (
                       <div>
                         <div className="relative flex items-center">
                           <div className="grow border-subtle border-t" />

--- a/apps/web/server/lib/auth/login/getServerSideProps.tsx
+++ b/apps/web/server/lib/auth/login/getServerSideProps.tsx
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { getServerSession } from "@calcom/features/auth/lib/getServerSession";
+import { IS_OIDC_LOGIN_ENABLED, OIDC_PROVIDER_NAME } from "@calcom/features/auth/lib/oidc";
 import { WEBSITE_URL } from "@calcom/lib/constants";
 import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import prisma from "@calcom/prisma";
@@ -89,6 +90,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       csrfToken: await getCsrfToken(context),
       isGoogleLoginEnabled: IS_GOOGLE_LOGIN_ENABLED,
       isOutlookLoginEnabled: false,
+      isOidcLoginEnabled: IS_OIDC_LOGIN_ENABLED,
+      oidcProviderName: OIDC_PROVIDER_NAME,
       totpEmail,
     },
   };

--- a/packages/features/auth/lib/identityProviders.test.ts
+++ b/packages/features/auth/lib/identityProviders.test.ts
@@ -6,7 +6,7 @@ describe("identityProviders", () => {
   describe("NEXTAUTH_TO_IDENTITY_PROVIDER", () => {
     it("contains exactly the expected mapping keys", () => {
       expect(Object.keys(NEXTAUTH_TO_IDENTITY_PROVIDER).sort()).toEqual(
-        ["azure-ad", "cal", "google", "saml", "saml-idp"].sort()
+        ["azure-ad", "cal", "google", "oidc", "saml", "saml-idp"].sort()
       );
     });
   });
@@ -30,6 +30,10 @@ describe("identityProviders", () => {
 
     it("maps 'cal' to CAL", () => {
       expect(getIdentityProvider("cal")).toBe(IdentityProvider.CAL);
+    });
+
+    it("maps 'oidc' to OIDC", () => {
+      expect(getIdentityProvider("oidc")).toBe(IdentityProvider.OIDC);
     });
 
     it("returns null for unknown provider", () => {

--- a/packages/features/auth/lib/identityProviders.ts
+++ b/packages/features/auth/lib/identityProviders.ts
@@ -10,6 +10,7 @@ export const NEXTAUTH_TO_IDENTITY_PROVIDER: Record<string, IdentityProvider> = {
   saml: IdentityProvider.SAML,
   "saml-idp": IdentityProvider.SAML,
   cal: IdentityProvider.CAL,
+  oidc: IdentityProvider.OIDC,
 };
 
 /**

--- a/packages/features/auth/lib/next-auth-options.test.ts
+++ b/packages/features/auth/lib/next-auth-options.test.ts
@@ -468,6 +468,7 @@ describe("Azure AD signIn callback", () => {
         saml: "SAML",
         "saml-idp": "SAML",
         cal: "CAL",
+        oidc: "OIDC",
       };
       return map[provider] ?? null;
     });
@@ -861,6 +862,121 @@ describe("Azure AD signIn callback", () => {
       expect(result).toBe("/auth/error?error=unverified-email");
     });
   });
+
+  describe("OIDC identity provider conversion (signIn callback)", () => {
+    it("CAL user with verified email converts to OIDC on OIDC login", async () => {
+      mockPrismaUserFindFirst
+        .mockResolvedValueOnce(null) // First call: lookup by identityProvider + providerAccountId
+        .mockResolvedValueOnce(null) // Legacy lookup
+        .mockResolvedValueOnce({
+          // Lookup by email
+          id: 60,
+          email: "user@example.com",
+          emailVerified: new Date(),
+          identityProvider: "CAL",
+          password: { hash: "hashed" },
+          twoFactorEnabled: false,
+        });
+
+      const result = await signInCallback({
+        user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
+        account: { provider: "oidc", providerAccountId: "oidc-conv-1", type: "oauth" as const },
+        profile: { email_verified: true } as any,
+        credentials: undefined,
+        email: undefined,
+      } as any);
+
+      expect(mockPrismaUserUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            identityProvider: "OIDC",
+            identityProviderId: "oidc-conv-1",
+          }),
+        })
+      );
+      expect(result).toBe(true);
+    });
+
+    it("OIDC user auto-merges on Google login when email is verified", async () => {
+      mockPrismaUserFindFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce({
+        id: 61,
+        email: "user@example.com",
+        emailVerified: new Date(),
+        identityProvider: "OIDC",
+        password: null,
+        twoFactorEnabled: false,
+      });
+
+      const result = await signInCallback({
+        user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
+        account: { provider: "google", providerAccountId: "google-conv-2", type: "oauth" as const },
+        profile: { email_verified: true } as any,
+        credentials: undefined,
+        email: undefined,
+      } as any);
+
+      // With isVerified=true and non-CAL provider, auto-merge path is taken (returns true directly)
+      expect(result).toBe(true);
+    });
+
+    it("GOOGLE user auto-merges on OIDC login when email is verified", async () => {
+      mockPrismaUserFindFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValueOnce({
+        id: 62,
+        email: "user@example.com",
+        emailVerified: new Date(),
+        identityProvider: "GOOGLE",
+        password: null,
+        twoFactorEnabled: false,
+      });
+
+      const result = await signInCallback({
+        user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
+        account: { provider: "oidc", providerAccountId: "oidc-conv-2", type: "oauth" as const },
+        profile: { email_verified: true } as any,
+        credentials: undefined,
+        email: undefined,
+      } as any);
+
+      // With isVerified=true and non-CAL provider, auto-merge path is taken (returns true directly)
+      expect(result).toBe(true);
+    });
+
+    it("unverified CAL account blocks OIDC linking (anti-hijack)", async () => {
+      mockPrismaUserFindFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 63,
+          email: "user@example.com",
+          emailVerified: null,
+          identityProvider: "CAL",
+          password: { hash: "hashed" },
+          twoFactorEnabled: false,
+        });
+
+      const result = await signInCallback({
+        user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
+        account: { provider: "oidc", providerAccountId: "oidc-hijack-1", type: "oauth" as const },
+        profile: { email_verified: true } as any,
+        credentials: undefined,
+        email: undefined,
+      } as any);
+
+      expect(result).toBe("/auth/error?error=unverified-email");
+    });
+
+    it("OIDC login without email_verified claim is rejected (no Azure-style carve-out)", async () => {
+      const result = await signInCallback({
+        user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
+        account: { provider: "oidc", providerAccountId: "oidc-unverified-1", type: "oauth" as const },
+        profile: { sub: "oidc-user-1", email: "user@example.com" } as any,
+        credentials: undefined,
+        email: undefined,
+      } as any);
+
+      expect(result).toBe("/auth/error?error=unverified-email");
+    });
+  });
 });
 
 describe("Azure AD JWT callback", () => {
@@ -878,6 +994,7 @@ describe("Azure AD JWT callback", () => {
         saml: "SAML",
         "saml-idp": "SAML",
         cal: "CAL",
+        oidc: "OIDC",
       };
       return map[provider] ?? null;
     });

--- a/packages/features/auth/lib/next-auth-options.test.ts
+++ b/packages/features/auth/lib/next-auth-options.test.ts
@@ -864,6 +864,8 @@ describe("Azure AD signIn callback", () => {
   });
 
   describe("OIDC identity provider conversion (signIn callback)", () => {
+    type OidcProfileFixture = { sub?: string; email?: string; email_verified?: boolean };
+
     it("CAL user with verified email converts to OIDC on OIDC login", async () => {
       mockPrismaUserFindFirst
         .mockResolvedValueOnce(null) // First call: lookup by identityProvider + providerAccountId
@@ -881,10 +883,10 @@ describe("Azure AD signIn callback", () => {
       const result = await signInCallback({
         user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
         account: { provider: "oidc", providerAccountId: "oidc-conv-1", type: "oauth" as const },
-        profile: { email_verified: true } as any,
+        profile: { email_verified: true } satisfies OidcProfileFixture,
         credentials: undefined,
         email: undefined,
-      } as any);
+      });
 
       expect(mockPrismaUserUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -910,10 +912,10 @@ describe("Azure AD signIn callback", () => {
       const result = await signInCallback({
         user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
         account: { provider: "google", providerAccountId: "google-conv-2", type: "oauth" as const },
-        profile: { email_verified: true } as any,
+        profile: { email_verified: true } satisfies OidcProfileFixture,
         credentials: undefined,
         email: undefined,
-      } as any);
+      });
 
       // With isVerified=true and non-CAL provider, auto-merge path is taken (returns true directly)
       expect(result).toBe(true);
@@ -932,10 +934,10 @@ describe("Azure AD signIn callback", () => {
       const result = await signInCallback({
         user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
         account: { provider: "oidc", providerAccountId: "oidc-conv-2", type: "oauth" as const },
-        profile: { email_verified: true } as any,
+        profile: { email_verified: true } satisfies OidcProfileFixture,
         credentials: undefined,
         email: undefined,
-      } as any);
+      });
 
       // With isVerified=true and non-CAL provider, auto-merge path is taken (returns true directly)
       expect(result).toBe(true);
@@ -957,10 +959,10 @@ describe("Azure AD signIn callback", () => {
       const result = await signInCallback({
         user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
         account: { provider: "oidc", providerAccountId: "oidc-hijack-1", type: "oauth" as const },
-        profile: { email_verified: true } as any,
+        profile: { email_verified: true } satisfies OidcProfileFixture,
         credentials: undefined,
         email: undefined,
-      } as any);
+      });
 
       expect(result).toBe("/auth/error?error=unverified-email");
     });
@@ -969,10 +971,10 @@ describe("Azure AD signIn callback", () => {
       const result = await signInCallback({
         user: { id: "1", email: "user@example.com", name: "User", emailVerified: null },
         account: { provider: "oidc", providerAccountId: "oidc-unverified-1", type: "oauth" as const },
-        profile: { sub: "oidc-user-1", email: "user@example.com" } as any,
+        profile: { sub: "oidc-user-1", email: "user@example.com" } satisfies OidcProfileFixture,
         credentials: undefined,
         email: undefined,
-      } as any);
+      });
 
       expect(result).toBe("/auth/error?error=unverified-email");
     });

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -4,6 +4,14 @@ import { updateProfilePhotoMicrosoft } from "@calcom/app-store/_utils/oauth/upda
 import { createGoogleCalendarServiceWithGoogleType } from "@calcom/app-store/googlecalendar/lib/CalendarService";
 import { getIdentityProvider } from "@calcom/features/auth/lib/identityProviders";
 import {
+  IS_OIDC_LOGIN_ENABLED,
+  OIDC_CLIENT_ID,
+  OIDC_CLIENT_SECRET,
+  OIDC_ISSUER,
+  OIDC_PROVIDER_NAME,
+} from "@calcom/features/auth/lib/oidc";
+import { createOidcProvider } from "@calcom/features/auth/lib/oidcProvider";
+import {
   OUTLOOK_CLIENT_ID,
   OUTLOOK_CLIENT_SECRET,
   OUTLOOK_LOGIN_ENABLED,
@@ -352,6 +360,17 @@ if (OUTLOOK_LOGIN_ENABLED && OUTLOOK_CLIENT_ID && OUTLOOK_CLIENT_SECRET) {
           image: null,
         };
       },
+    })
+  );
+}
+
+if (IS_OIDC_LOGIN_ENABLED && OIDC_CLIENT_ID && OIDC_CLIENT_SECRET && OIDC_ISSUER) {
+  providers.push(
+    createOidcProvider({
+      clientId: OIDC_CLIENT_ID,
+      clientSecret: OIDC_CLIENT_SECRET,
+      issuer: OIDC_ISSUER,
+      providerName: OIDC_PROVIDER_NAME,
     })
   );
 }
@@ -1027,12 +1046,13 @@ export const getOptions = ({
             }
           }
 
-          // User signs up with email/password and then tries to login with Google/SAML/AzureAD using the same email
+          // User signs up with email/password and then tries to login with Google/SAML/AzureAD/OIDC using the same email
           if (
             existingUserWithEmail.identityProvider === IdentityProvider.CAL &&
             (idP === IdentityProvider.GOOGLE ||
               idP === IdentityProvider.SAML ||
-              idP === IdentityProvider.AZUREAD)
+              idP === IdentityProvider.AZUREAD ||
+              idP === IdentityProvider.OIDC)
           ) {
             // Prevent account pre-hijacking: block OAuth linking for unverified accounts
             if (!existingUserWithEmail.emailVerified) {

--- a/packages/features/auth/lib/oidc.test.ts
+++ b/packages/features/auth/lib/oidc.test.ts
@@ -1,0 +1,111 @@
+import process from "node:process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("oidc", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore original env completely
+    for (const key of [
+      "OIDC_CLIENT_ID",
+      "OIDC_CLIENT_SECRET",
+      "OIDC_ISSUER",
+      "OIDC_PROVIDER_NAME",
+      "OIDC_LOGIN_ENABLED",
+    ]) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    vi.resetModules();
+  });
+
+  it("reads OIDC_CLIENT_ID from env", async () => {
+    process.env.OIDC_CLIENT_ID = "test-client-id";
+    const { OIDC_CLIENT_ID } = await import("./oidc");
+    expect(OIDC_CLIENT_ID).toBe("test-client-id");
+  });
+
+  it("reads OIDC_CLIENT_SECRET from env", async () => {
+    process.env.OIDC_CLIENT_SECRET = "test-secret";
+    const { OIDC_CLIENT_SECRET } = await import("./oidc");
+    expect(OIDC_CLIENT_SECRET).toBe("test-secret");
+  });
+
+  it("reads OIDC_ISSUER from env", async () => {
+    process.env.OIDC_ISSUER = "https://auth.example.com";
+    const { OIDC_ISSUER } = await import("./oidc");
+    expect(OIDC_ISSUER).toBe("https://auth.example.com");
+  });
+
+  it("OIDC_PROVIDER_NAME falls back to 'OIDC' when unset", async () => {
+    delete process.env.OIDC_PROVIDER_NAME;
+    const { OIDC_PROVIDER_NAME } = await import("./oidc");
+    expect(OIDC_PROVIDER_NAME).toBe("OIDC");
+  });
+
+  it("OIDC_PROVIDER_NAME uses the configured display name when set", async () => {
+    process.env.OIDC_PROVIDER_NAME = "Authentik";
+    const { OIDC_PROVIDER_NAME } = await import("./oidc");
+    expect(OIDC_PROVIDER_NAME).toBe("Authentik");
+  });
+
+  it("OIDC_LOGIN_ENABLED is true only for exact string 'true'", async () => {
+    process.env.OIDC_LOGIN_ENABLED = "true";
+    const mod = await import("./oidc");
+    expect(mod.OIDC_LOGIN_ENABLED).toBe(true);
+  });
+
+  it("OIDC_LOGIN_ENABLED is false for other values", async () => {
+    process.env.OIDC_LOGIN_ENABLED = "1";
+    const mod = await import("./oidc");
+    expect(mod.OIDC_LOGIN_ENABLED).toBe(false);
+  });
+
+  it("IS_OIDC_LOGIN_ENABLED is true when all required vars are set", async () => {
+    process.env.OIDC_CLIENT_ID = "client-id";
+    process.env.OIDC_CLIENT_SECRET = "client-secret";
+    process.env.OIDC_ISSUER = "https://auth.example.com";
+    process.env.OIDC_LOGIN_ENABLED = "true";
+    const { IS_OIDC_LOGIN_ENABLED } = await import("./oidc");
+    expect(IS_OIDC_LOGIN_ENABLED).toBe(true);
+  });
+
+  it("IS_OIDC_LOGIN_ENABLED is false when client ID is missing", async () => {
+    delete process.env.OIDC_CLIENT_ID;
+    process.env.OIDC_CLIENT_SECRET = "client-secret";
+    process.env.OIDC_ISSUER = "https://auth.example.com";
+    process.env.OIDC_LOGIN_ENABLED = "true";
+    const { IS_OIDC_LOGIN_ENABLED } = await import("./oidc");
+    expect(IS_OIDC_LOGIN_ENABLED).toBe(false);
+  });
+
+  it("IS_OIDC_LOGIN_ENABLED is false when client secret is missing", async () => {
+    process.env.OIDC_CLIENT_ID = "client-id";
+    delete process.env.OIDC_CLIENT_SECRET;
+    process.env.OIDC_ISSUER = "https://auth.example.com";
+    process.env.OIDC_LOGIN_ENABLED = "true";
+    const { IS_OIDC_LOGIN_ENABLED } = await import("./oidc");
+    expect(IS_OIDC_LOGIN_ENABLED).toBe(false);
+  });
+
+  it("IS_OIDC_LOGIN_ENABLED is false when issuer is missing", async () => {
+    process.env.OIDC_CLIENT_ID = "client-id";
+    process.env.OIDC_CLIENT_SECRET = "client-secret";
+    delete process.env.OIDC_ISSUER;
+    process.env.OIDC_LOGIN_ENABLED = "true";
+    const { IS_OIDC_LOGIN_ENABLED } = await import("./oidc");
+    expect(IS_OIDC_LOGIN_ENABLED).toBe(false);
+  });
+
+  it("IS_OIDC_LOGIN_ENABLED is false when OIDC_LOGIN_ENABLED is not 'true'", async () => {
+    process.env.OIDC_CLIENT_ID = "client-id";
+    process.env.OIDC_CLIENT_SECRET = "client-secret";
+    process.env.OIDC_ISSUER = "https://auth.example.com";
+    delete process.env.OIDC_LOGIN_ENABLED;
+    const { IS_OIDC_LOGIN_ENABLED } = await import("./oidc");
+    expect(IS_OIDC_LOGIN_ENABLED).toBe(false);
+  });
+});

--- a/packages/features/auth/lib/oidc.test.ts
+++ b/packages/features/auth/lib/oidc.test.ts
@@ -5,7 +5,6 @@ describe("oidc", () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
-    // Restore original env completely
     for (const key of [
       "OIDC_CLIENT_ID",
       "OIDC_CLIENT_SECRET",

--- a/packages/features/auth/lib/oidc.ts
+++ b/packages/features/auth/lib/oidc.ts
@@ -1,0 +1,11 @@
+export const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID;
+export const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET;
+export const OIDC_ISSUER = process.env.OIDC_ISSUER;
+export const OIDC_PROVIDER_NAME = process.env.OIDC_PROVIDER_NAME || "OIDC";
+export const OIDC_LOGIN_ENABLED = process.env.OIDC_LOGIN_ENABLED === "true";
+export const IS_OIDC_LOGIN_ENABLED = !!(
+  OIDC_CLIENT_ID &&
+  OIDC_CLIENT_SECRET &&
+  OIDC_ISSUER &&
+  process.env.OIDC_LOGIN_ENABLED === "true"
+);

--- a/packages/features/auth/lib/oidcProvider.test.ts
+++ b/packages/features/auth/lib/oidcProvider.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createOidcProvider } from "./oidcProvider";
+
+describe("createOidcProvider", () => {
+  const baseOptions = {
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    issuer: "https://auth.example.com",
+    providerName: "Authentik",
+  };
+
+  it("uses a fixed 'oidc' provider id and 'oauth' type", () => {
+    const provider = createOidcProvider(baseOptions);
+    expect(provider.id).toBe("oidc");
+    expect(provider.type).toBe("oauth");
+  });
+
+  it("uses the configured display name", () => {
+    const provider = createOidcProvider(baseOptions);
+    expect(provider.name).toBe("Authentik");
+  });
+
+  it("builds the wellKnown discovery URL from the issuer", () => {
+    const provider = createOidcProvider(baseOptions);
+    expect(provider.wellKnown).toBe("https://auth.example.com/.well-known/openid-configuration");
+  });
+
+  it("strips a trailing slash from the issuer before building the discovery URL", () => {
+    const provider = createOidcProvider({ ...baseOptions, issuer: "https://auth.example.com/" });
+    expect(provider.wellKnown).toBe("https://auth.example.com/.well-known/openid-configuration");
+    expect(provider.issuer).toBe("https://auth.example.com");
+  });
+
+  it("strips multiple trailing slashes from the issuer", () => {
+    const provider = createOidcProvider({ ...baseOptions, issuer: "https://auth.example.com//" });
+    expect(provider.wellKnown).toBe("https://auth.example.com/.well-known/openid-configuration");
+  });
+
+  it("requires PKCE and state checks", () => {
+    const provider = createOidcProvider(baseOptions);
+    expect(provider.checks).toEqual(["pkce", "state"]);
+  });
+
+  it("passes through clientId and clientSecret", () => {
+    const provider = createOidcProvider(baseOptions);
+    expect(provider.clientId).toBe("client-id");
+    expect(provider.clientSecret).toBe("client-secret");
+  });
+
+  describe("profile mapping", () => {
+    it("maps sub, name, email, and picture", () => {
+      const provider = createOidcProvider(baseOptions);
+      const result = provider.profile?.(
+        { sub: "1", name: "Jane Doe", email: "jane@example.com", picture: "https://example.com/jane.png" },
+        {} as never
+      );
+      expect(result).toEqual({
+        id: "1",
+        name: "Jane Doe",
+        email: "jane@example.com",
+        image: "https://example.com/jane.png",
+      });
+    });
+
+    it("falls back to preferred_username when name is absent", () => {
+      const provider = createOidcProvider(baseOptions);
+      const result = provider.profile?.(
+        { sub: "1", preferred_username: "janedoe", email: "jane@example.com" },
+        {} as never
+      );
+      expect(result?.name).toBe("janedoe");
+    });
+
+    it("falls back to email when name and preferred_username are absent", () => {
+      const provider = createOidcProvider(baseOptions);
+      const result = provider.profile?.({ sub: "1", email: "jane@example.com" }, {} as never);
+      expect(result?.name).toBe("jane@example.com");
+    });
+
+    it("falls back to sub when no other name field is present", () => {
+      const provider = createOidcProvider(baseOptions);
+      const result = provider.profile?.({ sub: "user-1" }, {} as never);
+      expect(result?.name).toBe("user-1");
+    });
+
+    it("maps a missing picture to a null image", () => {
+      const provider = createOidcProvider(baseOptions);
+      const result = provider.profile?.({ sub: "1", email: "jane@example.com" }, {} as never);
+      expect(result?.image).toBeNull();
+    });
+  });
+});

--- a/packages/features/auth/lib/oidcProvider.ts
+++ b/packages/features/auth/lib/oidcProvider.ts
@@ -1,4 +1,4 @@
-import type { OAuthConfig, OAuthUserConfig } from "next-auth/providers/index";
+import type { OAuthConfig, OAuthUserConfig } from "next-auth/providers/oauth";
 
 export interface OidcProfile extends Record<string, unknown> {
   sub: string;

--- a/packages/features/auth/lib/oidcProvider.ts
+++ b/packages/features/auth/lib/oidcProvider.ts
@@ -1,0 +1,55 @@
+import type { OAuthConfig, OAuthUserConfig } from "next-auth/providers/index";
+
+export interface OidcProfile extends Record<string, unknown> {
+  sub: string;
+  name?: string;
+  preferred_username?: string;
+  email?: string;
+  email_verified?: boolean;
+  picture?: string;
+}
+
+/**
+ * Generic OIDC provider for self-hosters using their own identity provider
+ * (Authentik, Keycloak, Authelia, Okta, etc). next-auth ships thin per-product
+ * wrappers (e.g. providers/authentik.js) that all follow this same shape, but
+ * no generic factory - this is that generic version, discovering endpoints via
+ * `.well-known/openid-configuration` (RFC 8414) instead of hardcoding one vendor.
+ */
+export function createOidcProvider(
+  options: Pick<OAuthUserConfig<OidcProfile>, "clientId" | "clientSecret"> & {
+    issuer: string;
+    providerName: string;
+  }
+): OAuthConfig<OidcProfile> {
+  const normalizedIssuer = options.issuer.replace(/\/+$/, "");
+
+  return {
+    id: "oidc",
+    name: options.providerName,
+    type: "oauth",
+    wellKnown: `${normalizedIssuer}/.well-known/openid-configuration`,
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    issuer: normalizedIssuer,
+    authorization: { params: { scope: "openid email profile" } },
+    checks: ["pkce", "state"],
+    idToken: true,
+    allowDangerousEmailAccountLinking: true,
+    profile(profile) {
+      return {
+        // next-auth's User.id is augmented to `number` (the Prisma user id) in
+        // types/next-auth.d.ts, but this callback only ever sees the IdP's `sub`
+        // claim (a string) before Cal.diy's own signIn callback resolves and
+        // overwrites it with the real database user. Google/Azure AD hit the same
+        // mismatch; their vendored provider factories just aren't checked this
+        // strictly because next-auth ships them as pre-compiled .js with generic
+        // .d.ts signatures. Cast is intentional, not a type-safety gap.
+        id: profile.sub as unknown as number,
+        name: profile.name ?? profile.preferred_username ?? profile.email ?? profile.sub,
+        email: profile.email,
+        image: profile.picture ?? null,
+      };
+    },
+  };
+}

--- a/packages/features/auth/lib/oidcProvider.ts
+++ b/packages/features/auth/lib/oidcProvider.ts
@@ -14,7 +14,7 @@ export interface OidcProfile extends Record<string, unknown> {
  * (Authentik, Keycloak, Authelia, Okta, etc). next-auth ships thin per-product
  * wrappers (e.g. providers/authentik.js) that all follow this same shape, but
  * no generic factory - this is that generic version, discovering endpoints via
- * `.well-known/openid-configuration` (RFC 8414) instead of hardcoding one vendor.
+ * `.well-known/openid-configuration` (OpenID Connect Discovery 1.0) instead of hardcoding one vendor.
  */
 export function createOidcProvider(
   options: Pick<OAuthUserConfig<OidcProfile>, "clientId" | "clientSecret"> & {

--- a/packages/i18n/locales/en/common.json
+++ b/packages/i18n/locales/en/common.json
@@ -1374,6 +1374,7 @@
   "signin_with_saml_oidc": "Sign in with SAML/OIDC",
   "continue_with_email": "Continue with Email",
   "continue_with_google": "Continue with Google",
+  "continue_with_oidc": "Continue with {{providerName}}",
   "last_used": "Last used",
   "you_will_need_to_generate": "You will need to generate an access token from your old scheduling tool.",
   "import": "Import",

--- a/packages/prisma/migrations/20260818150000_add_oidc_identity_provider/migration.sql
+++ b/packages/prisma/migrations/20260818150000_add_oidc_identity_provider/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "IdentityProvider" ADD VALUE 'OIDC';

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -346,6 +346,7 @@ enum IdentityProvider {
   GOOGLE
   SAML
   AZUREAD
+  OIDC
 }
 
 model DestinationCalendar {


### PR DESCRIPTION
## Summary

Third and final PR of the OIDC self-hosting sequence (#29945). Depends on #29988 (enum) and #29989 (NextAuth backend wiring) — this PR's diff includes those commits until they merge.

- Threads `isOidcLoginEnabled`/`oidcProviderName` (from `packages/features/auth/lib/oidc.ts`) through both `getServerSideProps` functions for login and signup.
- Adds a "Continue with {providerName}" button to `login-view.tsx` and `signup-view.tsx`, calling `signIn("oidc", ...)` directly.
- **Note on the signup button**: the existing Google/Microsoft signup buttons `router.push()` to `/auth/sso/google` / `/auth/sso/microsoft` — a route that doesn't exist anywhere in this repo (I couldn't find any page/rewrite handling it). Rather than copy that apparently non-functional pattern, the new OIDC button uses the same working `signIn()` call the login page already uses. Flagging this in case it's intentional/there's context I'm missing — happy to match the existing pattern instead if so.
- Adds `continue_with_oidc: "Continue with {{providerName}}"` to `common.json` (interpolated, since the provider name is admin-configured rather than a fixed brand like Google).
- Documents the new `OIDC_*` env vars in `.env.example`.

## Test plan

- [x] `tsc --noEmit` on `apps/web` — 0 errors (after running `packages/trpc`'s build step to generate its type output, per this repo's docs on tRPC changes)
- [x] `yarn biome check` — 0 errors on the changed files
- [ ] No automated component test included: the `apps/web/modules/**/*.test.tsx` vitest project has no path-alias config for `@components/*`, which `login-view.tsx` depends on, so a render test can't resolve its imports without changing shared vitest config (out of scope here). Coverage instead relies on PR #29989's backend `signIn` callback tests plus this PR's own type-checking of the prop wiring.
- [ ] Manual verification (start the dev server, point `OIDC_*` at a local Authentik/Keycloak, confirm the button renders and the full login round-trip works) is recommended before merge — I wasn't able to run this myself in this environment (no database configured).