### PR TITLE
perf(app-store): replace O(n^2) .find() with O(1) Set deduplication in getLocationGroupedOptions (#29959)

### DIFF
--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -26,6 +26,7 @@ export async function getLocationGroupedOptions(
       supportsCustomLabel?: boolean;
     }[]
   > = {};
+  const seenOptionsByCategory: Record<string, Set<string>> = {};
 
   // don't default to {}, when you do TS no longer determines the right types.
   let idToSearchObject: Prisma.CredentialWhereInput;
@@ -108,13 +109,13 @@ export async function getLocationGroupedOptions(
             ? { credentialId: app.credential.id, teamName: app.credential.team?.name ?? null }
             : {}),
         };
-        if (apps[groupByCategory]) {
-          const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
-          if (!existingOption) {
-            apps[groupByCategory] = [...apps[groupByCategory], option];
-          }
-        } else {
-          apps[groupByCategory] = [option];
+        if (!seenOptionsByCategory[groupByCategory]) {
+          seenOptionsByCategory[groupByCategory] = new Set();
+          apps[groupByCategory] = [];
+        }
+        if (!seenOptionsByCategory[groupByCategory].has(option.value)) {
+          seenOptionsByCategory[groupByCategory].add(option.value);
+          apps[groupByCategory].push(option);
         }
       }
     }


### PR DESCRIPTION
Closes #29959

### Summary of Changes
- Replaced $O(n^2)$ repeated `.find()` and spread-array reallocations in `getLocationGroupedOptions` with an $O(1)$ `seenOptionsByCategory: Record<string, Set<string>>` lookup table in `packages/app-store/server.ts`.
- Reduces duplicate option filtering time complexity from $O(n^2)$ to $O(n)$, drastically improving response latency and reducing server CPU overhead when accounts have dozens of installed app credentials.

### Verification
- Verified that output shape and grouping structure are identical to existing functionality while maintaining $O(1)$ per-item lookup cost.
