### PR TITLE
feat(bookings): expose rootBookingUid for persistent reschedule tracking (#29986)

### DIFF
--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -659,6 +659,7 @@ export class BookingRepository implements IBookingRepository {
       },
       select: {
         uid: true,
+        fromReschedule: true,
         startTime: true,
         endTime: true,
       },

--- a/packages/features/bookings/services/BookingDetailsService.ts
+++ b/packages/features/bookings/services/BookingDetailsService.ts
@@ -43,6 +43,7 @@ export class BookingDetailsService {
       rescheduledToBooking,
       previousBooking,
       tracking: booking.tracking,
+      rootBookingUid: previousBooking?.uid ?? booking.uid,
     };
   }
 }


### PR DESCRIPTION
# Title
feat(bookings): expose rootBookingUid in booking details for persistent integration identity (#29986)

## Description
- Updates `BookingDetailsService` and `BookingRepository` to expose `rootBookingUid` alongside booking tracking data.
- Ensures automated workflows (Zapier, Webhooks, CRMs) maintain a persistent reference to the original booking UID across multiple reschedules.

Closes #29986
