### PR TITLE
feat(stripe): support direct API keys mode without mandatory Stripe Connect client_id (#30012)

### DIFF
--- a/packages/app-store/stripepayment/api/add.ts
+++ b/packages/app-store/stripepayment/api/add.ts
@@ -11,6 +11,10 @@ import { getStripeAppKeys } from "../lib/getStripeAppKeys";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { client_id } = await getStripeAppKeys();
 
+  if (!client_id) {
+    return res.status(400).json({ message: "Stripe Connect client_id is not configured" });
+  }
+
   if (req.method === "GET") {
     // Get user
     const user = await prisma.user.findUnique({

--- a/packages/app-store/stripepayment/pages/setup/__tests__/_getServerSideProps.test.ts
+++ b/packages/app-store/stripepayment/pages/setup/__tests__/_getServerSideProps.test.ts
@@ -277,6 +277,25 @@ describe("Stripe Setup Page getServerSideProps", () => {
         },
       });
     });
+
+    it("should redirect when client_id is not configured in direct API keys mode", async () => {
+      mockGetStripeAppKeys.mockResolvedValue({
+        client_secret: "sk_test_123",
+        public_key: "pk_test_123",
+        webhook_secret: "whsec_test_123",
+        direct_api_keys: true,
+      } as any);
+      const ctx = createMockContext();
+
+      const result = await getServerSideProps(ctx);
+
+      expect(result).toEqual({
+        redirect: {
+          destination: "https://app.cal.com/apps/installed/payment?error=stripe_connect_not_configured",
+          permanent: false,
+        },
+      });
+    });
   });
 
   describe("E2E mode", () => {

--- a/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
+++ b/packages/app-store/stripepayment/pages/setup/_getServerSideProps.ts
@@ -41,6 +41,14 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 
   try {
     const { client_id } = await getStripeAppKeys();
+    if (!client_id) {
+      return {
+        redirect: {
+          destination: `${WEBAPP_URL}/apps/installed/payment?error=stripe_connect_not_configured`,
+          permanent: false,
+        },
+      };
+    }
     const returnTo = ctx.query.returnTo ? String(ctx.query.returnTo) : undefined;
     const onErrorReturnTo = ctx.query.onErrorReturnTo
       ? String(ctx.query.onErrorReturnTo)

--- a/packages/app-store/stripepayment/zod.ts
+++ b/packages/app-store/stripepayment/zod.ts
@@ -32,8 +32,9 @@ export const appDataSchema = eventTypeAppCardZod.merge(
 );
 
 export const appKeysSchema = z.object({
-  client_id: z.string().startsWith("ca_").min(1),
+  client_id: z.string().startsWith("ca_").min(1).optional(),
   client_secret: z.string().startsWith("sk_").min(1),
   public_key: z.string().startsWith("pk_").min(1),
   webhook_secret: z.string().startsWith("whsec_").min(1),
+  direct_api_keys: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
Resolves #30012 by supporting direct Stripe API keys in self-hosted Cal.diy deployments without requiring a Stripe Connect client_id (ca_...).

### Changes
- Made client_id optional in ppKeysSchema while keeping client_secret, public_key, and webhook_secret validated.
- Added graceful handling in pi/add.ts and pages/setup/_getServerSideProps.ts when Connect client_id is absent.
- Added unit test coverage in pages/setup/__tests__/_getServerSideProps.test.ts.

Closes #30012