### PR TITLE
perf(app-store): dedupe location options with a Set instead of a linear scan

### DIFF
--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -27,6 +27,11 @@ export async function getLocationGroupedOptions(
     }[]
   > = {};
 
+  // Mirrors the option values already collected per category. Without it the
+  // dedupe below rescans the whole category array on every credential, which is
+  // quadratic once an account has many installed apps.
+  const seenValuesByCategory: Record<string, Set<string>> = {};
+
   // don't default to {}, when you do TS no longer determines the right types.
   let idToSearchObject: Prisma.CredentialWhereInput;
   let user = null;
@@ -108,13 +113,16 @@ export async function getLocationGroupedOptions(
             ? { credentialId: app.credential.id, teamName: app.credential.team?.name ?? null }
             : {}),
         };
-        if (apps[groupByCategory]) {
-          const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
-          if (!existingOption) {
-            apps[groupByCategory] = [...apps[groupByCategory], option];
+        const categoryOptions = apps[groupByCategory];
+        const seenValues = seenValuesByCategory[groupByCategory];
+        if (categoryOptions && seenValues) {
+          if (!seenValues.has(option.value)) {
+            seenValues.add(option.value);
+            categoryOptions.push(option);
           }
         } else {
           apps[groupByCategory] = [option];
+          seenValuesByCategory[groupByCategory] = new Set([option.value]);
         }
       }
     }


### PR DESCRIPTION
## What is the problem

`getLocationGroupedOptions` deduped location options with a linear scan, and then rebuilt the array it was scanning:

```ts
if (apps[groupByCategory]) {
  const existingOption = apps[groupByCategory].find((o) => o.value === option.value);
  if (!existingOption) {
    apps[groupByCategory] = [...apps[groupByCategory], option];
  }
}
```

Both halves are O(n) per credential, so the loop is quadratic in the number of installed apps. #29959 reports the `.find()`; the spread is a second, independent O(n) that also copies the whole array on every insert.

## The fix

Keep a `Set` of the values already collected per category and `push` onto the existing array, so each insert is O(1).

Semantics are deliberately unchanged: the first option for a given value still wins, and insertion order is preserved.

## Verification

The requirement in the issue is that output stays identical, so I checked that directly rather than reasoning about it. Both algorithms were run over 400 randomised inputs (up to 60 entries, 4 categories, 12 distinct values, so duplicates are frequent) and compared by deep equality:

```
random trials: 400, output mismatches: 0
```

Timing the two on a single category shows the change in growth:

```
n=1000  old=  12.1ms  new= 0.1ms
n=4000  old=  63.3ms  new= 0.5ms
n=8000  old= 339.7ms  new= 2.1ms
```

The old path grows faster than linearly as `n` doubles; the new one does not. At 8000 options that is 339.7 ms to 2.1 ms.

Those numbers come from a standalone harness reproducing both variants of the dedupe, not from the app, because reaching this function requires Prisma plus `getEnabledAppsFromCredentials`. I have not added a Vitest case for the same reason: there is currently no test covering `getLocationGroupedOptions`, and the mocking needed to reach it is considerably larger than this diff. Happy to add one if you would rather the dedupe contract were pinned in the suite.

## Scope

One file, +12/-4.

`defaultLocations.forEach` just below uses the same spread-to-append pattern, and I left it alone on purpose: it iterates a fixed, small list rather than user credentials, so it is not quadratic in anything an account controls, and changing it would add diff without addressing the issue. Say the word if you would like it converted for consistency.

Closes #29959
