### PR TITLE
Add repocloud deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Currently Vercel Pro Plan is required to be able to Deploy this application with
 
 ### RepoCloud
 
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Calcom/)
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Cal.diy/)
 
 <!-- LICENSE -->
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To get a local copy up and running, please follow these simple steps.
 
 ### Prerequisites
 
-Here’s what you need to run Cal.diy.
+Here's what you need to run Cal.diy.
 
 - Node.js (Version: >=18.x)
 - PostgreSQL (Version: >=13.x)
@@ -650,6 +650,10 @@ Currently Vercel Pro Plan is required to be able to Deploy this application with
 ### Elestio
 
 [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/cal.com)
+
+### RepoCloud
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Calcom/)
 
 <!-- LICENSE -->
 


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option
alongside the existing providers (Railway, Northflank, Vercel, Render, Elestio).

RepoCloud provides managed cloud hosting for open-source applications
with one-click deployment.

- Adds deploy button to `README.md`
- Uses the same format/style as existing deploy buttons (heading + badge image)
- Links to: https://repocloud.io/details/Cal.diy/