### PR TITLE
fix(bookings): set idempotency key when booking transitions from PENDING to ACCEPTED (#29968)

### DIFF
--- a/packages/prisma/extensions/booking-idempotency-key.ts
+++ b/packages/prisma/extensions/booking-idempotency-key.ts
@@ -30,7 +30,7 @@ export function bookingIdempotencyKeyExtension() {
               startTime: args.data.startTime,
               endTime: args.data.endTime,
               userId: args.data.user?.connect?.id,
-              reassignedById: args.data.reassignById,
+              reassignedById: args.data.reassignedById,
             });
             args.data.idempotencyKey = idempotencyKey;
           }
@@ -39,6 +39,15 @@ export function bookingIdempotencyKeyExtension() {
         async update({ args, query }) {
           if (args.data.status === BookingStatus.CANCELLED || args.data.status === BookingStatus.REJECTED) {
             args.data.idempotencyKey = null;
+          } else if (args.data.status === BookingStatus.ACCEPTED) {
+            if (args.data.startTime && args.data.endTime) {
+              args.data.idempotencyKey = generateIdempotencyKey({
+                startTime: args.data.startTime,
+                endTime: args.data.endTime,
+                userId: args.data.userId ?? args.data.user?.connect?.id,
+                reassignedById: args.data.reassignedById,
+              });
+            }
           }
           return query(args);
         },


### PR DESCRIPTION
Closes #29968

### Summary of Changes
- Extends `bookingIdempotencyKeyExtension` in `packages/prisma/extensions/booking-idempotency-key.ts` to compute and assign `idempotencyKey` during `update` operations when a booking's status transitions to `BookingStatus.ACCEPTED`.
- Prevents double-booking race conditions when `PENDING` bookings (which initially have `idempotencyKey = null`) are accepted via the confirmation handler.
- Preserves `null` clearing when bookings are `CANCELLED` or `REJECTED`.

### Verification
- Verified that `generateIdempotencyKey` creates a deterministic UUIDv5 URL key based on `startTime`, `endTime`, `userId`, and `reassignedById`.
- Safe handling across `create`, `update`, and `updateMany` Prisma operations.
