### PR TITLE
fix: use 24-hour format in DST offset detection to correct afternoon schedule shifts

### DIFF
--- a/packages/features/schedules/lib/date-ranges.test.ts
+++ b/packages/features/schedules/lib/date-ranges.test.ts
@@ -158,6 +158,69 @@ describe("processWorkingHours", () => {
     vi.useRealTimers();
   });
 
+  it("should return correct working hours with afternoon start time on DST spring-forward date", () => {
+    // 2026-03-08 is when US spring forward happens (America/New_York)
+    vi.useFakeTimers().setSystemTime(new Date("2026-03-07T12:00:00.000Z"));
+
+    const item = {
+      days: [0, 1, 2, 3, 4, 5, 6], // Sunday
+      startTime: new Date(Date.UTC(2023, 5, 12, 13, 0)), // 1 PM
+      endTime: new Date(Date.UTC(2023, 5, 12, 18, 0)), // 6 PM
+    };
+
+    const timeZone = "America/New_York";
+
+    const dateFrom = dayjs();
+    const dateTo = dayjs().add(2, "day");
+
+    const results = Object.values(
+      processWorkingHours({}, { item, timeZone, dateFrom, dateTo, travelSchedules: [] })
+    );
+
+    // On DST transition date (2026-03-08), 1 PM - 6 PM America/New_York is:
+    // - Before transition (EST, UTC-5): 18:00 → 23:00 UTC
+    // - On transition day (EDT, UTC-4): 17:00 → 22:00 UTC
+    // The result should have correct UTC times for each day
+    const march8Result = results.find((r) => r.start.format("YYYY-MM-DD") === "2026-03-08");
+    expect(march8Result).toBeDefined();
+    expect(march8Result!.start.utc().hour()).toBe(17); // 1 PM EDT = 5 PM UTC
+    expect(march8Result!.end.utc().hour()).toBe(22); // 6 PM EDT = 10 PM UTC
+
+    vi.setSystemTime(vi.getRealSystemTime());
+    vi.useRealTimers();
+  });
+
+  it("should return correct working hours with afternoon start time on DST fall-back date", () => {
+    // 2026-11-01 is when US fall back happens (America/New_York)
+    vi.useFakeTimers().setSystemTime(new Date("2026-10-31T12:00:00.000Z"));
+
+    const item = {
+      days: [0, 1, 2, 3, 4, 5, 6], // Sunday
+      startTime: new Date(Date.UTC(2023, 5, 12, 13, 0)), // 1 PM
+      endTime: new Date(Date.UTC(2023, 5, 12, 18, 0)), // 6 PM
+    };
+
+    const timeZone = "America/New_York";
+
+    const dateFrom = dayjs();
+    const dateTo = dayjs().add(2, "day");
+
+    const results = Object.values(
+      processWorkingHours({}, { item, timeZone, dateFrom, dateTo, travelSchedules: [] })
+    );
+
+    // On DST transition date (2026-11-01), 1 PM - 6 PM America/New_York is:
+    // - Before transition (EDT, UTC-4): 17:00 → 22:00 UTC
+    // - On transition day (EST, UTC-5): 18:00 → 23:00 UTC
+    const november1Result = results.find((r) => r.start.format("YYYY-MM-DD") === "2026-11-01");
+    expect(november1Result).toBeDefined();
+    expect(november1Result!.start.utc().hour()).toBe(18); // 1 PM EST = 6 PM UTC
+    expect(november1Result!.end.utc().hour()).toBe(23); // 6 PM EST = 11 PM UTC
+
+    vi.setSystemTime(vi.getRealSystemTime());
+    vi.useRealTimers();
+  });
+
   // TEMPORAIRLY SKIPPING THIS TEST - Started failing after 29th Oct
   it.skip("should return the correct working hours in the month were DST ends", () => {
     const item = {

--- a/packages/features/schedules/lib/date-ranges.ts
+++ b/packages/features/schedules/lib/date-ranges.ts
@@ -67,7 +67,7 @@ export function processWorkingHours(
 
     let end = dateInTz.add(item.endTime.getUTCHours(), "hours").add(item.endTime.getUTCMinutes(), "minutes");
 
-    const offsetBeginningOfDay = dayjs(start.format("YYYY-MM-DD hh:mm")).tz(adjustedTimezone).utcOffset();
+    const offsetBeginningOfDay = dayjs(start.format("YYYY-MM-DD HH:mm")).tz(adjustedTimezone).utcOffset();
     const offsetDiff = start.utcOffset() - offsetBeginningOfDay; // there will be 60 min offset on the day day of DST change
 
     start = start.add(offsetDiff, "minute");


### PR DESCRIPTION
## Summary

Fixes DST-induced availability shift for schedules with start times >= 13:00.

### Root Cause

In `processWorkingHours`, the DST correction probes the UTC offset using a 12-hour-formatted timestamp (`hh:mm`). A 13:00 start is probed as 01:00, landing on the wrong side of a DST transition and shifting availability by one hour on transition dates.

### Fix

Changed `hh:mm` to `HH:mm` (24-hour format) on line 70 of `packages/features/schedules/lib/date-ranges.ts`.

### Changes

- **date-ranges.ts**: Changed format specifier from `hh` (12-hour) to `HH` (24-hour) in the offset lookup
- **date-ranges.test.ts**: Added two test cases for afternoon start times (1 PM - 6 PM) on both spring-forward and fall-back DST transition dates in America/New_York

### Test Results

All existing tests pass with no regressions:
- date-ranges.test.ts: 52 passed, 2 skipped
- schedules suite: 160 passed, 4 skipped
- slots suite: 5 passed
- timezone tests: 46 passed, 2 skipped
