### PR TITLE
refactor: Modify RegularBookingService to use repositories instead of direct PrismaClient injection

### DIFF
--- a/packages/features/bookings/di/BookingSeatRepository.module.ts
+++ b/packages/features/bookings/di/BookingSeatRepository.module.ts
@@ -1,0 +1,17 @@
+import { BookingSeatRepository } from "@calcom/features/bookings/repositories/BookingSeatRepository";
+import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
+import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
+import { DI_TOKENS } from "@calcom/features/di/tokens";
+
+const thisModule = createModule();
+const token = DI_TOKENS.BOOKING_SEAT_REPOSITORY;
+const moduleToken = DI_TOKENS.BOOKING_SEAT_REPOSITORY_MODULE;
+const loadModule = bindModuleToClassOnToken({
+  module: thisModule,
+  moduleToken,
+  token,
+  classs: BookingSeatRepository,
+  dep: prismaModuleLoader,
+});
+
+export const moduleLoader = { token, loadModule } satisfies ModuleLoader;

--- a/packages/features/bookings/di/RegularBookingService.module.ts
+++ b/packages/features/bookings/di/RegularBookingService.module.ts
@@ -1,14 +1,16 @@
 import { moduleLoader as bookingEventHandlerModuleLoader } from "@calcom/features/bookings/di/BookingEventHandlerService.module";
+import { moduleLoader as bookingSeatRepositoryModuleLoader } from "@calcom/features/bookings/di/BookingSeatRepository.module";
 import { RegularBookingService } from "@calcom/features/bookings/lib/service/RegularBookingService";
+import { moduleLoader as credentialRepositoryModuleLoader } from "@calcom/features/credentials/di/CredentialRepository.module";
 import { bindModuleToClassOnToken, createModule, type ModuleLoader } from "@calcom/features/di/di";
 import { moduleLoader as bookingRepositoryModuleLoader } from "@calcom/features/di/modules/Booking";
 import { moduleLoader as checkBookingAndDurationLimitsModuleLoader } from "@calcom/features/di/modules/CheckBookingAndDurationLimits";
 import { moduleLoader as luckyUserServiceModuleLoader } from "@calcom/features/di/modules/LuckyUser";
-import { moduleLoader as prismaModuleLoader } from "@calcom/features/di/modules/Prisma";
 import { moduleLoader as userRepositoryModuleLoader } from "@calcom/features/di/modules/User";
 import { DI_TOKENS } from "@calcom/features/di/tokens";
 import { moduleLoader as webhookProducerModuleLoader } from "@calcom/features/di/webhooks/modules/WebhookProducerService.module";
 import { moduleLoader as hashedLinkServiceModuleLoader } from "@calcom/features/hashedLink/di/HashedLinkService.module";
+import { moduleLoader as profileRepositoryModuleLoader } from "@calcom/features/users/di/Profile.module";
 import { moduleLoader as bookingEmailAndSmsTaskerModuleLoader } from "./tasker/BookingEmailAndSmsTasker.module";
 
 const thisModule = createModule();
@@ -20,10 +22,11 @@ const loadModule = bindModuleToClassOnToken({
   token,
   classs: RegularBookingService,
   depsMap: {
-    // TODO: In a followup PR, we aim to remove prisma dependency and instead inject the repositories as dependencies.
-    prismaClient: prismaModuleLoader,
     checkBookingAndDurationLimitsService: checkBookingAndDurationLimitsModuleLoader,
     bookingRepository: bookingRepositoryModuleLoader,
+    bookingSeatRepository: bookingSeatRepositoryModuleLoader,
+    profileRepository: profileRepositoryModuleLoader,
+    credentialRepository: credentialRepositoryModuleLoader,
     luckyUserService: luckyUserServiceModuleLoader,
     userRepository: userRepositoryModuleLoader,
     hashedLinkService: hashedLinkServiceModuleLoader,

--- a/packages/features/bookings/lib/service/RegularBookingService.integration-test.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.integration-test.ts
@@ -1,0 +1,96 @@
+import { BookingRepository } from "@calcom/features/bookings/repositories/BookingRepository";
+import { prisma } from "@calcom/prisma";
+import { BookingStatus } from "@calcom/prisma/enums";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const bookingRepository = new BookingRepository(prisma);
+
+describe("RegularBookingService persistence", () => {
+  let userId: number;
+  let hasUser = false;
+  let eventTypeId: number;
+  let acceptedBooking: { id: number; uid: string };
+
+  beforeEach(async () => {
+    const id = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: { email: `regular-booking-${id}@test.cal.com`, username: `regular-booking-${id}` },
+      select: { id: true },
+    });
+    userId = user.id;
+    hasUser = true;
+    const eventType = await prisma.eventType.create({
+      data: { title: "Seated event", slug: `seated-event-${id}`, length: 30, userId },
+      select: { id: true },
+    });
+    eventTypeId = eventType.id;
+
+    const startTime = new Date("2031-05-01T10:00:00.000Z");
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `accepted-booking-${id}`,
+        userId,
+        eventTypeId,
+        title: "Accepted booking",
+        startTime,
+        endTime: new Date("2031-05-01T10:30:00.000Z"),
+        status: BookingStatus.ACCEPTED,
+        attendees: {
+          create: { email: "accepted-attendee@test.cal.com", name: "Accepted Attendee", timeZone: "UTC" },
+        },
+      },
+      select: { id: true, uid: true },
+    });
+    acceptedBooking = booking;
+
+    await prisma.booking.create({
+      data: {
+        uid: `pending-booking-${id}`,
+        userId,
+        eventTypeId,
+        title: "Pending booking",
+        startTime,
+        endTime: new Date("2031-05-01T10:30:00.000Z"),
+        status: BookingStatus.PENDING,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    if (hasUser) await prisma.user.delete({ where: { id: userId } });
+    hasUser = false;
+  });
+
+  it("uses the accepted slot and persists calendar data created during booking", async () => {
+    const booking = await bookingRepository.findAcceptedForEventTypeAtStartTime({
+      eventTypeId,
+      startTime: new Date("2031-05-01T10:00:00.000Z"),
+    });
+    expect(booking).toEqual({ userId, attendees: [{ email: "accepted-attendee@test.cal.com" }] });
+
+    await bookingRepository.updateICalUID({ bookingId: acceptedBooking.id, iCalUID: "updated-ical-uid" });
+    await bookingRepository.updateLocationMetadataAndReferences({
+      bookingUid: acceptedBooking.uid,
+      location: "https://meet.example.com/booking",
+      metadata: { videoCallUrl: "https://meet.example.com/booking" },
+      references: [{ type: "google_calendar", uid: "calendar-event-id" }],
+    });
+
+    await expect(
+      prisma.booking.findUniqueOrThrow({
+        where: { id: acceptedBooking.id },
+        select: {
+          iCalUID: true,
+          location: true,
+          metadata: true,
+          references: { select: { type: true, uid: true } },
+        },
+      })
+    ).resolves.toEqual({
+      iCalUID: "updated-ical-uid",
+      location: "https://meet.example.com/booking",
+      metadata: { videoCallUrl: "https://meet.example.com/booking" },
+      references: [{ type: "google_calendar", uid: "calendar-event-id" }],
+    });
+  });
+});

--- a/packages/features/bookings/lib/service/RegularBookingService.ts
+++ b/packages/features/bookings/lib/service/RegularBookingService.ts
@@ -30,6 +30,7 @@ import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEvent
 import type { BookingEmailAndSmsTasker } from "@calcom/features/bookings/lib/tasker/BookingEmailAndSmsTasker";
 import type { BuiltCalendarEvent } from "@calcom/features/CalendarEventBuilder";
 import { CalendarEventBuilder } from "@calcom/features/CalendarEventBuilder";
+import type { CredentialRepository } from "@calcom/features/credentials/repositories/CredentialRepository";
 import { getSpamCheckService } from "@calcom/features/di/watchlist/containers/SpamCheckService.container";
 import {
   type EventTypeBrandingData,
@@ -39,7 +40,7 @@ import { getUsernameList } from "@calcom/features/eventtypes/lib/defaultEvents";
 import { getEventName, updateHostInEventName } from "@calcom/features/eventtypes/lib/eventNaming";
 import { getFullName } from "@calcom/features/form-builder/utils";
 import type { HashedLinkService } from "@calcom/features/hashedLink/lib/service/HashedLinkService";
-import { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
+import type { ProfileRepository } from "@calcom/features/profile/repositories/ProfileRepository";
 import { handleAnalyticsEvents } from "@calcom/features/tasker/tasks/analytics/handleAnalyticsEvents";
 import type { UserRepository } from "@calcom/features/users/repositories/UserRepository";
 import { UsersRepository } from "@calcom/features/users/users.repository";
@@ -67,7 +68,6 @@ import { safeStringify } from "@calcom/lib/safeStringify";
 import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import { distributedTracing } from "@calcom/lib/tracing/factory";
-import type { PrismaClient } from "@calcom/prisma";
 import type { AssignmentReasonEnum, DestinationCalendar, Prisma, User } from "@calcom/prisma/client";
 import { BookingStatus, CreationSource, SchedulingType, WebhookTriggerEvents } from "@calcom/prisma/enums";
 import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
@@ -82,6 +82,7 @@ import type { EventResult, PartialReference } from "@calcom/types/EventManager";
 import short, { uuid } from "short-uuid";
 import { v5 as uuidv5 } from "uuid";
 import type { BookingRepository } from "../../repositories/BookingRepository";
+import type { BookingSeatRepository } from "../../repositories/BookingSeatRepository";
 import { BookingActionMap, type BookingActionType, BookingEmailSmsHandler } from "../BookingEmailSmsHandler";
 import { getAllCredentialsIncludeServiceAccountKey } from "../getAllCredentialsForUsersOnEvent/getAllCredentials";
 import { refreshCredentials } from "../getAllCredentialsForUsersOnEvent/refreshCredentials";
@@ -422,8 +423,10 @@ function buildBookingCreatedPayload({
 
 export interface IBookingServiceDependencies {
   checkBookingAndDurationLimitsService: CheckBookingAndDurationLimitsService;
-  prismaClient: PrismaClient;
   bookingRepository: BookingRepository;
+  bookingSeatRepository: BookingSeatRepository;
+  profileRepository: ProfileRepository;
+  credentialRepository: CredentialRepository;
   luckyUserService: LuckyUserService;
   userRepository: UserRepository;
   hashedLinkService: HashedLinkService;
@@ -826,16 +829,9 @@ async function handler(
   let availableUsers: IsFixedAwareUser[] = [];
 
   if (eventType.seatsPerTimeSlot) {
-    const booking = await deps.prismaClient.booking.findFirst({
-      where: {
-        eventTypeId: eventType.id,
-        startTime: new Date(dayjs(reqBody.start).utc().format()),
-        status: BookingStatus.ACCEPTED,
-      },
-      select: {
-        userId: true,
-        attendees: { select: { email: true } },
-      },
+    const booking = await deps.bookingRepository.findAcceptedForEventTypeAtStartTime({
+      eventTypeId: eventType.id,
+      startTime: new Date(dayjs(reqBody.start).utc().format()),
     });
 
     if (booking) {
@@ -1309,15 +1305,8 @@ async function handler(
   });
   // For bookings made before introducing iCalSequence, assume that the sequence should start at 1. For new bookings start at 0.
   const iCalSequence = getICalSequence(originalRescheduledBooking);
-  const organizerOrganizationProfile = await deps.prismaClient.profile.findFirst({
-    where: {
-      userId: organizerUser.id,
-    },
-    select: {
-      organizationId: true,
-      username: true,
-      organization: { select: { hideBranding: true } },
-    },
+  const organizerOrganizationProfile = await deps.profileRepository.findOrganizationProfileByUserId({
+    userId: organizerUser.id,
   });
 
   const organizerOrganizationId = organizerOrganizationProfile?.organizationId;
@@ -1774,8 +1763,7 @@ async function handler(
 
         // Save description to bookingSeat
         const uniqueAttendeeId = uuid();
-        await deps.prismaClient.bookingSeat.create({
-          data: {
+        await deps.bookingSeatRepository.create({
             referenceUid: uniqueAttendeeId,
             data: {
               description: additionalNotes,
@@ -1792,8 +1780,7 @@ async function handler(
                 id: currentAttendee?.id,
               },
             },
-          },
-        });
+          }),
         evt.attendeeSeatId = uniqueAttendeeId;
       }
     } else {
@@ -2138,13 +2125,9 @@ async function handler(
 
         if (!isDryRun && evt.iCalUID !== booking.iCalUID) {
           // The eventManager could change the iCalUID. At this point we can update the DB record
-          await deps.prismaClient.booking.update({
-            where: {
-              id: booking.id,
-            },
-            data: {
-              iCalUID: evt.iCalUID || booking.iCalUID,
-            },
+          await deps.bookingRepository.updateICalUID({
+            bookingId: booking.id,
+            iCalUID: evt.iCalUID || booking.iCalUID,
           });
         }
       }
@@ -2255,25 +2238,9 @@ async function handler(
   if (bookingRequiresPayment) {
     tracingLogger.debug(`Booking ${organizerUser.username} requires payment`);
     // Load credentials.app.categories
-    const credentialPaymentAppCategories = await deps.prismaClient.credential.findMany({
-      where: {
-        ...(paymentAppData.credentialId ? { id: paymentAppData.credentialId } : { userId: organizerUser.id }),
-        app: {
-          categories: {
-            hasSome: ["payment"],
-          },
-        },
-      },
-      select: {
-        key: true,
-        appId: true,
-        app: {
-          select: {
-            categories: true,
-            dirName: true,
-          },
-        },
-      },
+    const credentialPaymentAppCategories = await deps.credentialRepository.findPaymentAppCredentials({
+      credentialId: paymentAppData.credentialId,
+      userId: organizerUser.id,
     });
     const eventTypePaymentAppCredential = credentialPaymentAppCategories.find((credential) => {
       return credential.appId === paymentAppData.appId;
@@ -2443,19 +2410,11 @@ async function handler(
 
   try {
     if (!isDryRun) {
-      await deps.prismaClient.booking.update({
-        where: {
-          uid: booking.uid,
-        },
-        data: {
-          location: evt.location,
-          metadata: { ...(typeof booking.metadata === "object" && booking.metadata), ...metadata },
-          references: {
-            createMany: {
-              data: referencesToCreate,
-            },
-          },
-        },
+      await deps.bookingRepository.updateLocationMetadataAndReferences({
+        bookingUid: booking.uid,
+        location: evt.location,
+        metadata: { ...(typeof booking.metadata === "object" && booking.metadata), ...metadata },
+        references: referencesToCreate,
       });
     }
   } catch (error) {

--- a/packages/features/bookings/repositories/BookingRepository.ts
+++ b/packages/features/bookings/repositories/BookingRepository.ts
@@ -340,6 +340,40 @@ const selectStatementToGetBookingForCalEventBuilder = {
 export class BookingRepository implements IBookingRepository {
   constructor(private prismaClient: PrismaClient) {}
 
+  async findAcceptedForEventTypeAtStartTime({
+    eventTypeId,
+    startTime,
+  }: {
+    eventTypeId: number;
+    startTime: Date;
+  }) {
+    return this.prismaClient.booking.findFirst({
+      where: { eventTypeId, startTime, status: BookingStatus.ACCEPTED },
+      select: { userId: true, attendees: { select: { email: true } } },
+    });
+  }
+
+  async updateICalUID({ bookingId, iCalUID }: { bookingId: number; iCalUID: string | null }) {
+    return this.prismaClient.booking.update({ where: { id: bookingId }, data: { iCalUID } });
+  }
+
+  async updateLocationMetadataAndReferences({
+    bookingUid,
+    location,
+    metadata,
+    references,
+  }: {
+    bookingUid: string;
+    location: string | null | undefined;
+    metadata: Prisma.InputJsonValue;
+    references: Prisma.BookingReferenceCreateManyBookingInput[];
+  }) {
+    return this.prismaClient.booking.update({
+      where: { uid: bookingUid },
+      data: { location, metadata, references: { createMany: { data: references } } },
+    });
+  }
+
   /**
    * Gets the fromReschedule field for a booking by UID
    * Used to identify if this booking was created from a reschedule

--- a/packages/features/bookings/repositories/BookingSeatRepository.integration-test.ts
+++ b/packages/features/bookings/repositories/BookingSeatRepository.integration-test.ts
@@ -1,0 +1,67 @@
+import { prisma } from "@calcom/prisma";
+import { BookingStatus } from "@calcom/prisma/enums";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BookingSeatRepository } from "./BookingSeatRepository";
+
+const repository = new BookingSeatRepository(prisma);
+
+describe("BookingSeatRepository", () => {
+  let userId: number;
+  let hasUser = false;
+  let bookingId: number;
+  let attendeeId: number;
+
+  beforeEach(async () => {
+    const id = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: { email: `booking-seat-${id}@test.cal.com`, username: `booking-seat-${id}` },
+      select: { id: true },
+    });
+    userId = user.id;
+    hasUser = true;
+    const booking = await prisma.booking.create({
+      data: {
+        uid: `booking-seat-${id}`,
+        userId,
+        title: "Seated booking",
+        startTime: new Date("2031-05-01T10:00:00.000Z"),
+        endTime: new Date("2031-05-01T10:30:00.000Z"),
+        status: BookingStatus.ACCEPTED,
+        attendees: {
+          create: { email: "seat-attendee@test.cal.com", name: "Seat Attendee", timeZone: "UTC" },
+        },
+      },
+      select: { id: true, attendees: { select: { id: true } } },
+    });
+    bookingId = booking.id;
+    attendeeId = booking.attendees[0].id;
+  });
+
+  afterEach(async () => {
+    if (hasUser) await prisma.user.delete({ where: { id: userId } });
+    hasUser = false;
+  });
+
+  it("creates a seat connected to the requested attendee and preserves booking form data", async () => {
+    await repository.create({
+      referenceUid: `seat-${crypto.randomUUID()}`,
+      booking: { connect: { id: bookingId } },
+      attendee: { connect: { id: attendeeId } },
+      data: { description: "Needs wheelchair access" },
+      metadata: { source: "booking-form" },
+    });
+
+    await expect(
+      prisma.attendee.findUniqueOrThrow({
+        where: { id: attendeeId },
+        select: { bookingSeat: { select: { bookingId: true, data: true, metadata: true } } },
+      })
+    ).resolves.toMatchObject({
+      bookingSeat: {
+        bookingId,
+        data: { description: "Needs wheelchair access" },
+        metadata: { source: "booking-form" },
+      },
+    });
+  });
+});

--- a/packages/features/bookings/repositories/BookingSeatRepository.ts
+++ b/packages/features/bookings/repositories/BookingSeatRepository.ts
@@ -1,7 +1,12 @@
 import type { PrismaClient } from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
 
 export class BookingSeatRepository {
   constructor(private prismaClient: PrismaClient) {}
+
+  async create(data: Prisma.BookingSeatCreateArgs["data"]) {
+    return this.prismaClient.bookingSeat.create({ data });
+  }
 
   getByUidIncludeAttendee(uid: string) {
     return this.prismaClient.bookingSeat.findUnique({

--- a/packages/features/credentials/repositories/CredentialRepository.integration-test.ts
+++ b/packages/features/credentials/repositories/CredentialRepository.integration-test.ts
@@ -60,4 +60,25 @@ describe("CredentialRepository.findPaymentAppCredentials (integration)", () => {
       repository.findPaymentAppCredentials({ credentialId: secondaryPaymentCredentialId, userId })
     ).resolves.toEqual([expect.objectContaining({ key: { account: "secondary" } })]);
   });
+
+  it("prevents IDOR: returns empty array when fetching another user's credentialId", async () => {
+  const userB = await prisma.user.create({
+    data: { 
+      email: `user-b-${crypto.randomUUID()}@test.cal.com`, 
+      username: `user-b-${crypto.randomUUID()}` 
+    },
+    select: { id: true },
+  });
+
+  try {
+    const crossUserCredentials = await repository.findPaymentAppCredentials({
+      credentialId: secondaryPaymentCredentialId,
+      userId: userB.id,
+    });
+
+    expect(crossUserCredentials).toEqual([]);
+  } finally {
+    await prisma.user.delete({ where: { id: userB.id } });
+  }
+});
 });

--- a/packages/features/credentials/repositories/CredentialRepository.integration-test.ts
+++ b/packages/features/credentials/repositories/CredentialRepository.integration-test.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@calcom/prisma";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CredentialRepository } from "./CredentialRepository";
+
+const repository = new CredentialRepository(prisma);
+
+describe("CredentialRepository.findPaymentAppCredentials (integration)", () => {
+  let userId: number;
+  let hasUser = false;
+  let secondaryPaymentCredentialId: number;
+  const appSlugs: string[] = [];
+
+  beforeEach(async () => {
+    const id = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: { email: `payment-credential-${id}@test.cal.com`, username: `payment-credential-${id}` },
+      select: { id: true },
+    });
+    userId = user.id;
+    hasUser = true;
+
+    const paymentAppSlug = `payment-app-${id}`;
+    const calendarAppSlug = `calendar-app-${id}`;
+    appSlugs.push(paymentAppSlug, calendarAppSlug);
+    await prisma.app.createMany({
+      data: [
+        { slug: paymentAppSlug, dirName: `payment-dir-${id}`, categories: ["payment"] },
+        { slug: calendarAppSlug, dirName: `calendar-dir-${id}`, categories: ["calendar"] },
+      ],
+    });
+    const [, secondaryPaymentCredential] = await Promise.all([
+      prisma.credential.create({
+        data: { type: "payment", key: { account: "primary" }, userId, appId: paymentAppSlug },
+      }),
+      prisma.credential.create({
+        data: { type: "payment", key: { account: "secondary" }, userId, appId: paymentAppSlug },
+        select: { id: true },
+      }),
+      prisma.credential.create({
+        data: { type: "calendar", key: { account: "calendar" }, userId, appId: calendarAppSlug },
+      }),
+    ]);
+    secondaryPaymentCredentialId = secondaryPaymentCredential.id;
+  });
+
+  afterEach(async () => {
+    if (hasUser) await prisma.user.delete({ where: { id: userId } });
+    hasUser = false;
+    await prisma.app.deleteMany({ where: { slug: { in: appSlugs.splice(0) } } });
+  });
+
+  it("excludes non-payment apps and honors an explicitly selected payment credential", async () => {
+    const paymentCredentials = await repository.findPaymentAppCredentials({ userId });
+    expect(paymentCredentials).toHaveLength(2);
+    expect(paymentCredentials.map((credential) => credential.key)).toEqual(
+      expect.arrayContaining([{ account: "primary" }, { account: "secondary" }])
+    );
+
+    await expect(
+      repository.findPaymentAppCredentials({ credentialId: secondaryPaymentCredentialId, userId })
+    ).resolves.toEqual([expect.objectContaining({ key: { account: "secondary" } })]);
+  });
+});

--- a/packages/features/credentials/repositories/CredentialRepository.ts
+++ b/packages/features/credentials/repositories/CredentialRepository.ts
@@ -37,7 +37,8 @@ export class CredentialRepository {
   }) {
     return this.prismaClient.credential.findMany({
       where: {
-        ...(credentialId ? { id: credentialId } : { userId }),
+        userId,
+        ...(credentialId && { id: credentialId }),
         app: { categories: { hasSome: ["payment"] } },
       },
       select: {

--- a/packages/features/credentials/repositories/CredentialRepository.ts
+++ b/packages/features/credentials/repositories/CredentialRepository.ts
@@ -28,6 +28,26 @@ type CredentialUpdateInput = {
 export class CredentialRepository {
   constructor(private prismaClient: PrismaClient) {}
 
+  async findPaymentAppCredentials({
+    credentialId,
+    userId,
+  }: {
+    credentialId?: number | null;
+    userId: number;
+  }) {
+    return this.prismaClient.credential.findMany({
+      where: {
+        ...(credentialId ? { id: credentialId } : { userId }),
+        app: { categories: { hasSome: ["payment"] } },
+      },
+      select: {
+        key: true,
+        appId: true,
+        app: { select: { categories: true, dirName: true } },
+      },
+    });
+  }
+
   async findByCredentialId(id: number) {
     return this.prismaClient.credential.findUnique({
       where: { id },

--- a/packages/features/di/tokens.ts
+++ b/packages/features/di/tokens.ts
@@ -23,6 +23,8 @@ export const DI_TOKENS = {
   USER_REPOSITORY_MODULE: Symbol("UserRepositoryModule"),
   BOOKING_REPOSITORY: Symbol("BookingRepository"),
   BOOKING_REPOSITORY_MODULE: Symbol("BookingRepositoryModule"),
+  BOOKING_SEAT_REPOSITORY: Symbol("BookingSeatRepository"),
+  BOOKING_SEAT_REPOSITORY_MODULE: Symbol("BookingSeatRepositoryModule"),
   BOOKING_ACCESS_SERVICE: Symbol("BookingAccessService"),
   BOOKING_ACCESS_SERVICE_MODULE: Symbol("BookingAccessServiceModule"),
   EVENT_TYPE_REPOSITORY: Symbol("EventTypeRepository"),

--- a/packages/features/profile/repositories/ProfileRepository.ts
+++ b/packages/features/profile/repositories/ProfileRepository.ts
@@ -1029,6 +1029,17 @@ export class ProfileRepository implements IProfileRepository {
       select: profileSelect,
     });
   }
+
+  async findOrganizationProfileByUserId({ userId }: { userId: number }) {
+    return this.prismaClient.profile.findFirst({
+      where: { userId },
+      select: {
+        organizationId: true,
+        username: true,
+        organization: { select: { hideBranding: true } },
+      },
+    });
+  }
 }
 
 export const normalizeProfile = <


### PR DESCRIPTION
## What does this PR do?

This PR removes the direct Prisma dependency from RegularBookingService by injecting repositories instead as well as resolves the TODO.

i have :
- Added repository backed access for booking, booking seat, profile, and credential operations.
- Added DI registration for BookingSeatRepository.
- Moved direct database queries and updates from the service into repository methods.


## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works
