### PR TITLE
fix: [Bug]: Out of Office allows saving overlapping date ranges without any w...

### DIFF
--- a/packages/features/ooo/repositories/PrismaOOORepository.ts
+++ b/packages/features/ooo/repositories/PrismaOOORepository.ts
@@ -52,6 +52,9 @@ export class PrismaOOORepository {
           },
         ],
       },
+      // Overlapping entries are flattened per-day downstream where the last entry wins, so a stable
+      // order is required to make the winning entry reproducible across identical requests.
+      orderBy: [{ start: "asc" }, { id: "asc" }],
       select: {
         id: true,
         start: true,
@@ -121,6 +124,9 @@ export class PrismaOOORepository {
           },
         ],
       },
+      // Overlapping entries are flattened per-day downstream where the last entry wins, so a stable
+      // order is required to make the winning entry reproducible across identical requests.
+      orderBy: [{ start: "asc" }, { id: "asc" }],
       select: {
         id: true,
         start: true,


### PR DESCRIPTION
Fixes #29951

## Root cause

Non-deterministic resolution of overlapping Out of Office entries

## Changes

- Added a deterministic orderBy [{ start: "asc" }, { id: "asc" }] to findManyOOO and findUserOOODays in PrismaOOORepository so the per-day last-write-wins flattening resolves to the most recently created overlapping entry, reproducibly. Whether overlaps should be rejected outright is an unanswered product decision and was intentionally not changed.