### PR TITLE
fix: use dynamic data-testid for VerticalTabItem info paragraph

### DIFF
--- a/packages/ui/components/navigation/tabs/VerticalTabItem.tsx
+++ b/packages/ui/components/navigation/tabs/VerticalTabItem.tsx
@@ -54,7 +54,10 @@ const VerticalTabItem = ({
           <Link
             onClick={(e) => {
               if (props.trackingMetadata) {
-                posthog.capture("settings_sidebar_button_clicked", props.trackingMetadata);
+                posthog.capture(
+                  "settings_sidebar_button_clicked",
+                  props.trackingMetadata,
+                );
               }
               if (props.onClick) {
                 e.preventDefault();
@@ -68,14 +71,16 @@ const VerticalTabItem = ({
             aria-disabled={props.disabled ? "true" : undefined}
             target={props.isExternalLink ? "_blank" : "_self"}
             className={classNames(
-              props.textClassNames || "text-default text-sm font-medium leading-none",
+              props.textClassNames ||
+                "text-default text-sm font-medium leading-none",
               "hover:bg-subtle [&[aria-current='page']]:bg-subtle [&[aria-current='page']]:text-emphasis group-hover:text-default group flex w-full flex-row items-center rounded-md p-2 transition ",
               props.disabled && "pointer-events-none opacity-30!",
               (isChild || !props.icon) && "ml-7",
-              props.className
+              props.className,
             )}
             data-testid={`vertical-tab-${props["data-testid"]}`}
-            aria-current={isCurrent ? "page" : undefined}>
+            aria-current={isCurrent ? "page" : undefined}
+          >
             {props.icon && (
               <Icon
                 name={props.icon}
@@ -86,11 +91,19 @@ const VerticalTabItem = ({
             <div className="h-fit min-w-0 flex-1">
               <span className="flex items-center gap-2">
                 {t(name)}
-                {props.isExternalLink ? <Icon name="external-link" data-testid="external-link" /> : null}
+                {props.isExternalLink ? (
+                  <Icon name="external-link" data-testid="external-link" />
+                ) : null}
               </span>
               {info && (
-                // TODO: I don't think having apps-info as a data-test-id is right here as this is meant to be dumb component.
-                <p data-testid="apps-info" className="mt-1 text-xs font-normal">
+                <p
+                  data-testid={
+                    props["data-testid"]
+                      ? `${props["data-testid"]}-info`
+                      : "vertical-tab-info"
+                  }
+                  className="mt-1 text-xs font-normal"
+                >
                   {info}
                 </p>
               )}

--- a/packages/ui/components/navigation/tabs/navigation.test.tsx
+++ b/packages/ui/components/navigation/tabs/navigation.test.tsx
@@ -148,7 +148,7 @@ describe("Navigation Components", () => {
         }
 
         if (tab.info) {
-          const infoElement = screen.getByTestId("apps-info");
+          const infoElement = screen.getByTestId(`${tab["data-testid"]}-info`);
           expect(infoElement).toBeInTheDocument();
           expect(infoElement).toHaveTextContent(tab.info);
         }


### PR DESCRIPTION
## Summary
Fixes the hardcoded `data-testid="apps-info"` in `VerticalTabItem` which 
made the component non-reusable and semantically incorrect.

## Problem
The `VerticalTabItem` component had a hardcoded `data-testid="apps-info"` 
on the info paragraph, which:
- Couples a generic reusable component to a specific use case ("apps")
- Makes it impossible to target the correct element in tests when 
  multiple `VerticalTabItem` components with `info` are rendered

## Fix
- Use the component's own `data-testid` prop to generate a dynamic test ID: 
  `${data-testid}-info`
- Falls back to `"vertical-tab-info"` when no `data-testid` is provided
- Removed the TODO comment that flagged this issue
- Updated the test in `navigation.test.tsx` to use the new dynamic test ID

## Files Changed
- `packages/ui/components/navigation/tabs/VerticalTabItem.tsx`
- `packages/ui/components/navigation/tabs/navigation.test.tsx`
