### PR TITLE
feat(i18n): add Persian (fa) to SUPPORTED_LOCALES (#30000)

### DIFF
--- a/packages/platform/constants/api.ts
+++ b/packages/platform/constants/api.ts
@@ -89,6 +89,8 @@ export const SUPPORTED_LOCALES = [
   "es-419",
   "eu",
   "et",
+  "fa",
+  "fa-IR",
   "fi",
   "fr",
   "he",


### PR DESCRIPTION
# Title
feat(i18n): add Persian (fa, fa-IR) to SUPPORTED_LOCALES (#30000)

## Description
- Adds `fa` and `fa-IR` to `SUPPORTED_LOCALES` in `packages/platform/constants/api.ts`.
- Enables recognition and locale negotiation for Persian/Farsi booking flows and API integrations.

Closes #30000
