### PR TITLE
fix(hitpay): respect zero-decimal currencies when charging and storing

### DIFF
--- a/packages/app-store/hitpay/lib/PaymentService.test.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.test.ts
@@ -1,0 +1,98 @@
+import axios from "axios";
+import qs from "qs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BuildPaymentService } from "./PaymentService";
+
+vi.mock("axios");
+
+const paymentCreate = vi.fn<(args: { data: { amount: number } }) => void>();
+
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    booking: {
+      findUnique: vi.fn(async () => ({
+        uid: "booking-uid",
+        title: "Paid event",
+        startTime: new Date("2026-04-01T10:00:00.000Z"),
+        endTime: new Date("2026-04-01T10:30:00.000Z"),
+        eventTypeId: 1,
+        eventType: { slug: "paid-event", seatsPerTimeSlot: null },
+        attendees: [],
+      })),
+      findMany: vi.fn(async () => []),
+    },
+    payment: {
+      create: (args: { data: { amount: number } }) => {
+        paymentCreate(args);
+        return { id: 1, ...args.data };
+      },
+    },
+  },
+}));
+
+const credentials = {
+  key: { isSandbox: true, sandbox: { apiKey: "test-api-key", saltKey: "test-salt-key" } },
+};
+
+/**
+ * HitPay's payment-requests API takes `amount` as a decimal string in major units and echoes it
+ * back the same way, so both directions have to respect zero-decimal currencies. Those are stored
+ * unscaled by `convertToSmallestCurrencyUnit`, which is what the price input writes.
+ * https://docs.hitpayapp.com/apis/payment-request/create-request
+ */
+const createPaymentWith = async ({
+  amount,
+  currency,
+}: {
+  amount: number;
+  currency: string;
+}): Promise<{ sent: string; stored: number }> => {
+  // Echo back whatever amount was actually requested, the way HitPay would.
+  vi.mocked(axios.post).mockImplementation(async (_url, body) => ({
+    data: {
+      id: "hitpay-request-id",
+      amount: (qs.parse(body as string) as { amount: string }).amount,
+      currency,
+    },
+  }));
+  vi.mocked(axios.get).mockResolvedValue({
+    data: { data: [{ url: "https://securecheckout.sandbox.hit-pay.com/payment-request/test" }] },
+  });
+
+  await BuildPaymentService(credentials).create(
+    { amount, currency },
+    1,
+    101,
+    "organizer",
+    "Booker",
+    "ON_BOOKING",
+    "booker@example.com"
+  );
+
+  const requestBody = qs.parse(vi.mocked(axios.post).mock.calls[0][1] as string) as { amount: string };
+
+  return { sent: requestBody.amount, stored: paymentCreate.mock.calls[0][0].data.amount };
+};
+
+describe("HitPayPaymentService.create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // JPY, KRW and VND have no minor unit, so the stored amount is already the amount to charge.
+  // Scaling it down bills the attendee 1% of the price.
+  it.each([
+    { currency: "jpy", amount: 10000 },
+    { currency: "krw", amount: 50000 },
+    { currency: "vnd", amount: 200000 },
+  ])("charges $currency unscaled and round-trips the stored amount", async ({ currency, amount }) => {
+    expect(await createPaymentWith({ amount, currency })).toEqual({ sent: `${amount}`, stored: amount });
+  });
+
+  it.each([
+    { currency: "usd", amount: 5000, sent: "50" },
+    { currency: "sgd", amount: 5000, sent: "50" },
+  ])("converts $currency from minor units", async ({ currency, amount, sent }) => {
+    expect(await createPaymentWith({ amount, currency })).toEqual({ sent, stored: amount });
+  });
+});

--- a/packages/app-store/hitpay/lib/PaymentService.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.ts
@@ -4,6 +4,10 @@ import { v4 as uuidv4 } from "uuid";
 import type z from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import {
+  convertFromSmallestToPresentableCurrencyUnit,
+  convertToSmallestCurrencyUnit,
+} from "@calcom/lib/currencyConversions";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -106,7 +110,7 @@ class HitPayPaymentService implements IAbstractPaymentService {
       const webhookUri = `${WEBAPP_URL}/api/integrations/${appConfig.slug}/webhook`;
 
       const formData = {
-        amount: payment.amount / 100,
+        amount: convertFromSmallestToPresentableCurrencyUnit(payment.amount, payment.currency),
         currency: payment.currency,
         email: bookerEmail,
         name: bookerName,
@@ -153,7 +157,7 @@ class HitPayPaymentService implements IAbstractPaymentService {
               id: bookingId,
             },
           },
-          amount: parseFloat(data.amount.replace(/,/g, "")) * 100,
+          amount: convertToSmallestCurrencyUnit(parseFloat(data.amount.replace(/,/g, "")), data.currency),
           externalId: data.id,
           currency: data.currency,
           data: Object.assign(


### PR DESCRIPTION
## What does this PR do?

- Fixes #30038

HitPay's payment-requests API takes `amount` as a decimal string in **major** units and echoes it
back the same way, so the integration converted in both directions — but unconditionally:

```ts
amount: payment.amount / 100,                                  // outbound  (:109)
...
amount: parseFloat(data.amount.replace(/,/g, "")) * 100,       // inbound   (:156)
```

The price input writes the amount through `convertToSmallestCurrencyUnit`, which stores
**zero-decimal currencies unscaled**. HitPay offers three of them — `jpy`, `krw`, `vnd`
(`components/constants.ts`) — so for those the outbound `/100` undercharges by 100×: a ¥10,000
event asks HitPay to collect **¥100**.

**Why this went unnoticed:** the two unconditional conversions cancel each other out in the
database. HitPay echoes back the 100 it was asked for, the inbound `* 100` turns it into 10000, and
the `Payment` row plus the booker's page both display ¥10,000 — while only 1% was actually charged.
`refund()` throws "Method not implemented" for this app, so there is no in-app correction either.

**Both lines have to change together.** Fixing only the outbound conversion sends the right amount
but then stores `1000000`, i.e. swaps a silent undercharge for a visible 100× overstatement:

| | Sent to HitPay | Stored | Booker sees |
| --- | --- | --- | --- |
| Current | `100` ❌ | 10000 | ¥10,000 |
| Outbound fix only | `10000` ✅ | **1000000** ❌ | **¥1,000,000** |
| This PR (both) | `10000` ✅ | 10000 ✅ | ¥10,000 |

Both directions now use the shared helpers in `@calcom/lib/currencyConversions` — the same module
the price input already uses, so storage, charge and display agree by construction.

Same class of bug as #29983, but an independent one in a different provider and file.

## Visual Demo (For contributors especially)

No UI surface: the amount is computed server-side in the outgoing HitPay request, and because the
two conversions currently cancel out, the booking page renders the *correct* price both before and
after. Screenshots would be identical and prove nothing — the meaningful evidence is the outgoing
request body and the persisted amount.

**Before (fix reverted, tests in place)** — the three zero-decimal currencies fail, the rest pass:

```
AssertionError: expected { sent: '100',  stored: 10000  } to deeply equal { sent: '10000',  stored: 10000  }
AssertionError: expected { sent: '500',  stored: 50000  } to deeply equal { sent: '50000',  stored: 50000  }
AssertionError: expected { sent: '2000', stored: 200000 } to deeply equal { sent: '200000', stored: 200000 }

 Tests  3 failed | 2 passed (5)
```

Note `stored` is correct in both columns — that is the masking effect, captured as a test.

**After (this PR)**:

```
 ✓ packages/app-store/hitpay/lib/PaymentService.test.ts (5 tests)

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

#### Video Demo (if applicable):

N/A — no UI change.

#### Image Demo (if applicable):

N/A — no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, internal currency conversion with no documented API change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No HitPay credentials or environment variables are needed — the test mocks the HTTP calls and
echoes back whatever amount was requested, the way HitPay does:

```bash
TZ=UTC yarn vitest run packages/app-store/hitpay/lib/PaymentService.test.ts
```

To see it fail without the fix, restore the two unconditional conversions in `PaymentService.ts`
and re-run.

To verify manually against HitPay sandbox:

- **Minimal test data:** an event type with the HitPay app enabled, currency **Japanese yen (JPY)**,
  price **10000**.
- **Expected (happy path):** the HitPay checkout requests **¥10,000**, matching the booking page and
  the `Payment` row. Before this change it requested ¥100 while both still displayed ¥10,000.
- Repeat with **USD** at price **50** to confirm unchanged behaviour: HitPay should request `50`.
- `krw` and `vnd` behave like `jpy`; the other 18 currencies in the picker behave like `usd`.

## Checklist
