### PR TITLE
fix(paypal): handle zero-decimal currencies properly during order creation

### DIFF
--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
 import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
@@ -85,7 +86,7 @@ class Paypal {
           reference_id: referenceId,
           amount: {
             currency_code: currency,
-            value: (amount / 100).toString(),
+            value: convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString(),
           },
         },
       ],


### PR DESCRIPTION
### Problem
When an event type is configured to accept PayPal payments in zero-decimal currencies such as Japanese Yen (JPY), the order creation path divides the stored amount by 100, causing PayPal to bill attendees only 1/100th of the configured price. For prices not divisible by 100 (e.g. ¥1,050), PayPal rejects the resulting decimal value and order creation fails.

### Root cause
`packages/app-store/paypal/lib/Paypal.ts` in `createOrder` hardcodes `(amount / 100).toString()` for purchase unit values, assuming all currencies have 2 decimal places. Unlike standard currencies stored in minor units (e.g. USD cents), zero-decimal currencies like JPY are stored unscaled in integer units throughout the application.

### Change
Updated `createOrder` in `packages/app-store/paypal/lib/Paypal.ts` to use `convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString()` from `@calcom/lib/currencyConversions`. This ensures zero-decimal currencies (JPY, KRW, etc.) retain their full integer amount while minor-unit currencies (USD, EUR, etc.) continue to be divided by 100.

### Proof

#### Test Red (Before Fix)
```
PS C:\Users\erijo\Downloads\claude\calcom> node --test packages/app-store/paypal/test_reproduce_issue_29983.mjs
Current value calculation in Paypal.ts: (amount / 100).toString()

Input: amount = 10000, currency = 'JPY'
Expected value sent to PayPal: '10000'
Actual value sent by Paypal.ts: '100'
▶ Paypal createOrder zero-decimal currency handling (Issue #29983)
  ✖ reproduces the bug in Paypal.ts createOrder when handling JPY (7.2918ms)
✖ Paypal createOrder zero-decimal currency handling (Issue #29983) (10.6252ms)
ℹ tests 1
ℹ suites 1
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 443.7527

✖ failing tests:

test at packages\app-store\paypal\test_reproduce_issue_29983.mjs:12:3
✖ reproduces the bug in Paypal.ts createOrder when handling JPY (7.2918ms)
  AssertionError [ERR_ASSERTION]: BUG REPRODUCED: Paypal.ts sent '100' instead of '10000' for JPY ¥10000 (divided by 100!)
  
  '100' !== '10000'
```

#### Test Green (After Fix)
```
PS C:\Users\erijo\Downloads\claude\calcom> node --test packages/app-store/paypal/test_reproduce_issue_29983.mjs
JPY ¥10,000 -> Sent value: '10000'
JPY ¥1,050 -> Sent value: '1050'
USD $50.00 (stored 5000) -> Sent value: '50'
EUR €15.50 (stored 1550) -> Sent value: '15.5'
▶ Paypal createOrder zero-decimal currency handling (Issue #29983)
  ✔ Paypal.ts imports and uses convertFromSmallestToPresentableCurrencyUnit (3.9961ms)
  ✔ correctly formats JPY (zero-decimal currency) without dividing by 100 (1.8027ms)
  ✔ correctly formats non-hundred JPY prices without creating decimals (0.6343ms)
  ✔ correctly formats USD (minor unit currency) by dividing by 100 (0.4216ms)
  ✔ correctly formats EUR (minor unit currency with decimal part) (0.502ms)
  ✔ correctly formats other zero-decimal currencies (KRW, CLP, VND) (0.5542ms)
✔ Paypal createOrder zero-decimal currency handling (Issue #29983) (11.3723ms)
ℹ tests 6
ℹ suites 1
ℹ pass 6
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 388.7951
```

### Reference
Fixes #29983
/claim 29983

### Disclosure
This fix was written with AI assistance.
