### PR TITLE
fix(security): prevent team webhook IDOR by enforcing ADMIN/OWNER role check (#29982)

### DIFF
--- a/packages/trpc/server/routers/viewer/webhook/util.ts
+++ b/packages/trpc/server/routers/viewer/webhook/util.ts
@@ -19,6 +19,7 @@ export const createWebhookProcedure = () => {
         select: {
           id: true,
           userId: true,
+          teamId: true,
           eventTypeId: true,
         },
       });
@@ -42,6 +43,18 @@ export const createWebhookProcedure = () => {
         }
 
         if (eventType.userId !== ctx.user.id) {
+          throw new TRPCError({ code: "FORBIDDEN" });
+        }
+      } else if (webhook.teamId) {
+        const membership = await prisma.membership.findFirst({
+          where: {
+            teamId: webhook.teamId,
+            userId: ctx.user.id,
+            accepted: true,
+            role: { in: ["ADMIN", "OWNER"] },
+          },
+        });
+        if (!membership) {
           throw new TRPCError({ code: "FORBIDDEN" });
         }
       } else if (webhook.userId && webhook.userId !== ctx.user.id) {


### PR DESCRIPTION
Closes #29982

### Summary of Changes
- Added `teamId` selection and explicit authorization verification in `createWebhookProcedure()` middleware (`packages/trpc/server/routers/viewer/webhook/util.ts`).
- When a webhook belongs to a team (`webhook.teamId`), the middleware checks `prisma.membership.findFirst({ where: { teamId: webhook.teamId, userId: ctx.user.id, accepted: true, role: { in: ["ADMIN", "OWNER"] } } })` and throws `TRPCError` with `FORBIDDEN` if the caller lacks administrative rights on the owning team.
- Prevents authorization bypass / IDOR vulnerability where regular team members could modify team webhooks and exfiltrate future booking payloads.

### Verification
- Verified that individual user webhooks continue to require `webhook.userId === ctx.user.id`.
- Verified that event-type webhooks continue to require `eventType.userId === ctx.user.id`.
- Verified that team webhooks now strictly enforce `ADMIN` or `OWNER` membership.
