### PR TITLE
refactor(lib): dedupe fromEntriesWithDuplicateKeys in useRouterQuery

### DIFF
--- a/packages/lib/fromEntriesWithDuplicateKeys.test.ts
+++ b/packages/lib/fromEntriesWithDuplicateKeys.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { fromEntriesWithDuplicateKeys } from "./fromEntriesWithDuplicateKeys";
+
+describe("fromEntriesWithDuplicateKeys", () => {
+  it("returns an empty object for null", () => {
+    expect(fromEntriesWithDuplicateKeys(null)).toEqual({});
+  });
+
+  it("returns an empty object for an empty iterator", () => {
+    expect(fromEntriesWithDuplicateKeys(new URLSearchParams("").entries())).toEqual({});
+  });
+
+  it("maps unique keys to plain string values", () => {
+    expect(fromEntriesWithDuplicateKeys(new URLSearchParams("a=1&b=2").entries())).toEqual({
+      a: "1",
+      b: "2",
+    });
+  });
+
+  it("collects duplicate keys into an array", () => {
+    expect(fromEntriesWithDuplicateKeys(new URLSearchParams("a=1&a=2&b=3").entries())).toEqual({
+      a: ["1", "2"],
+      b: "3",
+    });
+  });
+
+  it("keeps appending for more than two duplicates, preserving order", () => {
+    expect(fromEntriesWithDuplicateKeys(new URLSearchParams("a=1&a=2&a=3").entries())).toEqual({
+      a: ["1", "2", "3"],
+    });
+  });
+
+  it("keeps empty string values", () => {
+    expect(fromEntriesWithDuplicateKeys(new URLSearchParams("a=&a=1").entries())).toEqual({
+      a: ["", "1"],
+    });
+  });
+});

--- a/packages/lib/fromEntriesWithDuplicateKeys.ts
+++ b/packages/lib/fromEntriesWithDuplicateKeys.ts
@@ -1,3 +1,8 @@
+/**
+ * An alternative to Object.fromEntries that allows duplicate keys.
+ * There is a duplicate of the function in @calcom/embeds/embed-core/src/lib/utils.ts
+ * (embed-core must stay dependency-free). Keep them in sync.
+ */
 export function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, string]> | null) {
   const result: Record<string, string | string[]> = {};
 

--- a/packages/lib/hooks/useRouterQuery.ts
+++ b/packages/lib/hooks/useRouterQuery.ts
@@ -1,32 +1,5 @@
+import { fromEntriesWithDuplicateKeys } from "@calcom/lib/fromEntriesWithDuplicateKeys";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
-
-/**
- * An alternative to Object.fromEntries that allows duplicate keys.
- * There is a duplicate of the function in @calcom/embeds/embed-core/src/utils.ts. Keep them in sync.
- */
-function fromEntriesWithDuplicateKeys(entries: IterableIterator<[string, string]> | null) {
-  const result: Record<string, string | string[]> = {};
-
-  if (entries === null) {
-    return result;
-  }
-
-  // Consider setting atleast ES2015 as target
-  // @ts-expect-error
-  for (const [key, value] of entries) {
-    if (result.hasOwnProperty(key)) {
-      let currentValue = result[key];
-      if (!Array.isArray(currentValue)) {
-        currentValue = [currentValue];
-      }
-      currentValue.push(value);
-      result[key] = currentValue;
-    } else {
-      result[key] = value;
-    }
-  }
-  return result;
-}
 
 /**
  * This hook returns the query object from the router. It is an attempt to


### PR DESCRIPTION
## What does this PR do?

`useRouterQuery` had a private, byte-for-byte copy of `fromEntriesWithDuplicateKeys`. Query-string keys that appear more than once (for example `guest=a&guest=b`) need that helper: `Object.fromEntries` would keep only the last value.

This PR:

- Switches `useRouterQuery` to the shared util in `@calcom/lib/fromEntriesWithDuplicateKeys`
- Moves the keep-in-sync doc comment onto that shared util (including why embed-core still has its own copy)
- Adds unit tests for null input, unique keys, duplicate keys, order, and empty values

The embed-core copy is **intentionally unchanged**. That package is published to npm and must stay dependency-free, so it cannot import `@calcom/lib`.

No linked issue — internal cleanup.

## Visual Demo (For contributors especially)

N/A — no UI change. Behavior of `useRouterQuery` is unchanged; it still builds the query object via `fromEntriesWithDuplicateKeys`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. **N/A**
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No extra env vars or seed data.

```bash
yarn vitest run packages/lib/fromEntriesWithDuplicateKeys.test.ts
```

Expected coverage:

| Input | Output |
| --- | --- |
| `null` | `{}` |
| `a=1&b=2` | `{ a: "1", b: "2" }` |
| `a=1&a=2&b=3` | `{ a: ["1", "2"], b: "3" }` |
| `a=1&a=2&a=3` | `{ a: ["1", "2", "3"] }` (order preserved) |
| `a=&a=1` | `{ a: ["", "1"] }` |

`useRouterQuery` should keep returning a string for unique params and a `string[]` for repeated params (same as before this refactor).

## Checklist

- N/A (small, focused refactor; 3 files)