### PR TITLE
fix(trpc): use transaction client tx for tempOrgRedirect and team in updateUser (fixes #30085)

### DIFF
--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -86,7 +86,7 @@ export const userAdminRouter = router({
 
           // Update all of this users tempOrgRedirectUrls
           if (requestedUser.username && profile.organizationId) {
-            const data = await prisma.team.findUnique({
+            const data = await tx.team.findUnique({
               where: {
                 id: profile.organizationId,
               },
@@ -104,7 +104,7 @@ export const userAdminRouter = router({
 
             const toUrl = `${orgUrlPrefix}/${input.username}`;
 
-            await prisma.tempOrgRedirect.updateMany({
+            await tx.tempOrgRedirect.updateMany({
               where: {
                 type: RedirectType.User,
                 from: requestedUser.username, // Old username


### PR DESCRIPTION
## Summary & Problem Statement
- Fixes #30085:  previously performed  and  on the outer  client inside an interactive  block.
- When executed on the outer  client, the redirect rewrite committed immediately on a separate connection outside the transaction. If the transaction was rolled back (e.g. timeout , deadlock, or connection loss), the user rename was rolled back while the redirect remained pointed at the uncommitted new username URL, leaving orphaned redirects.

## Changes Made
- Updated :
  - Changed  to 
  - Changed  to 

## Verification
- Both queries now execute within the transactional boundary (), ensuring complete ACID atomicity and rollback safety during user renames.
