### PR TITLE
fix(paypal): handle zero-decimal currencies (JPY) during order creation (#29983)

### DIFF
--- a/packages/app-store/paypal/lib/Paypal.ts
+++ b/packages/app-store/paypal/lib/Paypal.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
 import { IS_PRODUCTION, WEBAPP_URL } from "@calcom/lib/constants";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import logger from "@calcom/lib/logger";
 import prisma from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
@@ -85,7 +86,7 @@ class Paypal {
           reference_id: referenceId,
           amount: {
             currency_code: currency,
-            value: (amount / 100).toString(),
+            value: convertFromSmallestToPresentableCurrencyUnit(amount, currency).toString(),
           },
         },
       ],


### PR DESCRIPTION
Closes #29983

### Summary of Changes
- Uses `convertFromSmallestToPresentableCurrencyUnit(amount, currency)` from `@calcom/lib/currencyConversions` when constructing PayPal order purchase unit amounts in `packages/app-store/paypal/lib/Paypal.ts`.
- Fixes critical pricing bug where zero-decimal currencies (such as Japanese Yen / `JPY`) were divided by 100, causing PayPal to collect only 1/100th of the organizer's configured price (e.g. ¥100 instead of ¥10,000).
- Preserves standard minor-unit conversions for decimal currencies (USD, EUR, GBP, etc.).

### Verification
- Verified against `@calcom/lib/currencyConversions`:
  - `JPY`: 10000 -> `"10000"` (sent as full unscaled unit)
  - `USD`: 5000 -> `"50"` (sent as $50.00)
