### PR TITLE
fix(availability): use 24-hour format when detecting the DST offset shift

### DIFF
--- a/packages/features/schedules/lib/date-ranges.test.ts
+++ b/packages/features/schedules/lib/date-ranges.test.ts
@@ -158,6 +158,36 @@ describe("processWorkingHours", () => {
     vi.useRealTimers();
   });
 
+  // The existing DST-change coverage above uses a 9 AM start, where 12- and 24-hour
+  // formatting coincide. An afternoon start is the case that exposes the difference.
+  it("It has the correct working hours on date of DST change for an afternoon schedule", () => {
+    const item = {
+      days: [0], // 2026-03-08 (the spring-forward date in America/New_York) is a Sunday
+      startTime: new Date(Date.UTC(2023, 5, 12, 13, 0)), // 1 PM
+      endTime: new Date(Date.UTC(2023, 5, 12, 18, 0)), // 6 PM
+    };
+
+    const timeZone = "America/New_York";
+
+    const results = Object.values(
+      processWorkingHours(
+        {},
+        {
+          item,
+          timeZone,
+          dateFrom: dayjs.utc("2026-03-08T00:00:00.000Z"),
+          dateTo: dayjs.utc("2026-03-09T00:00:00.000Z"),
+          travelSchedules: [],
+        }
+      )
+    );
+
+    // DST starts at 02:00 local, so the whole afternoon is EDT (UTC-4): 13:00-18:00 => 17:00-22:00 UTC.
+    expect(
+      results.map((range) => ({ start: range.start.toISOString(), end: range.end.toISOString() }))
+    ).toStrictEqual([{ start: "2026-03-08T17:00:00.000Z", end: "2026-03-08T22:00:00.000Z" }]);
+  });
+
   // TEMPORAIRLY SKIPPING THIS TEST - Started failing after 29th Oct
   it.skip("should return the correct working hours in the month were DST ends", () => {
     const item = {

--- a/packages/features/schedules/lib/date-ranges.ts
+++ b/packages/features/schedules/lib/date-ranges.ts
@@ -67,7 +67,7 @@ export function processWorkingHours(
 
     let end = dateInTz.add(item.endTime.getUTCHours(), "hours").add(item.endTime.getUTCMinutes(), "minutes");
 
-    const offsetBeginningOfDay = dayjs(start.format("YYYY-MM-DD hh:mm")).tz(adjustedTimezone).utcOffset();
+    const offsetBeginningOfDay = dayjs(start.format("YYYY-MM-DD HH:mm")).tz(adjustedTimezone).utcOffset();
     const offsetDiff = start.utcOffset() - offsetBeginningOfDay; // there will be 60 min offset on the day day of DST change
 
     start = start.add(offsetDiff, "minute");


### PR DESCRIPTION
## What does this PR do?

- Fixes #30021

The DST correction in `processWorkingHours` sampled the day's UTC offset from a **12-hour**
formatted timestamp:

```ts
const offsetBeginningOfDay = dayjs(start.format("YYYY-MM-DD hh:mm")).tz(adjustedTimezone).utcOffset();
const offsetDiff = start.utcOffset() - offsetBeginningOfDay; // 60 min offset on the day of DST change
start = start.add(offsetDiff, "minute");
end = end.add(offsetDiff, "minute");
```

`hh` is 12-hour, so a 13:00 start was probed as 01:00 and a 14:30 start as 02:30 — the wrong time
of day, and on the wrong side of the transition. `offsetDiff` came back as 60 and the correction
fired when it should not have, moving both bounds an hour later.

For a 1 PM – 6 PM `America/New_York` schedule on the spring-forward date, the emitted window was
`18:00 → 23:00` UTC instead of `17:00 → 22:00` — the organizer's **1 PM – 6 PM became 2 PM – 7 PM**.
Bookers were offered the hour past the end of availability, and the real first hour was dropped.

Switching to `HH` makes the probe read the actual start time, so the correction only applies when
the offset genuinely differs.

**Scope:** only start times ≥ 13:00 were affected, because `hh` and `HH` agree below that. That is
also why this was never caught — the existing DST test in `date-ranges.test.ts` uses a 9 AM start.
The added test uses an afternoon start.

As noted in the issue, the same line also derives its comparison value from a string parsed in the
**server's** local timezone, which shifts morning schedules on non-UTC hosts. That is a separate
defect and is **intentionally not addressed here**: the obvious repair
(`start.startOf("day").utcOffset()`) makes the result consistent across hosts but consistently
wrong, regressing the UTC path that currently works. It needs its own change.

## Visual Demo (For contributors especially)

No UI surface — the booking page renders whatever window is computed, so before and after are two
ordinary-looking but different sets of slots. The meaningful evidence is the computed window.

**Before (fix reverted, test in place)** — both bounds an hour late:

```
AssertionError: expected [ { …(2) } ] to strictly equal [ { …(2) } ]

- Expected
+ Received

  [
    {
-     "end": "2026-03-08T22:00:00.000Z",
-     "start": "2026-03-08T17:00:00.000Z",
+     "end": "2026-03-08T23:00:00.000Z",
+     "start": "2026-03-08T18:00:00.000Z",
    }
  ]
```

**After (this PR)**:

```
 ✓ packages/features/schedules/lib/date-ranges.test.ts (53 tests | 2 skipped)

 Test Files  1 passed (1)
      Tests  51 passed | 2 skipped (53)
```

Measured across the transition, 1 PM – 6 PM `America/New_York`, server `TZ=UTC`:

| Date | Before | After | Correct |
| --- | --- | --- | --- |
| 2026-03-06 | `18:00 → 23:00` | `18:00 → 23:00` | ✅ unchanged |
| 2026-03-07 | `18:00 → 23:00` | `18:00 → 23:00` | ✅ unchanged |
| **2026-03-08** | **`18:00 → 23:00`** ❌ | **`17:00 → 22:00`** ✅ | fixed |
| 2026-03-09 | `17:00 → 22:00` | `17:00 → 22:00` | ✅ unchanged |
| 2026-03-10 | `17:00 → 22:00` | `17:00 → 22:00` | ✅ unchanged |

A 9 AM – 5 PM schedule is byte-for-byte unchanged by this PR, as expected.

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, internal availability calculation with no documented API change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or external services required:

```bash
TZ=UTC yarn vitest run packages/features/schedules/lib/date-ranges.test.ts
```

To see it fail without the fix, change `HH` back to `hh` on the `offsetBeginningOfDay` line in
`date-ranges.ts` and re-run.

Full availability coverage, all green with the fix — 192 tests, no collateral change:

```bash
TZ=UTC yarn vitest run \
  packages/features/schedules/lib/date-ranges.test.ts \
  packages/features/schedules/lib/slots.test.ts \
  apps/web/test/lib/getSchedule.test.ts
TZ=UTC VITEST_MODE=timezone yarn vitest run
```

Manual verification:

- **Minimal test data:** an organizer whose schedule timezone observes DST (e.g. `America/New_York`),
  with availability set to **1:00 PM – 6:00 PM**.
- **Steps:** open the booking page for a DST transition date — **2026-03-08** for US spring forward.
- **Expected (happy path):** slots run 1 PM – 6 PM local. Before this change they ran 2 PM – 7 PM.
- Repeat with a **9:00 AM – 5:00 PM** schedule to confirm morning behaviour is unchanged.
