### PR TITLE
fix(data-table): replace div with td+colSpan in SeparatorRowRenderer

### DIFF
--- a/apps/web/modules/data-table/components/DataTable.tsx
+++ b/apps/web/modules/data-table/components/DataTable.tsx
@@ -281,16 +281,25 @@ type RowToRender<TData> = {
   virtualItem?: VirtualItem;
 };
 
-function SeparatorRowRenderer({ separator, className }: { separator: SeparatorRow; className?: string }) {
+function SeparatorRowRenderer({
+  separator,
+  className,
+  colSpan,
+}: {
+  separator: SeparatorRow;
+  className?: string;
+  colSpan?: number;
+}) {
   return (
-    <div
+    <td
+      colSpan={colSpan}
       className={classNames(
         "bg-cal-muted text-emphasis w-full px-3 py-2 font-semibold",
         separator.className,
         className
       )}>
       {separator.label}
-    </div>
+    </td>
   );
 }
 
@@ -381,7 +390,11 @@ function DataTableBody<TData>({
                 }),
               }}
               className="hover:bg-subtle border-muted flex w-full border-b">
-              <SeparatorRowRenderer separator={row.original as SeparatorRow} className={separatorClassName} />
+              <SeparatorRowRenderer
+                separator={row.original as SeparatorRow}
+                className={separatorClassName}
+                colSpan={table.getAllColumns().length}
+              />
             </TableRow>
           );
         }


### PR DESCRIPTION
## What does this PR do?

Fixes #28184

While setting up Cal.diy locally I noticed a React 19 hydration warning in the console on the Bookings page. After tracing it, the root cause is `SeparatorRowRenderer` in `DataTable.tsx` — it renders a `<div>` directly inside a `<tr>`, which is invalid HTML. Browsers silently move the element outside the table to correct it, causing a server/client DOM mismatch.

Replace the `<div>` with a `<td colSpan={table.getAllColumns().length}>` so the separator spans the full row width — consistent with the "no results" empty-state row already using this pattern at line 353.

## Visual Demo

No visible UI change. The separator row looks identical — only the underlying DOM element changes from `<div>` to `<td>`.

**Before:** console shows hydration warning on any DataTable page with separators
**After:** no warning

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. N/A — HTML correctness fix; hydration warning disappearing is the verification.

## How should this be tested?

1. Run the app locally: `yarn dx`
2. Navigate to the Bookings page
3. Open DevTools → Console
4. Confirm no `<div> cannot be a child of <tr>` hydration warning appears

No environment variables or seed data needed beyond the default dev setup.
