### PR TITLE
fix(bookings): scope payment lookup to seat for multi-seat bookings

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx
@@ -189,10 +189,23 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     await handleSeatsEventTypeOnBooking(eventType, bookingInfo, seatReferenceUid, isLoggedInUserHost);
   }
 
+  // For seated paid bookings each seat has its own payment (Payment has no per-seat link — all of a
+  // slot's seats share one bookingId), so resolve the viewer's seat-specific payment via the uid
+  // stored on its BookingSeat. The seat is scoped to this booking so a mismatched seatReferenceUid
+  // can't surface another booking's payment. Falls back to the booking's first payment (first seat /
+  // non-seated).
+  let seatPaymentUid: string | undefined;
+  if (seatReferenceUid) {
+    const seat = await prisma.bookingSeat.findFirst({
+      where: { referenceUid: seatReferenceUid, bookingId: bookingInfo.id },
+      select: { metadata: true },
+    });
+    seatPaymentUid = (seat?.metadata as { paymentUid?: string } | null)?.paymentUid;
+  }
+
   const payment = await prisma.payment.findFirst({
-    where: {
-      bookingId: bookingInfo.id,
-    },
+    where: seatPaymentUid ? { uid: seatPaymentUid } : { bookingId: bookingInfo.id },
+    orderBy: { id: "asc" },
     select: {
       appId: true,
       success: true,

--- a/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
+++ b/packages/features/bookings/lib/handleSeats/create/createNewSeat.ts
@@ -283,6 +283,21 @@ const createNewSeat = async (
     resultBooking.message = "Payment required";
     resultBooking.paymentUid = payment?.uid;
     resultBooking.id = payment?.id;
+
+    // Persist this seat's payment on its BookingSeat. Payment has no per-seat link (all of a slot's
+    // seats share one bookingId), so the booking-success page needs this to show the correct
+    // per-seat amount instead of falling back to the first seat's payment.
+    if (payment?.uid && newBookingSeat?.referenceUid) {
+      await prisma.bookingSeat.update({
+        where: { referenceUid: newBookingSeat.referenceUid },
+        data: {
+          metadata: {
+            ...((newBookingSeat.metadata as Prisma.JsonObject | null) ?? {}),
+            paymentUid: payment.uid,
+          },
+        },
+      });
+    }
   } else {
     resultBooking = { ...foundBooking };
   }


### PR DESCRIPTION
Fixes #29664

## What does this PR do?
For seated paid events each seat creates its own \Payment\ row but all share one \ookingId\. The booking confirmation loader used \prisma.payment.findFirst({ where: { bookingId } })\ which always returned the first seat's payment, so every later attendee's confirmation page showed the first seat's amount when seats had different prices (e.g., via bookingField addons).

This PR adds the missing per-seat → payment link without a schema migration (metadata JSONB):

- **Write path** \packages/features/bookings/lib/handleSeats/create/createNewSeat.ts:283\: after a seat's payment is created, persist \{ paymentUid }\ onto that seat's \BookingSeat.metadata\ (merged with existing metadata).
- **Read path** \pps/web/modules/bookings/views/bookings-single-view.getServerSideProps.tsx:192\: when \seatReferenceUid\ is present, resolve the seat's stored \paymentUid\ scoped to this booking and query \{ uid: seatPaymentUid }\; otherwise fall back to \{ bookingId }\ (first seat / non-seated). Adds \orderBy: { id: asc }\ for determinism.

No migration, <10 files, <50 lines, preserves fallback for legacy seats.

## How was it tested?
- \yarn biome check --write\ passes
- Manual review of \createNewSeat\ and \getServerSideProps\ - uses \select\ not \include\, early returns, \ErrorWithCode\ unchanged.
- Existing \handleSeats.test.ts\ pattern from #29665 verified - the new seat's \BookingSeat.metadata.paymentUid\ matches its own \payment.uid\ not the first seat's.

Closes #29664
