### PR TITLE
fix(security): prevent IDOR in updateWrongAssignmentReportStatus with team membership check (#29957)

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts
@@ -5,7 +5,6 @@ import type { TrpcSessionUser } from "@calcom/trpc/server/types";
 import { TRPCError } from "@trpc/server";
 import type { TUpdateWrongAssignmentReportStatusInputSchema } from "./updateWrongAssignmentReportStatus.schema";
 
-
 type UpdateWrongAssignmentReportStatusOptions = {
   ctx: {
     user: NonNullable<TrpcSessionUser>;
@@ -31,6 +30,20 @@ export const updateWrongAssignmentReportStatusHandler = async ({
     });
   }
 
+  const membership = await prisma.membership.findFirst({
+    where: {
+      userId: user.id,
+      teamId: report.teamId,
+      accepted: true,
+    },
+  });
+
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You are not authorized to review reports for this team",
+    });
+  }
 
   const updatedReport = await repo.updateStatus({
     id: reportId,


### PR DESCRIPTION
Closes #29957

### Summary of Changes
- Adds an explicit team membership verification check (`prisma.membership.findFirst({ where: { userId: user.id, teamId: report.teamId, accepted: true } })`) in `packages/trpc/server/routers/viewer/bookings/updateWrongAssignmentReportStatus.handler.ts`.
- Throws `TRPCError` with code `FORBIDDEN` if the caller is not an accepted member of the team associated with the wrong-assignment report.
- Resolves IDOR vulnerability that previously allowed any authenticated user to update or dismiss reports for arbitrary teams.

### Verification
- Verified that missing reports return `NOT_FOUND`.
- Verified that unauthorized callers attempting to update reports for foreign teams receive `FORBIDDEN`.
- Verified that valid team members can successfully update status.
