### PR TITLE
fix: enable PKCE for Azure AD login

### DIFF
--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -336,6 +336,11 @@ if (OUTLOOK_LOGIN_ENABLED && OUTLOOK_CLIENT_ID && OUTLOOK_CLIENT_SECRET) {
       clientId: OUTLOOK_CLIENT_ID,
       clientSecret: OUTLOOK_CLIENT_SECRET,
       allowDangerousEmailAccountLinking: true,
+      // next-auth only defaults unconfigured providers to checks: ["state"] (see
+      // core/lib/providers.js) - unlike GoogleProvider, which enables PKCE itself.
+      // Set it explicitly so Azure AD's callback can't be satisfied without a PKCE
+      // verifier, matching every other OAuth provider registered here.
+      checks: ["pkce", "state"],
       authorization: {
         params: {
           scope: ["openid", "profile", "email", ...MICROSOFT_CALENDAR_SCOPES].join(" "),


### PR DESCRIPTION
## What

Adds an explicit `checks: ["pkce", "state"]` to the Azure AD (`AzureADProvider`) registration in `packages/features/auth/lib/next-auth-options.ts`.

## Why

Traced this directly against the installed `next-auth@4.24.13` package:

- `node_modules/next-auth/core/lib/providers.js:62` — any provider that doesn't set `.checks` explicitly gets defaulted to `checks: ["state"]` only.
- `node_modules/next-auth/providers/google.js:19` — `GoogleProvider` is the one built-in provider in this codebase that sets `checks: ["pkce", "state"]` itself.
- `node_modules/next-auth/providers/azure-ad.js` — no such default. Azure AD gets state-only protection unless the caller configures it.

So today, Azure AD login in this repo runs with state-only checks, no PKCE.

This matters because of [GHSA-x445-f3h2-j279](https://github.com/nextauthjs/next-auth/security/advisories/GHSA-x445-f3h2-j279): in `next-auth <= 4.24.14`, OAuth check cookies (state/nonce/PKCE) aren't bound to the provider that created them, so a cookie minted during one provider's authorization flow can potentially be replayed against a different provider's callback. One of the advisory's stated exploit conditions is "at least one target provider's callback can be satisfied without a PKCE verifier." Azure AD, as currently configured, is exactly that provider.

This PR closes that specific gap by requiring PKCE on Azure AD too, matching Google.

**What this PR does *not* do:** it does not fix the advisory itself. The actual fix is upstream, in `next-auth@4.24.15` (currently pinned to `4.24.13` in `apps/web/package.json`). That's a repo-wide dependency bump affecting every login method (Google/Azure/SAML/credentials), so it deserves its own PR and testing pass rather than being bundled here or into an unrelated feature PR.

## Testing

- `TZ=UTC yarn vitest run packages/features/auth/lib/next-auth-options.test.ts` — all 37 existing tests pass unchanged (they exercise the `signIn` callback, not the authorization-redirect/cookie layer, so this change is invisible to them by design - it only affects the OAuth authorize/callback cookie exchange).
- `tsc --noEmit` on `packages/features` — no new errors.
- Not manually verified against a live Azure AD tenant in this environment; the change is a one-line config addition using next-auth's own documented `checks` option, identical in shape to what `GoogleProvider` already does internally.