### PR TITLE
fix(api): specify default false for CalVideoSettings boolean fields

### DIFF
--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -8357,11 +8357,13 @@
         "properties": {
           "disableRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to record the meeting"
+            "description": "If true, the organizer will not be able to record the meeting",
+            "default": false
           },
           "disableRecordingForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to record the meeting"
+            "description": "If true, the guests will not be able to record the meeting",
+            "default": false
           },
           "redirectUrlOnExit": {
             "type": "object",
@@ -8369,19 +8371,23 @@
           },
           "enableAutomaticRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, enables the automatic recording for the event when organizer joins the call"
+            "description": "If true, enables the automatic recording for the event when organizer joins the call",
+            "default": false
           },
           "enableAutomaticTranscription": {
             "type": "boolean",
-            "description": "If true, enables the automatic transcription for the event whenever someone joins the call"
+            "description": "If true, enables the automatic transcription for the event whenever someone joins the call",
+            "default": false
           },
           "disableTranscriptionForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to receive transcription of the meeting"
+            "description": "If true, the guests will not be able to receive transcription of the meeting",
+            "default": false
           },
           "disableTranscriptionForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to receive transcription of the meeting"
+            "description": "If true, the organizer will not be able to receive transcription of the meeting",
+            "default": false
           },
           "sendTranscriptionEmails": {
             "type": "boolean",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
@@ -141,6 +141,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForOrganizer?: boolean;
 
@@ -148,6 +149,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForGuests?: boolean;
 
@@ -162,6 +164,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic recording for the event when organizer joins the call",
+    default: false,
   })
   enableAutomaticRecordingForOrganizer?: boolean;
 
@@ -169,6 +172,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic transcription for the event whenever someone joins the call",
+    default: false,
   })
   enableAutomaticTranscription?: boolean;
 
@@ -176,6 +180,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForGuests?: boolean;
 
@@ -183,6 +188,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForOrganizer?: boolean;
 


### PR DESCRIPTION
## What does this PR do?

Resolves #30086 by adding `default: false` to the 6 optional boolean properties in the `CalVideoSettings` DTO and synchronizing the committed OpenAPI spec.

- Adds `default: false` to `@DocsPropertyOptional` decorators in `packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts` for:
  - `disableRecordingForOrganizer`
  - `disableRecordingForGuests`
  - `enableAutomaticRecordingForOrganizer`
  - `enableAutomaticTranscription`
  - `disableTranscriptionForGuests`
  - `disableTranscriptionForOrganizer`
- Aligns `docs/api-reference/v2/openapi.json` so the committed schema reflects the server-side `@default(false)` Prisma storage behavior.
- Preserves optional input semantics for backward compatibility.

- Fixes #30086

## Visual Demo (For contributors especially)

N/A (Schema and API documentation alignment only; no frontend UI changes)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Run `yarn turbo run build --filter=@calcom/platform-types` to verify type checking and build pass.
2. Inspect `docs/api-reference/v2/openapi.json` under `components.schemas.CalVideoSettings` to verify that the 6 boolean properties contain `"default": false`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings
- [x] My PR is small (<500 lines and <10 files)