### PR TITLE
fix(paypal): use zero-decimal aware conversion for order amount

### DIFF
--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
 import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
@@ -85,7 +86,7 @@ class Paypal {
           reference_id: referenceId,
           amount: {
             currency_code: currency,
-            value: (amount / 100).toString(),
+            value: convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString(),
           },
         },
       ],

--- a/packages/lib/currencyConversions.test.ts
+++ b/packages/lib/currencyConversions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convertToSmallestCurrencyUnit,
+  convertFromSmallestToPresentableCurrencyUnit,
+  formatPrice,
+} from "./currencyConversions";
+
+describe("currencyConversions", () => {
+  describe("convertToSmallestCurrencyUnit", () => {
+    it("should scale 2-decimal currencies by 100", () => {
+      expect(convertToSmallestCurrencyUnit(50, "USD")).toBe(5000);
+      expect(convertToSmallestCurrencyUnit(19.99, "EUR")).toBe(1999);
+      expect(convertToSmallestCurrencyUnit(10.5, "GBP")).toBe(1050);
+    });
+
+    it("should preserve zero-decimal currencies without scaling", () => {
+      expect(convertToSmallestCurrencyUnit(10000, "JPY")).toBe(10000);
+      expect(convertToSmallestCurrencyUnit(10000, "jpy")).toBe(10000);
+      expect(convertToSmallestCurrencyUnit(50000, "KRW")).toBe(50000);
+      expect(convertToSmallestCurrencyUnit(100000, "VND")).toBe(100000);
+      expect(convertToSmallestCurrencyUnit(500, "CLP")).toBe(500);
+    });
+  });
+
+  describe("convertFromSmallestToPresentableCurrencyUnit", () => {
+    it("should divide 2-decimal currencies by 100", () => {
+      expect(convertFromSmallestToPresentableCurrencyUnit(5000, "USD")).toBe(50);
+      expect(convertFromSmallestToPresentableCurrencyUnit(1999, "EUR")).toBe(19.99);
+    });
+
+    it("should preserve zero-decimal currencies without dividing", () => {
+      expect(convertFromSmallestToPresentableCurrencyUnit(10000, "JPY")).toBe(10000);
+      expect(convertFromSmallestToPresentableCurrencyUnit(10000, "jpy")).toBe(10000);
+      expect(convertFromSmallestToPresentableCurrencyUnit(50000, "KRW")).toBe(50000);
+      expect(convertFromSmallestToPresentableCurrencyUnit(100000, "VND")).toBe(100000);
+    });
+  });
+
+  describe("formatPrice", () => {
+    it("should format zero-decimal currencies correctly", () => {
+      const formatted = formatPrice(10000, "JPY", "en");
+      expect(formatted).toContain("10,000");
+    });
+
+    it("should format standard currencies correctly", () => {
+      const formatted = formatPrice(5000, "USD", "en");
+      expect(formatted).toContain("50.00");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #29983

## Problem

When an event type is configured to accept PayPal payments in zero-decimal currencies (such as Japanese yen - JPY), the amount sent to PayPal in \createOrder()\ was hardcoded as \(amount / 100).toString()\.
Because zero-decimal currencies are stored in unscaled whole units, dividing by 100 caused PayPal to collect only 1/100th of the configured price (e.g. ¥10,000 was collected as ¥100). Additionally, JPY prices not divisible by 100 created invalid decimal amounts that PayPal rejected.

## Fix

- In \packages/app-store/paypal/lib/Paypal.ts\, replace the hardcoded \mount / 100\ with \convertFromSmallestToPresentableCurrencyUnit(amount, currency)\ from \@calcom/lib/currencyConversions\.
- Added unit tests in \packages/lib/currencyConversions.test.ts\ verifying zero-decimal and 2-decimal currency conversions.