### PR TITLE
refactor: remove unused optional props and arguments in apps/web

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/SettingsLayoutAppDirClient.tsx
@@ -32,7 +32,6 @@ const getTabs = (
     slug?: string;
     name?: string;
     logoUrl?: string | null;
-    fullDomain?: string | null;
   } | null
 ) => {
   const tabs: VerticalTabItemProps[] = [

--- a/apps/web/app/SpeculationRules.tsx
+++ b/apps/web/app/SpeculationRules.tsx
@@ -1,19 +1,11 @@
 import Script from "next/script";
 
 export function SpeculationRules({
-  prefetchPathsOnHover = [],
   prerenderPathsOnHover = [],
 }: {
-  prefetchPathsOnHover?: string[];
   prerenderPathsOnHover?: string[];
 }) {
   const speculationRules = {
-    prefetch: [
-      {
-        urls: prefetchPathsOnHover,
-        eagerness: "moderate",
-      },
-    ],
     prerender: [
       {
         urls: prerenderPathsOnHover,

--- a/apps/web/components/booking/AcceptBookingButton.tsx
+++ b/apps/web/components/booking/AcceptBookingButton.tsx
@@ -10,8 +10,6 @@ interface AcceptBookingButtonProps {
   isRecurring?: boolean;
   isTabRecurring?: boolean;
   isTabUnconfirmed?: boolean;
-  size?: "sm" | "base" | "lg";
-  color?: "primary" | "secondary" | "minimal" | "destructive";
   className?: string;
 }
 
@@ -22,8 +20,6 @@ export function AcceptBookingButton({
   isRecurring = false,
   isTabRecurring = false,
   isTabUnconfirmed = false,
-  size = "base",
-  color = "primary",
   className,
 }: AcceptBookingButtonProps) {
   const { t } = useLocale();
@@ -38,8 +34,6 @@ export function AcceptBookingButton({
 
   return (
     <Button
-      color={color}
-      size={size}
       className={className}
       onClick={() => bookingConfirm({ bookingId, confirmed: true, recurringEventId })}
       disabled={isPending}

--- a/apps/web/components/booking/RejectBookingButton.tsx
+++ b/apps/web/components/booking/RejectBookingButton.tsx
@@ -11,8 +11,6 @@ interface RejectBookingButtonProps {
   isRecurring?: boolean;
   isTabRecurring?: boolean;
   isTabUnconfirmed?: boolean;
-  size?: "sm" | "base" | "lg";
-  color?: "primary" | "secondary" | "minimal" | "destructive";
   className?: string;
 }
 
@@ -23,8 +21,6 @@ export function RejectBookingButton({
   isRecurring = false,
   isTabRecurring = false,
   isTabUnconfirmed = false,
-  size = "base",
-  color = "secondary",
   className,
 }: RejectBookingButtonProps) {
   const { t } = useLocale();
@@ -48,8 +44,6 @@ export function RejectBookingButton({
       />
 
       <Button
-        color={color}
-        size={size}
         className={className}
         onClick={handleReject}
         disabled={isPending}

--- a/apps/web/components/booking/actions/BookingActionsDropdown.tsx
+++ b/apps/web/components/booking/actions/BookingActionsDropdown.tsx
@@ -44,7 +44,6 @@ import {
 
 interface BookingActionsDropdownProps {
   booking: BookingItemProps;
-  size?: "xs" | "sm" | "base" | "lg";
   className?: string;
   /**
    * Whether to use a portal for the dropdown menu.
@@ -62,7 +61,6 @@ interface BookingActionsDropdownProps {
 
 export function BookingActionsDropdown({
   booking,
-  size = "base",
   className,
   usePortal = true,
   context,
@@ -545,7 +543,6 @@ export function BookingActionsDropdown({
           <Button
             type="button"
             color="secondary"
-            size={size}
             StartIcon="ellipsis"
             className={classNames("px-2", className)}
             // Prevent click from bubbling to parent row/container click handlers

--- a/apps/web/components/dialog/CancelBookingDialog.tsx
+++ b/apps/web/components/dialog/CancelBookingDialog.tsx
@@ -49,7 +49,6 @@ interface ICancelBookingDialog {
   isHost: boolean;
   internalNotePresets?: { id: number; name: string; cancellationReason: string | null }[];
   eventTypeMetadata?: Record<string, unknown> | null;
-  requiresCancellationReason?: CancellationReasonRequirement | null;
 }
 
 export const CancelBookingDialog = (props: ICancelBookingDialog) => {
@@ -69,7 +68,6 @@ export const CancelBookingDialog = (props: ICancelBookingDialog) => {
     isHost,
     internalNotePresets = [],
     eventTypeMetadata,
-    requiresCancellationReason,
   } = props;
 
   const utils = trpc.useUtils();
@@ -116,7 +114,6 @@ export const CancelBookingDialog = (props: ICancelBookingDialog) => {
           isHost={isHost}
           internalNotePresets={internalNotePresets}
           eventTypeMetadata={eventTypeMetadata}
-          requiresCancellationReason={requiresCancellationReason}
           showErrorAsToast={true}
           onCanceled={handleCanceled}
         />

--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -50,7 +50,6 @@ const LocationInput = (props: {
   required: boolean;
   placeholder: string;
   className?: string;
-  defaultValue?: string;
 }): JSX.Element | null => {
   const { eventLocationType, locationFormMethods, ...remainingProps } = props;
   const { control } = useFormContext() as typeof locationFormMethods;
@@ -59,15 +58,12 @@ const LocationInput = (props: {
       <Input {...locationFormMethods.register(eventLocationType.variable)} type="text" {...remainingProps} />
     );
   } else if (eventLocationType?.organizerInputType === "phone") {
-    const { defaultValue, ...rest } = remainingProps;
-
     return (
       <Controller
         name={eventLocationType.variable}
         control={control}
-        defaultValue={defaultValue}
         render={({ field: { onChange, value } }) => {
-          return <PhoneInput onChange={onChange} value={value} {...rest} />;
+          return <PhoneInput onChange={onChange} value={value} {...remainingProps} />;
         }}
       />
     );

--- a/apps/web/components/dialog/EditLocationDialog.tsx
+++ b/apps/web/components/dialog/EditLocationDialog.tsx
@@ -35,15 +35,11 @@ interface ISetLocationDialog {
     newLocation: string;
     credentialId: number | null;
   }) => Promise<void>;
-  selection?: LocationOption;
   booking: {
     location: string | null;
   };
-  defaultValues?: LocationObject[];
   setShowLocationModal: React.Dispatch<React.SetStateAction<boolean>>;
   isOpenDialog: boolean;
-  setSelectedLocation?: (param: LocationOption | undefined) => void;
-  setEditingLocationType?: (param: string) => void;
   teamId?: number;
 }
 
@@ -82,27 +78,13 @@ const LocationInput = (props: {
 export const EditLocationDialog = (props: ISetLocationDialog) => {
   const {
     saveLocation,
-    selection,
     booking,
     setShowLocationModal,
     isOpenDialog,
-    defaultValues,
-    setSelectedLocation,
-    setEditingLocationType,
     teamId,
   } = props;
   const { t } = useLocale();
   const locationsQuery = trpc.viewer.apps.locationOptions.useQuery({ teamId });
-
-  useEffect(() => {
-    if (selection) {
-      locationFormMethods.setValue("locationType", selection?.value);
-      if (selection?.address) {
-        locationFormMethods.setValue("locationAddress", selection?.address);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection]);
 
   const locationFormSchema = z.object({
     locationType: z.string(),
@@ -170,16 +152,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
 
   const eventLocationType = getLocationByType(selectedLocation);
 
-  const defaultLocation = defaultValues?.find(
-    (location: { type: EventLocationType["type"]; address?: string }) => {
-      if (location.type === LocationType.InPerson) {
-        return location.type === eventLocationType?.type && location.address === selectedAddrValue;
-      } else {
-        return location.type === eventLocationType?.type;
-      }
-    }
-  );
-
   /**
    * Depending on the location type that is selected, we show different input types or no input at all.
    */
@@ -202,9 +174,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
               id="locationInput"
               placeholder={t(eventLocationType.organizerInputPlaceholder || "")}
               required
-              defaultValue={
-                defaultLocation ? defaultLocation[eventLocationType.defaultValueVariable] : undefined
-              }
             />
             <ErrorMessage
               errors={locationFormMethods.formState.errors}
@@ -244,7 +213,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
               });
               setIsLocationUpdating(false);
               setShowLocationModal(false);
-              setSelectedLocation?.(undefined);
               locationFormMethods.unregister([
                 "locationType",
                 "locationLink",
@@ -295,7 +263,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                           <LocationSelect
                             maxMenuHeight={300}
                             name="location"
-                            defaultValue={selection}
                             options={locationOptions}
                             isSearchable
                             onChange={(val) => {
@@ -312,7 +279,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
                                   "locationPhoneNumber",
                                   "locationAddress",
                                 ]);
-                                setSelectedLocation?.(val);
                               }
                             }}
                           />
@@ -329,8 +295,6 @@ export const EditLocationDialog = (props: ISetLocationDialog) => {
             <Button
               onClick={() => {
                 setShowLocationModal(false);
-                setSelectedLocation?.(undefined);
-                setEditingLocationType?.("");
                 locationFormMethods.unregister(["locationType", "locationLink"]);
               }}
               type="button"

--- a/apps/web/components/integrations/SubHeadingTitleWithConnections.tsx
+++ b/apps/web/components/integrations/SubHeadingTitleWithConnections.tsx
@@ -9,21 +9,6 @@ function pluralize(opts: { num: number; plural: string; singular: string }) {
   return opts.singular;
 }
 
-export default function SubHeadingTitleWithConnections(props: { title: ReactNode; numConnections?: number }) {
-  const num = props.numConnections;
-  return (
-    <>
-      <span>{props.title}</span>
-      {num ? (
-        <Badge variant="success">
-          {num}{" "}
-          {pluralize({
-            num,
-            singular: "connection",
-            plural: "connections",
-          })}
-        </Badge>
-      ) : null}
-    </>
-  );
+export default function SubHeadingTitleWithConnections(props: { title: ReactNode }) {
+  return <span>{props.title}</span>;
 }

--- a/apps/web/components/phone-input/PhoneInput.tsx
+++ b/apps/web/components/phone-input/PhoneInput.tsx
@@ -21,7 +21,6 @@ export type PhoneInputProps = {
   name?: string;
   disabled?: boolean;
   onChange: (value: string) => void;
-  defaultCountry?: string;
   inputStyle?: CSSProperties;
   flagButtonStyle?: CSSProperties;
 };
@@ -31,12 +30,11 @@ function BasePhoneInput({
   className = "",
   onChange,
   value,
-  defaultCountry = "us",
   ...rest
 }: PhoneInputProps) {
   const isPlatform = useIsPlatform();
   const defaultPhoneCountryFromStore = useBookerStore((state) => state.defaultPhoneCountry);
-  const effectiveDefaultCountry = defaultPhoneCountryFromStore || defaultCountry;
+  const effectiveDefaultCountry = defaultPhoneCountryFromStore || "us";
 
   // This is to trigger validation on prefill value changes
   useEffect(() => {
@@ -110,7 +108,7 @@ function BasePhoneInputWeb({
   inputStyle,
   flagButtonStyle,
   ...rest
-}: Omit<PhoneInputProps, "defaultCountry">) {
+}: PhoneInputProps) {
   const defaultCountry = useDefaultCountry();
 
   return (

--- a/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
+++ b/apps/web/components/ui/UsernameAvailability/PremiumTextfield.tsx
@@ -36,7 +36,6 @@ interface ICustomUsernameProps {
   setInputUsernameValue: (value: string) => void;
   onSuccessMutation?: () => void;
   onErrorMutation?: (error: TRPCClientErrorLike<AppRouter>) => void;
-  readonly?: boolean;
 }
 
 const obtainNewUsernameChangeCondition = ({
@@ -66,7 +65,6 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
     usernameRef,
     onSuccessMutation,
     onErrorMutation,
-    readonly: disabled,
   } = props;
   const [user] = trpc.viewer.me.get.useSuspenseQuery();
   const [usernameIsAvailable, setUsernameIsAvailable] = useState(false);
@@ -215,7 +213,6 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
             autoComplete="none"
             autoCapitalize="none"
             autoCorrect="none"
-            disabled={disabled}
             className={classNames(
               "border-l my-0 rounded-md font-sans text-sm leading-4 focus:ring-0! sm:rounded-l-none",
               isInputUsernamePremium
@@ -223,8 +220,7 @@ const PremiumTextfield = (props: ICustomUsernameProps) => {
                 : "border focus:border",
               markAsError
                 ? "focus:shadow-0 focus:ring-shadow-0 border-red-500  focus:border-red-500 focus:outline-none"
-                : "border-l-default",
-              disabled ? "bg-subtle text-muted focus:border-0" : ""
+                : "border-l-default"
             )}
             value={inputUsernameValue}
             onChange={(event) => {

--- a/apps/web/modules/apps/components/DisconnectIntegration.tsx
+++ b/apps/web/modules/apps/components/DisconnectIntegration.tsx
@@ -13,8 +13,6 @@ export default function DisconnectIntegration(props: {
   credentialId: number;
   teamId?: number | null;
   label?: string;
-  trashIcon?: boolean;
-  isGlobal?: boolean;
   onSuccess?: () => void;
   buttonProps?: ButtonProps;
 }) {

--- a/apps/web/modules/bookings/components/JoinMeetingButton.tsx
+++ b/apps/web/modules/bookings/components/JoinMeetingButton.tsx
@@ -10,20 +10,14 @@ interface JoinMeetingButtonProps {
   location: string | null;
   metadata?: unknown;
   bookingStatus: BookingStatus;
-  size?: "sm" | "base" | "lg";
-  color?: "primary" | "secondary" | "minimal" | "destructive";
   className?: string;
-  onClick?: (e: React.MouseEvent) => void;
 }
 
 export function JoinMeetingButton({
   location,
   metadata,
   bookingStatus,
-  size = "base",
-  color = "secondary",
   className,
-  onClick,
 }: JoinMeetingButtonProps) {
   const { t } = useLocale();
   const { isJoinable, locationToDisplay, provider } = useJoinableLocation({
@@ -39,13 +33,10 @@ export function JoinMeetingButton({
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    onClick?.(e);
   };
 
   return (
     <Button
-      color={color}
-      size={size}
       href={locationToDisplay}
       target="_blank"
       rel="noopener noreferrer"

--- a/apps/web/modules/bookings/components/event-meta/Details.tsx
+++ b/apps/web/modules/bookings/components/event-meta/Details.tsx
@@ -45,9 +45,6 @@ interface EventMetaProps extends React.HTMLAttributes<HTMLDivElement> {
   customIcon?: React.ReactNode;
   icon?: IconName;
   iconUrl?: string;
-  // Emphasises the text in the block. For now only
-  // applying in dark mode.
-  highlight?: boolean;
   contentClassName?: string;
   isDark?: boolean;
 }
@@ -72,7 +69,6 @@ export const EventMetaBlock = ({
   icon,
   iconUrl,
   children,
-  highlight,
   contentClassName,
   className,
   isDark,
@@ -83,8 +79,7 @@ export const EventMetaBlock = ({
   return (
     <div
       className={classNames(
-        "flex items-start justify-start text-sm",
-        highlight ? "text-emphasis" : "text-text",
+        "flex items-start justify-start text-sm text-text",
         className
       )}
       {...rest}>

--- a/apps/web/modules/bookings/hooks/useBookings.ts
+++ b/apps/web/modules/bookings/hooks/useBookings.ts
@@ -50,7 +50,6 @@ export interface IUseBookings {
   bookingForm: UseBookingFormReturnType["bookingForm"];
   metadata: Record<string, string>;
   teamMemberEmail?: string | null;
-  isBookingDryRun?: boolean;
 }
 
 const getBaseBookingEventPayload = (booking: {
@@ -84,7 +83,6 @@ const getBookingSuccessfulEventPayload = (booking: {
   paymentRequired: boolean;
   uid?: string;
   isRecurring: boolean;
-  videoCallUrl?: string;
 }) => {
   return {
     uid: booking.uid,
@@ -108,7 +106,7 @@ export interface IUseBookingErrors {
 }
 export type UseBookingsReturnType = ReturnType<typeof useBookings>;
 
-export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookingDryRun }: IUseBookings) => {
+export const useBookings = ({ event, hashedLink, bookingForm, metadata }: IUseBookings) => {
   const router = useRouter();
   const eventSlug = useBookerStoreContext((state) => state.eventSlug);
   const eventTypeId = useBookerStoreContext((state) => state.eventId);
@@ -416,7 +414,6 @@ export const useBookings = ({ event, hashedLink, bookingForm, metadata, isBookin
     metadata,
     handleRecBooking: createRecurringBookingMutation.mutate,
     handleBooking: createBookingMutation.mutate,
-    isBookingDryRun,
   });
 
   const errors = {

--- a/apps/web/modules/bookings/hooks/useBookings.ts
+++ b/apps/web/modules/bookings/hooks/useBookings.ts
@@ -60,7 +60,6 @@ const getBaseBookingEventPayload = (booking: {
   status?: BookingStatus;
   paymentRequired: boolean;
   isRecurring: boolean;
-  videoCallUrl?: string;
 }) => {
   return {
     title: booking.title,
@@ -70,7 +69,6 @@ const getBaseBookingEventPayload = (booking: {
     status: booking.status,
     paymentRequired: booking.paymentRequired,
     isRecurring: booking.isRecurring,
-    videoCallUrl: booking.videoCallUrl,
   };
 };
 

--- a/apps/web/modules/bookings/hooks/useNearestFutureBooking.ts
+++ b/apps/web/modules/bookings/hooks/useNearestFutureBooking.ts
@@ -10,7 +10,6 @@ interface UseNearestFutureBookingProps {
     statuses: BookingListingStatus[];
     userIds?: number[];
   };
-  enabled?: boolean;
 }
 
 /**
@@ -24,7 +23,6 @@ interface UseNearestFutureBookingProps {
 export function useNearestFutureBooking({
   currentWeekStart,
   filters,
-  enabled = true,
 }: UseNearestFutureBookingProps) {
   // Search from the end of current week to NAVIGATION_PROBE_WINDOW_MONTHS months ahead
   const afterDate = currentWeekStart.add(1, "week").startOf("day");
@@ -42,7 +40,6 @@ export function useNearestFutureBooking({
       // Default sort for "upcoming" status is ASC, which gives us the nearest future booking
     },
     {
-      enabled,
       staleTime: 5 * 60 * 1000, // 5 minutes
     }
   );

--- a/apps/web/modules/bookings/hooks/useNearestPastBooking.ts
+++ b/apps/web/modules/bookings/hooks/useNearestPastBooking.ts
@@ -10,7 +10,6 @@ interface UseNearestPastBookingProps {
     statuses: BookingListingStatus[];
     userIds?: number[];
   };
-  enabled?: boolean;
 }
 
 /**
@@ -25,7 +24,6 @@ interface UseNearestPastBookingProps {
 export function useNearestPastBooking({
   currentWeekStart,
   filters,
-  enabled = true,
 }: UseNearestPastBookingProps) {
   // Search from NAVIGATION_PROBE_WINDOW_MONTHS months ago to the start of current week
   const afterDate = currentWeekStart.subtract(NAVIGATION_PROBE_WINDOW_MONTHS, "month").startOf("day");
@@ -43,7 +41,6 @@ export function useNearestPastBooking({
       sort: { sortStart: "desc" }, // Get the closest past booking first
     },
     {
-      enabled,
       staleTime: 5 * 60 * 1000, // 5 minutes
     }
   );

--- a/apps/web/modules/bookings/store/bookingDetailsSheetStore.tsx
+++ b/apps/web/modules/bookings/store/bookingDetailsSheetStore.tsx
@@ -215,11 +215,9 @@ function useBiDirectionalSyncBetweenStoreAndUrl({ store }: { store: BookingDetai
 export function BookingDetailsSheetStoreProvider({
   children,
   bookings,
-  capabilities,
 }: {
   children: React.ReactNode;
   bookings: BookingOutput[];
-  capabilities?: NavigationCapabilities | null;
 }) {
   const [store] = useState(() => createBookingDetailsSheetStore(bookings));
   const previousBookingsRef = useRef<BookingOutput[]>(bookings);
@@ -234,11 +232,6 @@ export function BookingDetailsSheetStoreProvider({
     store.getState().setBookings(bookings);
     previousBookingsRef.current = bookings;
   }, [bookings, store]);
-
-  // Update capabilities when they change
-  useEffect(() => {
-    store.getState().setCapabilities(capabilities ?? null);
-  }, [capabilities, store]);
 
   useBiDirectionalSyncBetweenStoreAndUrl({ store });
 

--- a/apps/web/modules/calendars/components/SelectedCalendarsSettingsWebWrapper.tsx
+++ b/apps/web/modules/calendars/components/SelectedCalendarsSettingsWebWrapper.tsx
@@ -22,7 +22,6 @@ type SelectedCalendarsSettingsWebWrapperProps = {
   fromOnboarding?: boolean;
   destinationCalendarId?: string;
   isPending?: boolean;
-  classNames?: string;
   eventTypeId?: number;
   disabledScope?: SelectedCalendarSettingsScope;
   scope?: SelectedCalendarSettingsScope;
@@ -38,7 +37,6 @@ const ConnectedCalendarList = ({
   disableConnectionModification,
   eventTypeId,
   onChanged,
-  destinationCalendarId,
   isDisabled,
 }: {
   fromOnboarding?: boolean;
@@ -47,7 +45,6 @@ const ConnectedCalendarList = ({
   disableConnectionModification?: boolean;
   eventTypeId: number | null;
   onChanged?: () => unknown | Promise<unknown>;
-  destinationCalendarId?: string;
   isDisabled: boolean;
 }) => {
   const { t } = useLocale();
@@ -89,7 +86,7 @@ const ConnectedCalendarList = ({
                           name={cal.name || "Nameless calendar"}
                           type={connectedCalendar.integration.type}
                           isChecked={cal.isSelected}
-                          destination={cal.externalId === destinationCalendarId}
+                          destination={false}
                           credentialId={cal.credentialId}
                           eventTypeId={(() => {
                             if (shouldUseEventTypeScope) {
@@ -176,7 +173,7 @@ export const SelectedCalendarsSettingsWebWrapper = (props: SelectedCalendarsSett
   const shouldDisableConnectionModification = isDisabled || disableConnectionModification;
   return (
     <div>
-      <SelectedCalendarsSettings classNames={props.classNames}>
+      <SelectedCalendarsSettings>
         <SelectedCalendarsSettingsHeading
           isConnectedCalendarsPresent={!!query.data?.connectedCalendars.length}
           isPending={isPending}

--- a/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/event/Empty.tsx
@@ -13,8 +13,6 @@ import type { GridCellToDateProps } from "@calcom/features/calendars/weeklyview/
 import { gridCellToDateTime } from "@calcom/features/calendars/weeklyview/utils";
 
 type EmptyCellProps = GridCellToDateProps & {
-  isDisabled?: boolean;
-  topOffsetMinutes?: number;
 };
 
 export function EmptyCell(props: EmptyCellProps) {
@@ -132,12 +130,11 @@ export function AvailableCellsForDay({ timezone, availableSlots, day, startHour 
 }
 
 type CellProps = {
-  isDisabled?: boolean;
   topOffsetMinutes?: number;
   timeSlot: Dayjs;
 };
 
-function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
+function Cell({ topOffsetMinutes, timeSlot }: CellProps) {
   const { timeFormat } = useTimePreferences();
 
   const { onEmptyCellClick, hoverEventDuration } = useCalendarStore(
@@ -152,11 +149,9 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
     <div
       className={classNames(
         "group flex w-[calc(100%-1px)] items-center justify-center",
-        isDisabled && "pointer-events-none",
-        !isDisabled && "bg-default dark:bg-cal-muted",
+        "bg-default dark:bg-cal-muted",
         topOffsetMinutes && "absolute"
       )}
-      data-disabled={isDisabled}
       data-slot={timeSlot.toISOString()}
       data-testid="calendar-empty-cell"
       style={{
@@ -167,7 +162,7 @@ function Cell({ isDisabled, topOffsetMinutes, timeSlot }: CellProps) {
       onClick={() => {
         onEmptyCellClick?.(timeSlot.toDate());
       }}>
-      {!isDisabled && hoverEventDuration !== 0 && (
+      {hoverEventDuration !== 0 && (
         <div
           className={classNames(
             "bg-brand-default hover:bg-brand-default text-brand dark:border-emphasis absolute hidden rounded-[4px] p-[6px] text-xs font-semibold leading-5 group-hover:flex group-hover:cursor-pointer",

--- a/apps/web/modules/calendars/weeklyview/components/event/Event.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/event/Event.tsx
@@ -10,7 +10,6 @@ type EventProps = {
   currentlySelectedEventId?: number;
   eventDuration: number;
   onEventClick?: (event: CalendarEvent) => void;
-  disabled?: boolean;
   isHovered?: boolean;
 };
 
@@ -61,7 +60,6 @@ export function Event({
   event,
   currentlySelectedEventId,
   eventDuration,
-  disabled,
   onEventClick,
   isHovered = false,
 }: EventProps) {
@@ -115,7 +113,6 @@ export function Event({
         className={classNames(
           eventClasses({
             status: options?.status,
-            disabled,
             selected,
             borderOnly: options?.borderOnly ?? false,
           }),

--- a/apps/web/modules/calendars/weeklyview/components/grid/index.tsx
+++ b/apps/web/modules/calendars/weeklyview/components/grid/index.tsx
@@ -4,18 +4,17 @@ type Props = {
   offsetHeight: number | undefined;
   gridStopsPerDay: number;
   children: React.ReactNode;
-  zIndex?: number;
 };
 
 export const SchedulerColumns = React.forwardRef<HTMLOListElement, Props>(function SchedulerColumns(
-  { offsetHeight, gridStopsPerDay, children, zIndex },
+  { offsetHeight, gridStopsPerDay, children },
   ref
 ) {
   return (
     <ol
       ref={ref}
       className="scheduler-grid-row-template col-start-1 col-end-2 row-start-1 grid auto-cols-auto text-[0px] scheduler-wrapper"
-      style={{ marginTop: offsetHeight || "var(--gridDefaultSize)", zIndex }}
+      style={{ marginTop: offsetHeight || "var(--gridDefaultSize)" }}
       data-gridstopsperday={gridStopsPerDay}>
       {children}
     </ol>

--- a/apps/web/modules/data-table/DataTableProvider.tsx
+++ b/apps/web/modules/data-table/DataTableProvider.tsx
@@ -73,11 +73,7 @@ interface DataTableProviderProps {
   tableIdentifier: string;
   children: React.ReactNode;
   useSegments?: UseSegments;
-  ctaContainerClassName?: string;
   defaultPageSize?: number;
-  segments?: FilterSegmentOutput[];
-  timeZone?: string;
-  preferredSegmentId?: SegmentIdentifier | null;
   systemSegments?: SystemFilterSegment[];
   validateActiveFilters?: ActiveFiltersValidatorState;
 }
@@ -141,10 +137,6 @@ export function DataTableProvider({
   children,
   useSegments,
   defaultPageSize,
-  ctaContainerClassName,
-  segments: providedSegments,
-  timeZone,
-  preferredSegmentId,
   systemSegments,
   validateActiveFilters,
 }: DataTableProviderProps) {
@@ -152,13 +144,9 @@ export function DataTableProvider({
     <DataTableStateProvider
       tableIdentifier={tableIdentifier}
       defaultPageSize={defaultPageSize}
-      ctaContainerClassName={ctaContainerClassName}
-      timeZone={timeZone}
-      preferredSegmentId={preferredSegmentId}
       validateActiveFilters={validateActiveFilters}>
       <DataTableSegmentProvider
         useSegments={useSegments}
-        segments={providedSegments}
         systemSegments={systemSegments}>
         <DataTableFiltersProvider>
           <DataTableContextBridge>{children}</DataTableContextBridge>

--- a/apps/web/modules/data-table/components/filters/ActiveFilters.tsx
+++ b/apps/web/modules/data-table/components/filters/ActiveFilters.tsx
@@ -9,10 +9,9 @@ import { FilterPopover } from "./FilterPopover";
 // Add the new ActiveFilters component
 interface ActiveFiltersProps<TData> {
   table: Table<TData>;
-  columnIdsToHide?: string[];
 }
 
-export function ActiveFilters<TData>({ table, columnIdsToHide }: ActiveFiltersProps<TData>) {
+export function ActiveFilters<TData>({ table }: ActiveFiltersProps<TData>) {
   const { activeFilters } = useDataTable();
   const filterableColumns = useFilterableColumns(table);
 
@@ -21,9 +20,6 @@ export function ActiveFilters<TData>({ table, columnIdsToHide }: ActiveFiltersPr
       {activeFilters.map((filter) => {
         const column = filterableColumns.find((col) => col.id === filter.f);
         if (!column) {
-          return null;
-        }
-        if (columnIdsToHide?.includes(column.id)) {
           return null;
         }
 

--- a/apps/web/modules/data-table/components/filters/ClearFiltersButton.tsx
+++ b/apps/web/modules/data-table/components/filters/ClearFiltersButton.tsx
@@ -4,11 +4,11 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 
 import { useDataTable } from "~/data-table/hooks/useDataTable";
 
-export const ClearFiltersButton = ({ exclude }: { exclude?: string[] }) => {
+export const ClearFiltersButton = () => {
   const { t } = useLocale();
   const { activeFilters, clearAll } = useDataTable();
 
-  if (!activeFilters?.length || (exclude && activeFilters.every((filter) => exclude.includes(filter.f)))) {
+  if (!activeFilters?.length) {
     return null;
   }
 
@@ -20,7 +20,7 @@ export const ClearFiltersButton = ({ exclude }: { exclude?: string[] }) => {
         target="_blank"
         rel="noreferrer"
         StartIcon="x"
-        onClick={() => clearAll(exclude)}>
+        onClick={() => clearAll()}>
         {t("clear")}
       </Button>
     </Tooltip>

--- a/apps/web/modules/data-table/components/filters/FilterBar.tsx
+++ b/apps/web/modules/data-table/components/filters/FilterBar.tsx
@@ -10,7 +10,7 @@ interface FilterBarProps<TData> {
 }
 
 export function FilterBar<TData>({ table }: FilterBarProps<TData>) {
-  const displayedFilterCount = useDisplayedFilterCount({});
+  const displayedFilterCount = useDisplayedFilterCount();
 
   return (
     <>

--- a/apps/web/modules/data-table/components/filters/FilterBar.tsx
+++ b/apps/web/modules/data-table/components/filters/FilterBar.tsx
@@ -7,16 +7,15 @@ import { AddFilterButton } from "./AddFilterButton";
 
 interface FilterBarProps<TData> {
   table: Table<TData>;
-  columnIdsToHide?: string[];
 }
 
-export function FilterBar<TData>({ table, columnIdsToHide }: FilterBarProps<TData>) {
-  const displayedFilterCount = useDisplayedFilterCount({ columnIdsToHide });
+export function FilterBar<TData>({ table }: FilterBarProps<TData>) {
+  const displayedFilterCount = useDisplayedFilterCount({});
 
   return (
     <>
       {displayedFilterCount === 0 && <AddFilterButton table={table} />}
-      <ActiveFilters table={table} columnIdsToHide={columnIdsToHide} />
+      <ActiveFilters table={table} />
       {displayedFilterCount > 0 && <AddFilterButton table={table} variant="minimal" />}
     </>
   );

--- a/apps/web/modules/data-table/hooks/useDisplayedFilterCount.ts
+++ b/apps/web/modules/data-table/hooks/useDisplayedFilterCount.ts
@@ -2,15 +2,7 @@ import { useMemo } from "react";
 
 import { useDataTable } from "./useDataTable";
 
-type UseDisplayedFilterCountProps = {
-  columnIdsToHide?: string[];
-};
-
-export const useDisplayedFilterCount = ({ columnIdsToHide }: UseDisplayedFilterCountProps = {}) => {
+export const useDisplayedFilterCount = () => {
   const { activeFilters } = useDataTable();
-  return useMemo(() => {
-    return (activeFilters ?? []).filter((filter) =>
-      columnIdsToHide ? !columnIdsToHide.includes(filter.f) : true
-    ).length;
-  }, [activeFilters, columnIdsToHide]);
+  return useMemo(() => (activeFilters ?? []).length, [activeFilters]);
 };

--- a/apps/web/modules/embed/components/Embed.tsx
+++ b/apps/web/modules/embed/components/Embed.tsx
@@ -479,7 +479,6 @@ const EmailEmbedPreview = ({
   userSettingsTimezone,
 }: {
   eventType: EventType;
-  timezone?: string;
   emailContentRef: RefObject<HTMLDivElement>;
   username?: string;
   month?: string;

--- a/apps/web/modules/event-types/components/locations/CalVideoSettings.tsx
+++ b/apps/web/modules/event-types/components/locations/CalVideoSettings.tsx
@@ -5,7 +5,6 @@ import { useFormContext, Controller } from "react-hook-form";
 
 import { useIsPlatform } from "@calcom/atoms/hooks/useIsPlatform";
 import type { FormValues } from "@calcom/features/eventtypes/lib/types";
-import type { CalVideoSettings as CalVideoSettingsType } from "@calcom/features/eventtypes/lib/types";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import classNames from "@calcom/ui/classNames";
 import { TextField } from "@calcom/ui/components/form";
@@ -15,7 +14,7 @@ import { Tooltip } from "@calcom/ui/components/tooltip";
 import LocationSettingsContainer from "@calcom/web/modules/event-types/components/locations/LocationSettingsContainer";
 import { InfoBadge } from "@calcom/ui/components/badge";
 
-const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSettingsType }) => {
+const CalVideoSettings = () => {
   const { t } = useLocale();
   const formMethods = useFormContext<FormValues>();
   const isPlatform = useIsPlatform();
@@ -44,7 +43,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
           <LocationSettingsContainer>
             <Controller
               name="calVideoSettings.disableRecordingForGuests"
-              defaultValue={!!calVideoSettings?.disableRecordingForGuests}
+              defaultValue={false}
               render={({ field: { onChange, value } }) => {
                 return (
                   <SettingsToggle
@@ -61,7 +60,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
 
             <Controller
               name="calVideoSettings.disableRecordingForOrganizer"
-              defaultValue={!!calVideoSettings?.disableRecordingForOrganizer}
+              defaultValue={false}
               render={({ field: { onChange, value } }) => {
                 return (
                   <SettingsToggle
@@ -79,7 +78,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
             {!isPlatform && (
               <Controller
                 name="calVideoSettings.enableAutomaticRecordingForOrganizer"
-                defaultValue={!!calVideoSettings?.enableAutomaticRecordingForOrganizer}
+                defaultValue={false}
                 render={({ field: { onChange, value } }) => {
                   return (
                     <SettingsToggle
@@ -97,7 +96,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
 
             <Controller
               name="calVideoSettings.enableAutomaticTranscription"
-              defaultValue={!!calVideoSettings?.enableAutomaticTranscription}
+              defaultValue={false}
               render={({ field: { onChange, value } }) => {
                 return (
                   <SettingsToggle
@@ -115,7 +114,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
             {!isPlatform && (
               <Controller
                 name="calVideoSettings.disableTranscriptionForGuests"
-                defaultValue={!!calVideoSettings?.disableTranscriptionForGuests}
+                defaultValue={false}
                 render={({ field: { onChange, value } }) => {
                   return (
                     <SettingsToggle
@@ -133,7 +132,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
             {!isPlatform && (
               <Controller
                 name="calVideoSettings.disableTranscriptionForOrganizer"
-                defaultValue={!!calVideoSettings?.disableTranscriptionForOrganizer}
+                defaultValue={false}
                 render={({ field: { onChange, value } }) => {
                   return (
                     <SettingsToggle
@@ -151,7 +150,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
 
             <Controller
               name="calVideoSettings.requireEmailForGuests"
-              defaultValue={!!calVideoSettings?.requireEmailForGuests}
+              defaultValue={false}
               render={({ field: { onChange, value } }) => {
                 return (
                   <SettingsToggle
@@ -174,7 +173,7 @@ const CalVideoSettings = ({ calVideoSettings }: { calVideoSettings?: CalVideoSet
                   <InfoBadge content={t("enter_redirect_url_on_exit_description")} />
                 </div>
               }
-              defaultValue={calVideoSettings?.redirectUrlOnExit || ""}
+              defaultValue=""
               data-testid="calVideoSettings.redirectUrlOnExit"
               containerClassName="mt-4"
               className="leading-6"

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -452,20 +452,16 @@ export const FormBuilder = function FormBuilder({
 };
 
 function Options({
-  label = "Options",
   value,
 
   onChange = () => { },
   className = "",
-  readOnly = false,
   showPrice = false,
   paymentCurrency,
 }: {
-  label?: string;
   value: { label: string; value: string; price?: number }[];
   onChange?: (value: { label: string; value: string; price?: number }[]) => void;
   className?: string;
-  readOnly?: boolean;
   showPrice?: boolean;
   paymentCurrency: string;
 }) {
@@ -486,7 +482,6 @@ function Options({
   }
   return (
     <div className={className}>
-      <Label>{label}</Label>
       <div className="bg-cal-muted rounded-md p-4" data-testid="options-container">
         <ul ref={animationRef} className="flex flex-col gap-3">
           {value?.map((option, index) => (
@@ -506,11 +501,10 @@ function Options({
                       });
                       onChange(newOptions);
                     }}
-                    readOnly={readOnly}
                     placeholder={t("enter_option", { index: index + 1 })}
-                    className={value.length > 2 && !readOnly ? "pr-8" : ""}
+                    className={value.length > 2 ? "pr-8" : ""}
                   />
-                  {value.length > 2 && !readOnly && (
+                  {value.length > 2 && (
                     <Button
                       type="button"
                       className="absolute right-1 top-1/2 -translate-y-1/2 hover:bg-transparent! focus:bg-transparent! focus:outline-none! focus:ring-0!"
@@ -543,7 +537,6 @@ function Options({
                         };
                         onChange(updatedOptions);
                       }}
-                      readOnly={readOnly}
                       placeholder="0"
                       addOnLeading={getCurrencySymbol(paymentCurrency)}
                     />
@@ -553,20 +546,18 @@ function Options({
             </li>
           ))}
         </ul>
-        {!readOnly && (
-          <Button
-            color="minimal"
-            data-testid="add-option"
-            className="mt-3"
-            onClick={() => {
-              const newOptions = [...(value || [])];
-              newOptions.push({ label: "", value: "", price: 0 });
-              onChange(newOptions);
-            }}
-            StartIcon="plus">
-            Add an Option
-          </Button>
-        )}
+        <Button
+          color="minimal"
+          data-testid="add-option"
+          className="mt-3"
+          onClick={() => {
+            const newOptions = [...(value || [])];
+            newOptions.push({ label: "", value: "", price: 0 });
+            onChange(newOptions);
+          }}
+          StartIcon="plus">
+          Add an Option
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/modules/event-types/views/event-types-listing-view.tsx
+++ b/apps/web/modules/event-types/views/event-types-listing-view.tsx
@@ -98,7 +98,6 @@ interface InfiniteEventTypeListProps {
         eventTypes: InfiniteEventType[];
       }[]
     | undefined;
-  lockedByOrg?: boolean;
   isPending?: boolean;
   debouncedSearchTerm?: string;
 }
@@ -282,7 +281,6 @@ export const InfiniteEventTypeList = ({
   readOnly,
   pages,
   bookerUrl,
-  lockedByOrg,
   isPending,
   debouncedSearchTerm,
 }: InfiniteEventTypeListProps): JSX.Element => {
@@ -604,7 +602,6 @@ export const InfiniteEventTypeList = ({
                                 <div className="self-center rounded-md p-2">
                                   <Switch
                                     name="Hidden"
-                                    disabled={lockedByOrg}
                                     checked={!type.hidden}
                                     onCheckedChange={() => {
                                       setHiddenMutation.mutate({

--- a/apps/web/modules/filters/components/TeamsFilter.tsx
+++ b/apps/web/modules/filters/components/TeamsFilter.tsx
@@ -150,16 +150,13 @@ export const FilterCheckboxFieldsContainer = ({
 
 type Props = InputHTMLAttributes<HTMLInputElement> & {
   label: string;
-  testId?: string;
   icon?: ReactNode;
 };
 
 export const FilterCheckboxField = forwardRef<HTMLInputElement, Props>(
-  ({ label, icon, testId, ...rest }, ref) => {
+  ({ label, icon, ...rest }, ref) => {
     return (
-      <div
-        data-testid={testId}
-        className="hover:bg-cal-muted flex items-center py-2 pl-3 pr-2.5 transition hover:cursor-pointer">
+      <div className="hover:bg-cal-muted flex items-center py-2 pl-3 pr-2.5 transition hover:cursor-pointer">
         <label className="flex w-full max-w-full items-center justify-between hover:cursor-pointer">
           <div className="flex items-center truncate">
             {icon && (

--- a/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
+++ b/apps/web/modules/onboarding/components/onboarding-browser-view.tsx
@@ -14,22 +14,18 @@ type OnboardingBrowserViewProps = {
   name?: string;
   bio?: string;
   username?: string | null;
-  teamSlug?: string;
 };
 
 const getDisplayUrl = (
   orgSlug: string | null | undefined,
-  username: string | null | undefined,
-  teamSlug: string | undefined
+  username: string | null | undefined
 ): string => {
   if (orgSlug) {
-    return teamSlug !== undefined
-      ? `${orgSlug}.${""}/team/${teamSlug || ""}`
-      : `${orgSlug}.${""}/${username || ""}`;
+    return `${orgSlug}.${""}/${username || ""}`;
   }
 
   const webappUrl = WEBAPP_URL.replace(/^https?:\/\//, "");
-  return teamSlug !== undefined ? `${webappUrl}/team/${teamSlug || ""}` : `${webappUrl}/${username || ""}`;
+  return `${webappUrl}/${username || ""}`;
 };
 
 export const OnboardingBrowserView = ({
@@ -37,13 +33,12 @@ export const OnboardingBrowserView = ({
   name,
   bio,
   username,
-  teamSlug,
 }: OnboardingBrowserViewProps) => {
   const { t } = useLocale();
   const pathname = usePathname();
   const orgBranding = null as { slug: string } | null;
 
-  const displayUrl = getDisplayUrl(orgBranding?.slug, username, teamSlug);
+  const displayUrl = getDisplayUrl(orgBranding?.slug, username);
 
   // Animation variants for entry and exit
   const containerVariants = {

--- a/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
+++ b/apps/web/modules/onboarding/hooks/useSubmitOnboarding.ts
@@ -18,8 +18,7 @@ export const useSubmitOnboarding = () => {
   const submitOnboarding = async (
     store: OnboardingState,
     userEmail: string,
-    invitesToSubmit: OnboardingState["invites"],
-    options?: { billingPeriod?: "MONTHLY" | "ANNUALLY" }
+    invitesToSubmit: OnboardingState["invites"]
   ) => {
     setIsSubmitting(true);
     setError(null);
@@ -97,7 +96,6 @@ export const useSubmitOnboarding = () => {
         creationSource: CreationSource.WEBAPP,
         teams: teamsData,
         invitedMembers: allInvitedMembers,
-        ...(options?.billingPeriod && { billingPeriod: options.billingPeriod }),
       });
 
       // If there's a checkout URL, redirect to Stripe (billing enabled flow)

--- a/apps/web/modules/onboarding/personal/_components/useAppInstallation.ts
+++ b/apps/web/modules/onboarding/personal/_components/useAppInstallation.ts
@@ -4,22 +4,17 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { showToast } from "@calcom/ui/components/toast";
 
-type InstallSuccessCallback = (appSlug: string) => void;
-
 export const useAppInstallation = () => {
   const { t } = useLocale();
   const utils = trpc.useUtils();
   const [installingAppSlug, setInstallingAppSlug] = useState<string | null>(null);
 
-  const createInstallHandlers = (appSlug: string, onSuccess?: InstallSuccessCallback) => {
+  const createInstallHandlers = (_appSlug: string) => {
     return {
       onSuccess: () => {
         setInstallingAppSlug(null);
         utils.viewer.apps.integrations.invalidate();
         showToast(t("app_successfully_installed"), "success");
-
-        // Call custom success callback if provided
-        onSuccess?.(appSlug);
       },
       onError: (error: unknown) => {
         setInstallingAppSlug(null);

--- a/apps/web/modules/schedules/components/NewScheduleButton.tsx
+++ b/apps/web/modules/schedules/components/NewScheduleButton.tsx
@@ -12,13 +12,7 @@ import { Form } from "@calcom/ui/components/form";
 import { InputField } from "@calcom/ui/components/form";
 import { showToast } from "@calcom/ui/components/toast";
 
-export function NewScheduleButton({
-  name = "new-schedule",
-  fromEventType,
-}: {
-  name?: string;
-  fromEventType?: boolean;
-}) {
+export function NewScheduleButton() {
   const router = useRouter();
   const { t } = useLocale();
 
@@ -30,7 +24,7 @@ export function NewScheduleButton({
 
   const createMutation = trpc.viewer.availability.schedule.create.useMutation({
     onSuccess: async ({ schedule }) => {
-      await router.push(`/availability/${schedule.id}${fromEventType ? "?fromEventType=true" : ""}`);
+      await router.push(`/availability/${schedule.id}`);
       showToast(t("schedule_created_successfully", { scheduleName: schedule.name }), "success");
       revalidateAvailabilityList();
       utils.viewer.availability.list.setData(undefined, (data) => {
@@ -59,9 +53,9 @@ export function NewScheduleButton({
   });
 
   return (
-    <Dialog name={name} clearQueryParamsOnClose={["copy-schedule-id"]}>
+    <Dialog name="new-schedule" clearQueryParamsOnClose={["copy-schedule-id"]}>
       <DialogTrigger asChild>
-        <Button variant="fab" data-testid={name} StartIcon="plus" size="sm">
+        <Button variant="fab" data-testid="new-schedule" StartIcon="plus" size="sm">
           {t("new")}
         </Button>
       </DialogTrigger>

--- a/apps/web/modules/schedules/components/Schedule.tsx
+++ b/apps/web/modules/schedules/components/Schedule.tsx
@@ -16,9 +16,6 @@ const Schedule = <
   name: TPath;
   control: Control<TFieldValues>;
   weekStart?: number;
-  disabled?: boolean;
-  labels?: ScheduleLabelsType;
-  userTimeFormat?: number | null;
 }) => {
   const query = useMeQuery();
   const { timeFormat } = query.data || { timeFormat: null };

--- a/apps/web/modules/schedules/hooks/useSchedule.ts
+++ b/apps/web/modules/schedules/hooks/useSchedule.ts
@@ -24,7 +24,6 @@ export type UseScheduleWithCacheArgs = {
   orgSlug?: string;
   teamMemberEmail?: string | null;
   useApiV2?: boolean;
-  enabled?: boolean;
   /***
    * Required when prefetching is needed
    */
@@ -62,7 +61,6 @@ export const useSchedule = ({
   orgSlug,
   teamMemberEmail,
   useApiV2 = false,
-  enabled: enabledProp = true,
   bookerLayout,
 }: UseScheduleWithCacheArgs) => {
   const bookerState = useBookerStore((state) => state.state);
@@ -131,8 +129,7 @@ export const useSchedule = ({
       Boolean(month) &&
       Boolean(timezone) &&
       // Should only wait for one or the other, not both.
-      (Boolean(eventSlug) || Boolean(eventId) || eventId === 0) &&
-      enabledProp,
+      (Boolean(eventSlug) || Boolean(eventId) || eventId === 0),
   };
 
   const isCallingApiV2Slots = useApiV2 && Boolean(isTeamEvent) && options.enabled;

--- a/apps/web/modules/users/components/UserForm.tsx
+++ b/apps/web/modules/users/components/UserForm.tsx
@@ -63,12 +63,10 @@ export type FormValues = Pick<
 
 export function UserForm({
   defaultValues,
-  localeProp = "en",
   onSubmit = noop,
   submitLabel = "save",
 }: {
   defaultValues?: Pick<User, keyof FormValues>;
-  localeProp?: string;
   onSubmit: (data: FormValues) => void;
   submitLabel?: string;
 }) {
@@ -81,15 +79,15 @@ export function UserForm({
 
   const weekStartOptions = useMemo(
     () => [
-      { value: "Sunday", label: nameOfDay(language || localeProp, 0) },
-      { value: "Monday", label: nameOfDay(language || localeProp, 1) },
-      { value: "Tuesday", label: nameOfDay(language || localeProp, 2) },
-      { value: "Wednesday", label: nameOfDay(language || localeProp, 3) },
-      { value: "Thursday", label: nameOfDay(language || localeProp, 4) },
-      { value: "Friday", label: nameOfDay(language || localeProp, 5) },
-      { value: "Saturday", label: nameOfDay(language || localeProp, 6) },
+      { value: "Sunday", label: nameOfDay(language, 0) },
+      { value: "Monday", label: nameOfDay(language, 1) },
+      { value: "Tuesday", label: nameOfDay(language, 2) },
+      { value: "Wednesday", label: nameOfDay(language, 3) },
+      { value: "Thursday", label: nameOfDay(language, 4) },
+      { value: "Friday", label: nameOfDay(language, 5) },
+      { value: "Saturday", label: nameOfDay(language, 6) },
     ],
-    [language, localeProp]
+    [language]
   );
 
   const userRoleOptions = [
@@ -178,7 +176,7 @@ export function UserForm({
         <div>
           <Label className="text-default font-medium">{t("member_since")}</Label>
           <div className="text-default mt-1 text-sm">
-            {formatToLocalizedDate(new Date(defaultValues.createdDate), localeProp)}
+            {formatToLocalizedDate(new Date(defaultValues.createdDate))}
           </div>
         </div>
       )}

--- a/apps/web/modules/webhooks/components/WebhookForm.tsx
+++ b/apps/web/modules/webhooks/components/WebhookForm.tsx
@@ -244,7 +244,6 @@ export type WebhookFormValues = {
 const WebhookForm = (props: {
   webhook?: TWebhook | WebhookFormData;
   apps?: (keyof typeof WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2)[];
-  overrideTriggerOptions?: (typeof WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2)["core"];
   onSubmit: (event: WebhookFormSubmitData) => void;
   onCancel?: () => void;
   headerWrapper?: (
@@ -252,13 +251,11 @@ const WebhookForm = (props: {
     children: React.ReactNode
   ) => React.ReactNode;
 }) => {
-  const { apps = [], overrideTriggerOptions } = props;
+  const { apps = [] } = props;
   const { t } = useLocale();
   const webhookVariables = getWebhookVariables(t);
 
-  const triggerOptions = overrideTriggerOptions
-    ? [...overrideTriggerOptions]
-    : [...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2["core"]];
+  const triggerOptions = [...WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2["core"]];
   if (apps) {
     for (const app of apps) {
       if (WEBHOOK_TRIGGER_EVENTS_GROUPED_BY_APP_V2[app]) {

--- a/apps/web/modules/webhooks/components/WebhookListItem.tsx
+++ b/apps/web/modules/webhooks/components/WebhookListItem.tsx
@@ -44,8 +44,6 @@ const MAX_BADGES_TWO_ROWS = 7;
 
 export default function WebhookListItem(props: {
   webhook: Webhook;
-  profile?: { name: string | null; image?: string; slug?: string | null };
-  canEditWebhook?: boolean;
   editHref?: string;
   onEditWebhookAction?: () => void;
   permissions: {

--- a/apps/web/modules/webhooks/views/webhook-form-header.tsx
+++ b/apps/web/modules/webhooks/views/webhook-form-header.tsx
@@ -16,28 +16,17 @@ import type { ReactNode } from "react";
 type WebhookFormHeaderProps = {
   CTA?: ReactNode;
   titleKey?: "add_webhook" | "edit_webhook" | "create_webhook";
-  showBackButton?: boolean;
 };
 
 export function WebhookFormHeader({
   CTA,
   titleKey = "add_webhook",
-  showBackButton = true,
 }: WebhookFormHeaderProps) {
   const { t } = useLocale();
 
   return (
     <AppHeader>
       <div className="flex min-w-0 items-start gap-3">
-        {showBackButton && (
-          <Button
-            aria-label={t("go_back")}
-            render={<Link href="/settings/developer/webhooks" />}
-            size="icon-sm"
-            variant="ghost">
-            <ArrowLeftIcon />
-          </Button>
-        )}
         <AppHeaderContent title={t(titleKey)}>
           <AppHeaderDescription>{t("add_webhook_description", { appName: APP_NAME })}</AppHeaderDescription>
         </AppHeaderContent>

--- a/apps/web/modules/webhooks/views/webhooks-header.tsx
+++ b/apps/web/modules/webhooks/views/webhooks-header.tsx
@@ -8,9 +8,8 @@ import {
   AppHeaderContent,
   AppHeaderDescription,
 } from "@coss/ui/shared/app-header";
-import type { ReactNode } from "react";
 
-export function WebhooksHeader({ actions }: { actions?: ReactNode }) {
+export function WebhooksHeader() {
   const { t } = useLocale();
 
   return (
@@ -18,7 +17,6 @@ export function WebhooksHeader({ actions }: { actions?: ReactNode }) {
       <AppHeaderContent title={t("webhooks")}>
         <AppHeaderDescription>{t("add_webhook_description", { appName: APP_NAME })}</AppHeaderDescription>
       </AppHeaderContent>
-      {actions ? <AppHeaderActions>{actions}</AppHeaderActions> : null}
     </AppHeader>
   );
 }


### PR DESCRIPTION
Hey folks, I'm working on an experimental CLI which uses the tsgo toolchain to find optional component and function signatures that are in practice never passed. This is essentially dead code elimination, and a complementary workflow to run alongside a tool like knip.

The changeset in this PR has been done using the script as the reporting tool, and an agent validator loop walking through each reported line one by one to first inspect the report, analyze the call sites, removing them, and later re-running ts. If done correctly, the code that has been removed should have been effectively dead.

The reporting script heavily relies on type quality and only reports on types whos members are statically enumerable.

Scope notes:
- Only `apps/web` is touched. Findings in shared `packages/*` were excluded because they can have consumers outside this project's typecheck graph (platform atoms, API apps, embeds).
- Two components were deliberately left alone and may deserve maintainer attention instead: `CalendarListContainer` (its `heading`/`fromOnboarding` props are never passed, which means the component currently renders `null` on both of its call sites) and `LimitedBadges` (`maxVisible` is never passed, so the visible/hidden split degenerates).

I'm opening this PR in an effort to help you eliminate dead code, but also to gain feedback on the script and the detection mechanisms. There are always risks of false positive reports, and removal of code that is actually still required at runtime.

Some references of PRs opened to other repositories that have been merged or are still open:
✅ [Sentry (4k loc removed)](https://github.com/getsentry/sentry/pull/122234/)
⏳ [Sentry (followup 1k loc removed)](https://github.com/getsentry/sentry/pull/122373)
⏳ [Tanstack](https://github.com/TanStack/tanstack.com/pull/1173)
⏳ [npmx](https://github.com/npmx-dev/npmx.dev/pull/3195)
⏳ [Signal Desktop](https://github.com/signalapp/Signal-Desktop/pull/7997)

Would love to hear your feedback 🙏🏼

Made with [Cursor](https://cursor.com)