### PR TITLE
fix: Release status: v6.2.0 is impractical for self-hosted multi-user use whi...

### DIFF
--- a/packages/trpc/server/routers/features/_router.ts
+++ b/packages/trpc/server/routers/features/_router.ts
@@ -1,3 +1,4 @@
+import { getFeatureRepository } from "@calcom/features/di/containers/FeatureRepository";
 import { getFeaturesRepository } from "@calcom/features/di/containers/FeaturesRepository";
 import type { AppFlags } from "@calcom/features/flags/config";
 import publicProcedure from "@calcom/trpc/server/procedures/publicProcedure";
@@ -7,8 +8,8 @@ import { map } from "./map";
 
 export const featureFlagRouter = router({
   list: publicProcedure.query(async () => {
-    const featuresRepository = getFeaturesRepository();
-    return featuresRepository.getAllFeatures();
+    const featureRepository = getFeatureRepository();
+    return featureRepository.findAll();
   }),
   checkTeamFeature: publicProcedure
     .input(


### PR DESCRIPTION
Fixes #30013

## Root cause

features.list served from deprecated FeaturesRepository static 5-minute cache that flag mutations never invalidate

## Changes

- Serve viewer.features.list from the cache-invalidating FeatureRepository (CachedFeatureRepository, whose cache is busted by the toggleFeatureFlag mutation) instead of the deprecated FeaturesRepository static in-memory cache, plus a regression test asserting the delegation.