### PR TITLE
fix(hitpay): keep zero-decimal currency amounts unscaled

### DIFF
--- a/packages/app-store/hitpay/lib/PaymentService.test.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("@calcom/prisma", () => ({
+  default: {
+    booking: {
+      findUnique: vi.fn(),
+    },
+    payment: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+import axios from "axios";
+import prisma from "@calcom/prisma";
+import { BuildPaymentService } from "./PaymentService";
+
+const mockedAxiosPost = vi.mocked(axios.post);
+const mockedAxiosGet = vi.mocked(axios.get);
+const mockedBookingFindUnique = vi.mocked(prisma.booking.findUnique);
+const mockedPaymentCreate = vi.mocked(prisma.payment.create);
+
+const booking = {
+  uid: "uid-1",
+  title: "HitPay test booking",
+  startTime: new Date("2026-08-28T10:00:00Z"),
+  endTime: new Date("2026-08-28T10:30:00Z"),
+  eventTypeId: 1,
+  eventType: { slug: "hitpay-test", seatsPerTimeSlot: null },
+  attendees: [],
+};
+
+const paymentDefaults = {
+  amount: 10000,
+  currency: "JPY",
+};
+
+beforeEach(() => {
+  mockedBookingFindUnique.mockResolvedValue(booking as any);
+  mockedPaymentCreate.mockImplementation(((args: any) =>
+    Promise.resolve({ id: 1, ...args.data })) as any);
+  mockedAxiosPost.mockResolvedValue({
+    data: { id: "req-1", amount: "10000", currency: "JPY", url: "http://hitpay.test/pay" },
+  } as any);
+  mockedAxiosGet.mockResolvedValue({
+    data: { data: [{ url: "http://hitpay.test/pay/default" }] },
+  } as any);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("HitPayPaymentService amount handling", () => {
+  it("sends zero-decimal currency amounts unscaled to the HitPay API", async () => {
+    const service = BuildPaymentService({
+      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
+    });
+
+    await service.create(paymentDefaults as any, 1, 1, "user", "Booker", "HOLD", "booker@test.com");
+
+    const [url, formData] = mockedAxiosPost.mock.calls[0];
+    expect(url).toContain("/v1/payment-requests");
+    expect((formData as any).amount).toBe(10000);
+    expect((formData as any).currency).toBe("JPY");
+  });
+
+  it("sends two-decimal currency amounts divided by 100 to the HitPay API", async () => {
+    mockedAxiosPost.mockResolvedValue({
+      data: { id: "req-2", amount: "100.00", currency: "USD" },
+    } as any);
+    const service = BuildPaymentService({
+      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
+    });
+
+    await service.create(
+      { amount: 10000, currency: "USD" } as any,
+      1,
+      1,
+      "user",
+      "Booker",
+      "HOLD",
+      "booker@test.com"
+    );
+
+    const [, formData] = mockedAxiosPost.mock.calls[0];
+    expect((formData as any).amount).toBe(100);
+  });
+
+  it("stores the echoed zero-decimal amount unscaled, preserving the charged amount", async () => {
+    const service = BuildPaymentService({
+      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
+    });
+
+    await service.create(paymentDefaults as any, 1, 1, "user", "Booker", "HOLD", "booker@test.com");
+
+    const stored = mockedPaymentCreate.mock.calls[0][0] as any;
+    expect(stored.data.amount).toBe(10000);
+    expect(stored.data.currency).toBe("JPY");
+  });
+
+  it("stores an echoed two-decimal amount scaled to the smallest unit", async () => {
+    mockedAxiosPost.mockResolvedValue({
+      data: { id: "req-3", amount: "100.00", currency: "USD" },
+    } as any);
+    const service = BuildPaymentService({
+      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
+    });
+
+    await service.create(
+      { amount: 10000, currency: "USD" } as any,
+      1,
+      1,
+      "user",
+      "Booker",
+      "HOLD",
+      "booker@test.com"
+    );
+
+    const stored = mockedPaymentCreate.mock.calls[0][0] as any;
+    expect(stored.data.amount).toBe(10000);
+  });
+});

--- a/packages/app-store/hitpay/lib/PaymentService.test.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.test.ts
@@ -1,3 +1,4 @@
+import qs from "qs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("axios", () => ({
@@ -11,6 +12,7 @@ vi.mock("@calcom/prisma", () => ({
   default: {
     booking: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
     },
     payment: {
       create: vi.fn(),
@@ -20,11 +22,13 @@ vi.mock("@calcom/prisma", () => ({
 
 import axios from "axios";
 import prisma from "@calcom/prisma";
+import type { Booking, Payment, PaymentOption } from "@calcom/prisma/client";
 import { BuildPaymentService } from "./PaymentService";
 
 const mockedAxiosPost = vi.mocked(axios.post);
 const mockedAxiosGet = vi.mocked(axios.get);
 const mockedBookingFindUnique = vi.mocked(prisma.booking.findUnique);
+const mockedBookingFindMany = vi.mocked(prisma.booking.findMany);
 const mockedPaymentCreate = vi.mocked(prisma.payment.create);
 
 const booking = {
@@ -35,53 +39,53 @@ const booking = {
   eventTypeId: 1,
   eventType: { slug: "hitpay-test", seatsPerTimeSlot: null },
   attendees: [],
-};
+} as unknown as Booking;
 
-const paymentDefaults = {
-  amount: 10000,
-  currency: "JPY",
-};
+const payment = { amount: 10000, currency: "JPY" };
 
 beforeEach(() => {
-  mockedBookingFindUnique.mockResolvedValue(booking as any);
-  mockedPaymentCreate.mockImplementation(((args: any) =>
-    Promise.resolve({ id: 1, ...args.data })) as any);
+  mockedBookingFindUnique.mockResolvedValue(booking);
+  mockedBookingFindMany.mockResolvedValue([]);
+  mockedPaymentCreate.mockImplementation((async (args) => ({
+    id: 1,
+    ...args.data,
+  })) as unknown as typeof mockedPaymentCreate);
   mockedAxiosPost.mockResolvedValue({
     data: { id: "req-1", amount: "10000", currency: "JPY", url: "http://hitpay.test/pay" },
-  } as any);
+  });
   mockedAxiosGet.mockResolvedValue({
     data: { data: [{ url: "http://hitpay.test/pay/default" }] },
-  } as any);
+  });
 });
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
+const buildService = () =>
+  BuildPaymentService({
+    key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
+  });
+
+const createPayment = (paymentOption: PaymentOption = "HOLD") =>
+  buildService().create(payment, 1, 1, "user", "Booker", paymentOption, "booker@test.com");
+
 describe("HitPayPaymentService amount handling", () => {
   it("sends zero-decimal currency amounts unscaled to the HitPay API", async () => {
-    const service = BuildPaymentService({
-      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
-    });
+    await createPayment();
 
-    await service.create(paymentDefaults as any, 1, 1, "user", "Booker", "HOLD", "booker@test.com");
-
-    const [url, formData] = mockedAxiosPost.mock.calls[0];
+    const [url, body] = mockedAxiosPost.mock.calls[0];
     expect(url).toContain("/v1/payment-requests");
-    expect((formData as any).amount).toBe(10000);
-    expect((formData as any).currency).toBe("JPY");
+    expect(qs.parse(body as string)).toMatchObject({ amount: "10000", currency: "JPY" });
   });
 
   it("sends two-decimal currency amounts divided by 100 to the HitPay API", async () => {
     mockedAxiosPost.mockResolvedValue({
       data: { id: "req-2", amount: "100.00", currency: "USD" },
-    } as any);
-    const service = BuildPaymentService({
-      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
     });
 
-    await service.create(
-      { amount: 10000, currency: "USD" } as any,
+    await buildService().create(
+      { amount: 10000, currency: "USD" },
       1,
       1,
       "user",
@@ -90,18 +94,14 @@ describe("HitPayPaymentService amount handling", () => {
       "booker@test.com"
     );
 
-    const [, formData] = mockedAxiosPost.mock.calls[0];
-    expect((formData as any).amount).toBe(100);
+    const [, body] = mockedAxiosPost.mock.calls[0];
+    expect(qs.parse(body as string)).toMatchObject({ amount: "100", currency: "USD" });
   });
 
   it("stores the echoed zero-decimal amount unscaled, preserving the charged amount", async () => {
-    const service = BuildPaymentService({
-      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
-    });
+    await createPayment();
 
-    await service.create(paymentDefaults as any, 1, 1, "user", "Booker", "HOLD", "booker@test.com");
-
-    const stored = mockedPaymentCreate.mock.calls[0][0] as any;
+    const stored = mockedPaymentCreate.mock.calls[0][0];
     expect(stored.data.amount).toBe(10000);
     expect(stored.data.currency).toBe("JPY");
   });
@@ -109,13 +109,10 @@ describe("HitPayPaymentService amount handling", () => {
   it("stores an echoed two-decimal amount scaled to the smallest unit", async () => {
     mockedAxiosPost.mockResolvedValue({
       data: { id: "req-3", amount: "100.00", currency: "USD" },
-    } as any);
-    const service = BuildPaymentService({
-      key: { isSandbox: true, sandbox: { apiKey: "sandbox-key" } },
     });
 
-    await service.create(
-      { amount: 10000, currency: "USD" } as any,
+    await buildService().create(
+      { amount: 10000, currency: "USD" },
       1,
       1,
       "user",
@@ -124,7 +121,8 @@ describe("HitPayPaymentService amount handling", () => {
       "booker@test.com"
     );
 
-    const stored = mockedPaymentCreate.mock.calls[0][0] as any;
+    const stored = mockedPaymentCreate.mock.calls[0][0];
     expect(stored.data.amount).toBe(10000);
+    expect(stored.data.currency).toBe("USD");
   });
 });

--- a/packages/app-store/hitpay/lib/PaymentService.ts
+++ b/packages/app-store/hitpay/lib/PaymentService.ts
@@ -4,6 +4,10 @@ import { v4 as uuidv4 } from "uuid";
 import type z from "zod";
 
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import {
+  convertFromSmallestToPresentableCurrencyUnit,
+  convertToSmallestCurrencyUnit,
+} from "@calcom/lib/currencyConversions";
 import { ErrorCode } from "@calcom/lib/errorCodes";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -106,7 +110,7 @@ class HitPayPaymentService implements IAbstractPaymentService {
       const webhookUri = `${WEBAPP_URL}/api/integrations/${appConfig.slug}/webhook`;
 
       const formData = {
-        amount: payment.amount / 100,
+        amount: convertFromSmallestToPresentableCurrencyUnit(payment.amount, payment.currency),
         currency: payment.currency,
         email: bookerEmail,
         name: bookerName,
@@ -153,7 +157,10 @@ class HitPayPaymentService implements IAbstractPaymentService {
               id: bookingId,
             },
           },
-          amount: parseFloat(data.amount.replace(/,/g, "")) * 100,
+          amount: convertToSmallestCurrencyUnit(
+            parseFloat(data.amount.replace(/,/g, "")),
+            data.currency
+          ),
           externalId: data.id,
           currency: data.currency,
           data: Object.assign(


### PR DESCRIPTION
## Summary

For the three zero-decimal currencies HitPay supports (JPY, KRW, VND), the integration charged 1/100th of the configured price: `PaymentService.create()` divided the stored smallest-unit amount by 100 unconditionally when building the payment-request, and multiplied the echoed major-unit amount back by 100 when storing the `Payment` row — while zero-decimal currencies are stored unscaled, so the two conversions corrupted the request amount and then masked the undercharge in the DB.

Both conversions now go through the shared zero-decimal-aware helpers `convertFromSmallestToPresentableCurrencyUnit` / `convertToSmallestCurrencyUnit` from `@calcom/lib/currencyConversions` (the same list of zero-decimal currencies the booking-time price normalization uses). Behavior for two-decimal currencies is unchanged.

Note: `packages/app-store/hitpay/lib/currencyConversions.ts` is an unused duplicate of `@calcom/lib/currencyConversions`; left untouched, but flagging it as a candidate for removal in a follow-up.

## What was tested

- Built a regression suite (`PaymentService.test.ts`, 4 cases) covering: zero-decimal request amount unscaled, two-decimal request amount divided by 100, echoed zero-decimal amount stored unscaled, echoed two-decimal amount stored in smallest units. `yarn vitest run packages/app-store/hitpay/lib/PaymentService.test.ts` — see CI for execution (local full install not possible on this machine).
- Ran the conversion arithmetic against the compiled repo helpers (`currencyConversions.js` emitted by tsc): JPY/KRW/VND request + echo paths and USD both directions all assert correctly.

Fixes #30038