### PR TITLE
fix(googlecalendar): suppress notifications on hangout-link follow-up patch

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -300,6 +300,7 @@ class GoogleCalendarService implements Calendar {
           // Update the same event but this time we know the hangout link
           calendarId: selectedCalendar,
           eventId: event.id || "",
+          sendUpdates: "none",
           requestBody: {
             description: getRichDescription({
               ...calEvent,

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
@@ -866,6 +866,10 @@ describe("createEvent", () => {
     expect(patchCall.requestBody.location).toBe(mockHangoutLink);
     expect(patchCall.requestBody.description).toBeDefined();
 
+    // The insert suppresses Google's invitation (sendUpdates: "none"), so the
+    // follow-up patch must too, otherwise attendees get a phantom "Updated invitation"
+    expect(patchCall.sendUpdates).toBe("none");
+
     log.info("createEvent with hangoutLink patch test passed");
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #30044

Part of the bug report in #30044: when a booking is created with Google
Calendar + Google Meet, `events.insert` is called with `sendUpdates: "none"`
so that Cal.diy manages its own confirmation emails and Google does not send a
notification. A follow-up `events.patch` then writes the Meet/hangout link into
the event description, but it omits `sendUpdates` entirely. Google therefore
notifies the attendee about the change with an "Updated invitation" email even
though no original invitation was ever sent to them - the attendee's only
interaction with the event is a phantom update email.

This change makes the follow-up patch consistent with the insert by passing
`sendUpdates: "none"`, so Google stops sending that misleading notification
(it also removes the accidental email channel that this issue reports being
lost on the failure path).

Note: this PR addresses the notification-inconsistency part of #30044 (the
reporter's option 3). The broader question of sending Cal.diy's confirmation
emails when a calendar integration fails (options 1 and 2) is a larger
behavior change and is left to a follow-up.

## Visual Demo (For contributors especially)

N/A - this is a one-line API parameter change; behavior is covered by the unit
test assertion added in this PR.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables are required.
- Unit test: `packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts` - the `createEvent > should patch event location with hangoutLink when event is created with hangoutLink` test now asserts that the follow-up `events.patch` call includes `sendUpdates: "none"`.
- Run: `yarn vitest run packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts`
- Local check: all 20 tests in the file pass. The new assertion fails (patch omits `sendUpdates`) before the fix and passes after it.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- [x] My PR is small (<500 lines and <10 files; this PR is 2 files, +5 lines) and should NOT be split into smaller PRs

---

_Automated by pr-pipeline (com.ashutosh.prpipeline)._