### PR TITLE
feat: add search and cursor based pagination to userAdminRouter.list

### DIFF
--- a/packages/trpc/server/routers/viewer/users/_router.test.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockListUsers } = vi.hoisted(() => ({ mockListUsers: vi.fn() }));
+
+vi.mock("@calcom/features/auth/lib/userFromSessionUtils", () => ({
+  getUserSession: vi.fn(async (ctx: { session?: unknown; user?: unknown }) => ({
+    session: ctx.session,
+    user: ctx.user,
+  })),
+}));
+
+vi.mock("@calcom/features/di/containers/UserRepository", () => ({
+  getUserRepository: () => ({ listUsers: mockListUsers }),
+}));
+
+import { userAdminRouter } from "./_router";
+
+const caller = userAdminRouter.createCaller({
+  session: { user: { id: "1" } },
+  user: { id: 1, role: "ADMIN" },
+} as never);
+
+describe("userAdminRouter.list", () => {
+  it("uses the default pagination values", async () => {
+    mockListUsers.mockResolvedValue({ nextCursor: undefined, total: 0, users: [] });
+
+    await expect(caller.list()).resolves.toEqual({
+      meta: { totalRowCount: 0 },
+      nextCursor: undefined,
+      rows: [],
+    });
+    expect(mockListUsers).toHaveBeenCalledWith({ cursor: null, limit: 50 });
+  });
+
+  it("passes search and cursor pagination to the repository", async () => {
+    const users = [{ email: "alex@example.com", id: 42 }];
+    mockListUsers.mockResolvedValue({ nextCursor: 42, total: 101, users });
+
+    await expect(caller.list({ cursor: 10, limit: 25, searchTerm: "  alex  " })).resolves.toEqual({
+      meta: { totalRowCount: 101 },
+      nextCursor: 42,
+      rows: users,
+    });
+    expect(mockListUsers).toHaveBeenCalledWith({ cursor: 10, limit: 25, searchTerm: "alex" });
+  });
+});

--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -1,3 +1,4 @@
+import { getUserRepository } from "@calcom/features/di/containers/UserRepository";
 import { WEBAPP_URL } from "@calcom/lib/constants";
 import { CreationSource, RedirectType } from "@calcom/prisma/enums";
 import { UserSchema } from "@calcom/prisma/zod/modelSchema/UserSchema";
@@ -6,6 +7,7 @@ import { router } from "@calcom/trpc/server/trpc";
 import type { inferRouterOutputs } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { listUsersSchema } from "./listUsers.schema";
 
 export type UserAdminRouter = typeof userAdminRouter;
 export type UserAdminRouterOutputs = inferRouterOutputs<UserAdminRouter>;
@@ -54,11 +56,22 @@ export const userAdminRouter = router({
     const { requestedUser } = ctx;
     return { user: requestedUser };
   }),
-  list: authedAdminProcedure.query(async ({ ctx }) => {
-    const { prisma } = ctx;
-    // TODO: Add search, pagination, etc.
-    const users = await prisma.user.findMany();
-    return users;
+  list: authedAdminProcedure.input(listUsersSchema).query(async ({ input }) => {
+    const userRepository = getUserRepository()
+
+    const { cursor, limit, searchTerm } = input
+
+    const { users, total, nextCursor } = await userRepository.listUsers({
+      searchTerm,
+      limit,
+      cursor
+    });
+
+    return {
+      rows: users,
+      nextCursor,
+      meta: { totalRowCount: total },
+    };
   }),
   add: authedAdminProcedure.input(userBodySchema).mutation(async ({ ctx, input }) => {
     const { prisma } = ctx;

--- a/packages/trpc/server/routers/viewer/users/listUsers.schema.ts
+++ b/packages/trpc/server/routers/viewer/users/listUsers.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const listUsersSchema = z
+  .object({
+    limit: z.number().int().min(1).max(100).default(50),
+    cursor: z.number().int().positive().nullable().default(null),
+    searchTerm: z.string().trim().max(100).nullish(),
+  })
+  .default({});


### PR DESCRIPTION
## What does this PR do?

This PR resolves the `TODO: Add search, pagination, etc.` in `userAdminRouter.list`  (packages/trpc/server/routers/viewer/users/_router.ts), which previously called  `prisma.user.findMany()` unfiltered and unpaginated fetching all users on every  call.  


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
