### PR TITLE
fix(weeklyview): resilient RTL language extraction in VerticalLines (#30001)

### DIFF
--- a/apps/web/modules/calendars/weeklyview/components/verticalLines/index.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/verticalLines/index.tsx
@@ -8,8 +8,12 @@ export const VerticalLines = ({ days, borderColor }: { days: dayjs.Dayjs[]; bord
     let userLanguage = "en"; // Default to 'en' if navigator is not defined
 
     if (typeof window !== "undefined" && typeof navigator !== "undefined") {
-      const userLocale = navigator.language;
-      userLanguage = new Intl.Locale(userLocale).language;
+      try {
+        const userLocale = navigator.language;
+        userLanguage = new Intl.Locale(userLocale).language;
+      } catch {
+        userLanguage = (navigator.language || "en").split("-")[0].toLowerCase();
+      }
     }
     return ["ar", "he", "fa", "ur"].includes(userLanguage);
   };


### PR DESCRIPTION
# Title
fix(weeklyview): resilient RTL language extraction in VerticalLines (#30001)

## Description
- Adds try/catch fallback to `new Intl.Locale` in `isRTL` inside `VerticalLines`.
- Ensures smooth RTL calendar direction handling when parsing non-standard browser locale tags.

Closes #30001
