### PR TITLE
fix: prevent layout shift on Refer and earn page load

### DIFF
--- a/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
+++ b/apps/web/app/(use-page-wrapper)/refer/DubReferralsPage.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { DubEmbed } from "@dub/embed-react";
-import { useTheme } from "next-themes";
-import { useState, useEffect } from "react";
-
 import { IS_DUB_REFERRALS_ENABLED } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { showToast } from "@calcom/ui/components/toast";
+import { DubEmbed } from "@dub/embed-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import Loading from "./loading";
 
 const fetchReferralsToken = async () => {
   try {
@@ -30,6 +30,7 @@ const fetchReferralsToken = async () => {
 // The enabled referrals page implementation
 export const DubReferralsPage = () => {
   const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const { t } = useLocale();
   const { resolvedTheme } = useTheme();
 
@@ -41,13 +42,26 @@ export const DubReferralsPage = () => {
       } catch (err) {
         console.error("Error fetching referrals token:", err);
         showToast(t("unexpected_error_try_again"), "error");
+      } finally {
+        setIsLoading(false);
       }
     };
 
     getToken();
   }, [t]);
 
-  if (!IS_DUB_REFERRALS_ENABLED || !token) {
+  if (!IS_DUB_REFERRALS_ENABLED) {
+    return null;
+  }
+
+  // Keep the route's loading skeleton mounted for the duration of the client-side
+  // token fetch, otherwise the page collapses to zero height between the skeleton
+  // unmounting and the DubEmbed widget mounting, causing a visible bounce.
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!token) {
     return null;
   }
 


### PR DESCRIPTION
Fixes #29950

## What does this PR do?
The "Refer and earn" settings page (`/refer`) returned `null` from `DubReferralsPage` while the Dub referral token was being fetched client-side. This meant the page collapsed to zero height right after the route's `loading.tsx` skeleton unmounted, then popped back to full size once the `DubEmbed` widget mounted with the token — producing the jarring bounce/layout shift described in the issue.

This PR reuses the existing route `Loading` skeleton while the token fetch is in progress (tracked via a new `isLoading` state, set in the `useEffect`'s `finally` block), instead of rendering nothing during that window. The page now holds a consistent height through the client-side fetch phase, so there's no visible collapse or pop.

The change is minimal — only `DubReferralsPage.tsx` is modified, reusing the sibling `loading.tsx` skeleton component that already existed for the route-level Suspense fallback.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. — N/A, this is a UI-only fix with no doc-relevant changes.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
1. Set `NEXT_PUBLIC_DUB_PROGRAM_ID` to a non-empty value (this flag gates the whole feature via `IS_DUB_REFERRALS_ENABLED`).
2. Run the app locally and log in as any seeded user (e.g. `pro@example.com`).
3. Open DevTools → Network tab → throttle to "Slow 3G" so the transition is visible.
4. Click your profile name in the sidebar → "Refer and earn".
5. Expected: the loading skeleton stays visible and consistently sized for the duration of the token fetch — no visible collapse, jump, or bounce once the widget mounts.
