### PR TITLE
fix(paypal): preserve unscaled amount for zero-decimal currencies like JPY (#29983)

### DIFF
--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
 import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
@@ -85,7 +86,7 @@ class Paypal {
           reference_id: referenceId,
           amount: {
             currency_code: currency,
-            value: (amount / 100).toString(),
+            value: convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString(),
           },
         },
       ],

--- a/packages/app-store/paypal/lib/PaypalCurrency.unit.test.ts
+++ b/packages/app-store/paypal/lib/PaypalCurrency.unit.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
+
+describe("PayPal currency conversion for zero-decimal and standard currencies", () => {
+  it("converts standard minor unit currencies (USD, EUR) by dividing by 100", () => {
+    expect(convertFromSmallestToPresentableCurrencyUnit(5000, "USD").toString()).toBe("50");
+    expect(convertFromSmallestToPresentableCurrencyUnit(1000, "EUR").toString()).toBe("10");
+  });
+
+  it("preserves unscaled amounts for zero-decimal currencies (JPY, KRW, VND)", () => {
+    expect(convertFromSmallestToPresentableCurrencyUnit(10000, "JPY").toString()).toBe("10000");
+    expect(convertFromSmallestToPresentableCurrencyUnit(1050, "JPY").toString()).toBe("1050");
+    expect(convertFromSmallestToPresentableCurrencyUnit(50000, "KRW").toString()).toBe("50000");
+  });
+});


### PR DESCRIPTION
# Title
fix(paypal): preserve unscaled amount for zero-decimal currencies like JPY (#29983)

## Description
- Replaces hardcoded `amount / 100` division with `convertFromSmallestToPresentableCurrencyUnit` in `Paypal.createOrder`.
- Fixes critical pricing discrepancy where Japanese yen (JPY) bookings collected only 1/100th of the configured price or threw decimal validation errors at PayPal.
- Preserves standard minor unit handling for USD, EUR, and other decimal currencies.
- Adds dedicated regression unit tests for currency scaling behavior.

Closes #29983
