### PR TITLE
fix(theme): resolve theme synchronization bug on public booking pages

### DIFF
--- a/apps/web/lib/__tests__/getThemeProviderProps.test.ts
+++ b/apps/web/lib/__tests__/getThemeProviderProps.test.ts
@@ -1,10 +1,7 @@
+import { EmbedTheme } from "@calcom/features/embed/lib/constants";
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { describe, expect, it } from "vitest";
-
-import { EmbedTheme } from "@calcom/features/embed/lib/constants";
-
-import { getThemeProviderProps } from "../getThemeProviderProps";
-import { getUniqueIdentifierForBookingPage } from "../getThemeProviderProps";
+import { getThemeProviderProps, getUniqueIdentifierForBookingPage } from "../getThemeProviderProps";
 
 describe("getThemeProviderProps", () => {
   const fnArg = {
@@ -26,6 +23,7 @@ describe("getThemeProviderProps", () => {
       key: expectedStorageKey,
       nonce: "test-nonce",
       enableColorScheme: false,
+      defaultTheme: "system",
     };
 
     it("should return app theme configuration when not in booking page or embed mode", () => {
@@ -77,11 +75,13 @@ describe("getThemeProviderProps", () => {
     });
   });
 
+  // THEME SYNC ON PUBLIC PAGE
   describe("Booking Page Theme Support", () => {
     const bookingPageExpectedProps = {
       attribute: "class",
       nonce: "test-nonce",
       enableColorScheme: false,
+      defaultTheme: "system",
     };
 
     it("should handle booking page theme", () => {
@@ -131,6 +131,7 @@ describe("getThemeProviderProps", () => {
       enableColorScheme: false,
       enableSystem: true,
       forcedTheme: undefined,
+      defaultTheme: "system",
     };
 
     it("should handle embed mode with default theme", () => {

--- a/apps/web/lib/getThemeProviderProps.ts
+++ b/apps/web/lib/getThemeProviderProps.ts
@@ -1,9 +1,8 @@
+import { EmbedTheme } from "@calcom/features/embed/lib/constants";
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { z } from "zod";
 
-import { EmbedTheme } from "@calcom/features/embed/lib/constants";
-
-const enum ThemeSupport {
+enum ThemeSupport {
   // e.g. Login Page
   None = "none",
   // Entire App except Booking Pages
@@ -108,6 +107,7 @@ export function getThemeProviderProps({
       nonce: props.nonce,
       enableColorScheme: false,
       enableSystem: themeSupport !== ThemeSupport.None,
+      defaultTheme: "system",
     };
   }
 
@@ -140,6 +140,7 @@ export function getThemeProviderProps({
     enableColorScheme: false,
     // Enables theme switching based on system preference if true
     enableSystem: themeSupport !== ThemeSupport.None,
+    defaultTheme: "system", // necessary so that <ThemeProvider> doesn't fallback to 'light' when theme not provided
     // next-themes doesn't listen to changes on storageKey. So we need to force a re-render when storageKey changes
     // This is how login to dashboard soft navigation changes theme from light to dark
     key: storageKey,

--- a/packages/lib/hooks/useTheme.ts
+++ b/packages/lib/hooks/useTheme.ts
@@ -1,18 +1,18 @@
+import { useEmbedTheme } from "@calcom/embed-core/embed-iframe";
+import { localStorage } from "@calcom/lib/webstorage";
 import { useTheme as useNextTheme } from "next-themes";
 import { useEffect } from "react";
 
-import { useEmbedTheme } from "@calcom/embed-core/embed-iframe";
-import { localStorage } from "@calcom/lib/webstorage";
-
 /**
  * It should be called once per route if you intend to use a theme different from `system` theme. `system` theme is automatically supported using <ThemeProvider />
- * If needed you can also set system theme by passing 'system' as `themeToSet`
- * It handles embed configured theme automatically
- * To just read the values pass `getOnly` as `true` and `themeToSet` as `null`
+ * - If needed you can also set system theme by passing 'system' as `themeToSet`
+ * - It handles embed configured theme automatically
+ * - To just read the values pass `getOnly` as `true` and `themeToSet` as `null`
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export default function useTheme(themeToSet: "system" | (string & {}) | undefined | null, getOnly = false) {
-  if (typeof window !== "undefined") {
+  // runs when we have a theme (light or dark) rather than system
+  if (typeof window !== "undefined" && themeToSet !== null) {
     const themeFromLocalStorage = localStorage.getItem("app-theme");
     themeToSet = themeToSet ?? themeFromLocalStorage ?? "system";
   }
@@ -28,7 +28,12 @@ export default function useTheme(themeToSet: "system" | (string & {}) | undefine
     // Embed theme takes precedence over theme configured in app.
     // If embedTheme isn't set i.e. it's not explicitly configured with a theme, then it would use the theme configured in appearance.
     // If embedTheme is set to "auto" then we consider it as null which then uses system theme.
-    const finalThemeToSet = embedTheme ? (embedTheme === "auto" ? "system" : embedTheme) : themeToSet;
+    // If themeToSet is received as 'null' from database(profile.theme) and here null means System default theme  then finalThemeToSet fall back to "system", thereby calling setTheme("system")
+    const finalThemeToSet = embedTheme
+      ? embedTheme === "auto"
+        ? "system"
+        : embedTheme
+      : (themeToSet ?? "system");
 
     if (!finalThemeToSet || finalThemeToSet === activeTheme) return;
 


### PR DESCRIPTION
## What does this PR do?
Fixes the theme synchronization issue on public booking pages. 

When a user switches their "Booking page theme" from a manual override (like "Light" or "Dark") back to "System default", the server passes `null` to `useTheme`. Previously, this caused `next-themes` to stick to the stale value left in local storage, completely ignoring the OS system preference (`matchMedia`). 

**Changes Made:**
1. **`useTheme.ts`**: Actively force a fallback to `"system"` when `themeToSet` is `null`. This guarantees that if the user chooses System Default, it actively pushes `"system"` into `next-themes`, which clears the stale local storage and successfully syncs back to the OS theme.
2. **`getThemeProviderProps.ts`**: Injected `defaultTheme: "system"` into the SSR props to prevent `<ThemeProvider>` from falling back to 'light' when no theme is provided.
3. **Unit Tests**: Updated `getThemeProviderProps.test.ts` to include the new `defaultTheme: "system"` property in the expected test objects, ensuring the test suite strictly checks the correct shape of the return object.

- Fixes [#XXXX](https://github.com/calcom/cal.diy/compare/main...innovate-with-ravi:cal.diy:Theme-Sync-Fix?expand=1#XXXX) 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Are there environment variables that should be set? No.
- What are the minimal test data to have? Any local user account.
- **To Verify:**
  1. Go to `http://localhost:3000/settings/my-account/appearance`
  2. Under "Booking page theme", explicitly set it to **Dark**. Check your public booking page (`/username`) and confirm it is dark.
  3. Change the setting to **Light**. Confirm the public booking page is light.
  4. Change the setting to **System default**.
  5. **Expected Output:** The public booking page should immediately drop the stale local storage value and sync to whatever your OS's current color scheme is.

## Checklist

- [ ] I haven't read the [[contributing guide](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)](https://github.com/calcom/cal.diy/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my changes generate no new warnings
- [ ] My PR is too large (>500 lines or >10 files) and should be split into smaller PRs