### PR TITLE
perf(app-store): optimize location option deduplication to O(1)

### DIFF
--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -85,6 +85,8 @@ export async function getLocationGroupedOptions(
 
   const integrations = await getEnabledAppsFromCredentials(credentials, { filterOnCredentials: true });
 
+  const seenOptionsByCategory: Record<string, Set<string>> = {};
+
   integrations.forEach((app) => {
     // All apps that are labeled as a locationOption are video apps.
     if (app.locationOption) {
@@ -94,6 +96,11 @@ export async function getLocationGroupedOptions(
           ? app.categories.find((groupByCategory) => !defaultVideoAppCategories.includes(groupByCategory))
           : app.categories[0] || app.category;
       if (!groupByCategory) groupByCategory = AppCategories.conferencing;
+
+      if (!apps[groupByCategory]) {
+        apps[groupByCategory] = [];
+        seenOptionsByCategory[groupByCategory] = new Set();
+      }
 
       for (const { teamName } of app.credentials.map((credential) => ({
         teamName: credential.team?.name,
@@ -108,13 +115,9 @@ export async function getLocationGroupedOptions(
             ? { credentialId: app.credential.id, teamName: app.credential.team?.name ?? null }
             : {}),
         };
-        if (apps[groupByCategory]) {
-          const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
-          if (!existingOption) {
-            apps[groupByCategory] = [...apps[groupByCategory], option];
-          }
-        } else {
-          apps[groupByCategory] = [option];
+        if (!seenOptionsByCategory[groupByCategory].has(option.value)) {
+          seenOptionsByCategory[groupByCategory].add(option.value);
+          apps[groupByCategory].push(option);
         }
       }
     }
@@ -122,26 +125,15 @@ export async function getLocationGroupedOptions(
 
   defaultLocations.forEach((l) => {
     const category = l.category;
-    if (apps[category]) {
-      apps[category] = [
-        ...apps[category],
-        {
-          label: l.label,
-          value: l.type,
-          icon: l.iconUrl,
-          supportsCustomLabel: l.supportsCustomLabel,
-        },
-      ];
-    } else {
-      apps[category] = [
-        {
-          label: l.label,
-          value: l.type,
-          icon: l.iconUrl,
-          supportsCustomLabel: l.supportsCustomLabel,
-        },
-      ];
+    if (!apps[category]) {
+      apps[category] = [];
     }
+    apps[category].push({
+      label: l.label,
+      value: l.type,
+      icon: l.iconUrl,
+      supportsCustomLabel: l.supportsCustomLabel,
+    });
   });
   const locations = [];
 


### PR DESCRIPTION
## Summary

Fixes #29959

## Problem

In \getLocationGroupedOptions\ (\packages/app-store/server.ts\), deduplicating options per category used \pps[groupByCategory].find((o) => o.value === option.value)\ along with array spreading inside loops. When many app credentials exist, this produces repeated \(O(N)\) linear scans and array allocations resulting in \(O(N^2)\) execution time.

## Fix

- Maintain a \seenOptionsByCategory: Record<string, Set<string>>\ for \(O(1)\) membership checks.
- Push directly into \pps[groupByCategory]\ rather than copying the array via spread syntax.
- Reduces worst-case deduplication complexity from \(O(N^2)\) to \(O(N)\).