### PR TITLE
fix(office365video): detect invalid_grant so dead Teams credentials get invalidated

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -108,9 +108,21 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         body: new URLSearchParams(params),
       });
     },
-    isTokenObjectUnusable: async function () {
-      // TODO: Implement this. As current implementation of CalendarService doesn't handle it. It hasn't been handled in the OAuthManager implementation as well.
-      // This is a placeholder for future implementation.
+    isTokenObjectUnusable: async function (response) {
+      // Delegation credentials use the client_credentials grant and have no refresh token that
+      // could go stale, so a failure there is a configuration problem rather than a dead
+      // connection. Invalidating would only hide the real cause from the admin.
+      if (credential?.delegatedTo) {
+        return null;
+      }
+
+      if (!response.ok) {
+        const responseBody = await response.json().catch(() => null);
+        if (responseBody?.error === "invalid_grant") {
+          return { reason: "invalid_grant" };
+        }
+      }
+
       return null;
     },
     isAccessTokenUnusable: async function () {


### PR DESCRIPTION
## What does this PR do?

Implements `isTokenObjectUnusable` in the `office365video` (MS Teams) adapter so that a rejected
refresh token actually invalidates the credential, instead of leaving a dead connection looking
healthy forever.

## The problem

Microsoft invalidates refresh tokens after 90 days of inactivity. When that happens, every booking
that uses MS Teams as its location silently loses its video link — the booking is created, the
calendar entry exists, and the attendee just gets *"There was a problem adding a video link"*.

The connection keeps showing as healthy under **Installed Apps**, because `Credential.invalid`
is never set. Nothing tells the user to reconnect, so this can go unnoticed for months. On the
instance where I found this, one user had been generating link-less Teams bookings since February
before anyone noticed.

Observed in the server log at booking time:

```
OAuthManager refreshOAuthToken → Token parsing error:
  {"error":"invalid_grant",
   "error_description":"AADSTS9002313: Invalid request. Request is malformed or invalid.",
   "error_codes":[9002313], "tokenStatus":2}
TeamsVideoApiAdapter → Error creating MS Teams meeting → "Invalid token response"
```

## Root cause

`tokenStatus: 2` is `TokenStatus.INCONCLUSIVE`. `OAuthManager` only acts on `UNUSABLE_TOKEN_OBJECT`
(→ `invalidateTokenObject()`) or `UNUSABLE_ACCESS_TOKEN` (→ `expireAccessToken()`):

```ts
// packages/app-store/_utils/oauth/OAuthManager.ts
const tokenObjectUsabilityRes = await this.isTokenObjectUnusable(response.clone());
...
if (tokenStatus === TokenStatus.UNUSABLE_TOKEN_OBJECT) {
  await this.invalidateTokenObject();
}
```

But the adapter's hook is a placeholder that always returns `null`, so the status can never be
anything else:

```ts
isTokenObjectUnusable: async function () {
  // TODO: Implement this. As current implementation of CalendarService doesn't handle it.
  // It hasn't been handled in the OAuthManager implementation as well.
  return null;
},
```

The second half of that comment is no longer accurate — `OAuthManager` *does* handle it, and
`googlecalendar/lib/CalendarAuth.ts` already uses the same hook successfully. Microsoft is simply
the one provider that never got wired up, so Google surfaces broken connections and Teams stays
quiet.

## The fix

Mirrors the existing Google Calendar implementation, with one addition: delegation credentials are
skipped. They use the `client_credentials` grant and have no refresh token that could go stale, so
a failure there is a configuration problem — invalidating would hide the real cause from the admin.

The check keys off the OAuth2 standard `invalid_grant` error rather than specific `AADSTS` codes,
matching how the Google adapter does it.

## Notes for the reviewer

- `packages/app-store/office365calendar/lib/CalendarService.ts` carries the **same** placeholder
  and presumably the same symptom for calendar sync. I left it out to keep this PR to the case I
  could actually reproduce and verify — happy to extend it if you'd prefer both in one go.
- `isAccessTokenUnusable` is left as-is. For an expired refresh token, invalidation is the correct
  outcome; refreshing the access token cannot help.
- I dropped the `(response.status < 200 && response.status >= 300)` clause that appears in the
  Google adapter — that condition can never be true, and `!response.ok` already covers it.

## How to test

1. Connect MS Teams, then revoke the app's consent in Microsoft Entra ID (or wait out the 90-day
   refresh token lifetime).
2. Book an event that uses MS Teams as its location.
3. **Before:** booking has no Teams link, `Credential.invalid` stays `false`, Installed Apps shows
   the connection as fine.
   **After:** the credential is marked invalid, so the broken connection becomes visible and the
   user can reconnect.
