### PR TITLE
fix(v2-api): search across all associated booking room references for transcripts/recordings (fixes #30091)

### DIFF
--- a/apps/api/v2/src/platform/bookings/2024-08-13/services/cal-video.service.ts
+++ b/apps/api/v2/src/platform/bookings/2024-08-13/services/cal-video.service.ts
@@ -18,11 +18,11 @@ export class CalVideoService {
     private readonly calVideoOutputService: CalVideoOutputService
   ) {}
 
-  private getVideoSessionsRoomName(references?: Array<{ type: string; meetingId?: string | null }>) {
-    return (
-      references?.filter((reference) => reference.type === CAL_VIDEO_TYPE)?.pop()?.meetingId ??
-      undefined
-    );
+  private getVideoSessionsRoomNames(references?: Array<{ type: string; meetingId?: string | null }>): string[] {
+    const names = references
+      ?.filter((reference) => reference.type === CAL_VIDEO_TYPE && Boolean(reference.meetingId))
+      .map((reference) => reference.meetingId as string) ?? [];
+    return [...new Set(names)];
   }
 
   async getRecordings(bookingUid: string) {
@@ -31,42 +31,49 @@ export class CalVideoService {
       throw new NotFoundException(`Booking with uid=${bookingUid} was not found in the database`);
     }
 
-    const roomName = this.getVideoSessionsRoomName(booking.references);
-    if (!roomName) {
+    const roomNames = this.getVideoSessionsRoomNames(booking.references);
+    if (roomNames.length === 0) {
       throw new NotFoundException(`No Cal Video reference found with booking uid ${bookingUid}`);
     }
 
-    const recordings = await getRecordingsOfCalVideoByRoomName(roomName);
+    const allRecordingsNested = await Promise.all(
+      roomNames.map(async (roomName) => {
+        const recordings = await getRecordingsOfCalVideoByRoomName(roomName).catch((err: Error) => {
+          this.logger.warn(`Failed to fetch recordings for room ${roomName}: ${err.message}`);
+          return null;
+        });
 
-    if (!recordings || !("data" in recordings)) return [];
+        if (!recordings || !("data" in recordings)) return [];
 
-    const recordingWithDownloadLink = recordings.data.map((recording) => {
-      return getDownloadLinkOfCalVideoByRecordingId(recording.id)
-        .then((res: { download_link: string } | undefined) => ({
-          id: recording.id,
-          roomName: recording.room_name,
-          startTs: recording.start_ts,
-          status: recording.status,
-          maxParticipants: recording.max_participants,
-          duration: recording.duration,
-          shareToken: recording.share_token,
-          downloadLink: res?.download_link,
-        }))
-        .catch((err: Error) => ({
-          id: recording.id,
-          roomName: recording.room_name,
-          startTs: recording.start_ts,
-          status: recording.status,
-          maxParticipants: recording.max_participants,
-          duration: recording.duration,
-          shareToken: recording.share_token,
-          downloadLink: null,
-          error: err.message,
-        }));
-    });
-    const allRecordingsWithDownloadLink = await Promise.all(recordingWithDownloadLink);
+        const recordingWithDownloadLink = recordings.data.map((recording) => {
+          return getDownloadLinkOfCalVideoByRecordingId(recording.id)
+            .then((res: { download_link: string } | undefined) => ({
+              id: recording.id,
+              roomName: recording.room_name,
+              startTs: recording.start_ts,
+              status: recording.status,
+              maxParticipants: recording.max_participants,
+              duration: recording.duration,
+              shareToken: recording.share_token,
+              downloadLink: res?.download_link,
+            }))
+            .catch((err: Error) => ({
+              id: recording.id,
+              roomName: recording.room_name,
+              startTs: recording.start_ts,
+              status: recording.status,
+              maxParticipants: recording.max_participants,
+              duration: recording.duration,
+              shareToken: recording.share_token,
+              downloadLink: null,
+              error: err.message,
+            }));
+        });
+        return Promise.all(recordingWithDownloadLink);
+      })
+    );
 
-    return allRecordingsWithDownloadLink;
+    return allRecordingsNested.flat();
   }
 
   async getTranscripts(bookingUid: string) {
@@ -75,14 +82,21 @@ export class CalVideoService {
       throw new NotFoundException(`Booking with uid=${bookingUid} was not found in the database`);
     }
 
-    const roomName = this.getVideoSessionsRoomName(booking.references);
-    if (!roomName) {
+    const roomNames = this.getVideoSessionsRoomNames(booking.references);
+    if (roomNames.length === 0) {
       throw new NotFoundException(`No Cal Video reference found with booking uid ${bookingUid}`);
     }
 
-    const transcripts = await getAllTranscriptsAccessLinkFromRoomName(roomName);
+    const transcriptLists = await Promise.all(
+      roomNames.map((roomName) =>
+        getAllTranscriptsAccessLinkFromRoomName(roomName).catch((err: Error) => {
+          this.logger.warn(`Failed to fetch transcripts for room ${roomName}: ${err.message}`);
+          return [];
+        })
+      )
+    );
 
-    return transcripts;
+    return transcriptLists.flat();
   }
 
   async getVideoSessions(bookingUid: string) {
@@ -91,12 +105,21 @@ export class CalVideoService {
       throw new NotFoundException(`Booking with uid=${bookingUid} was not found in the database`);
     }
 
-    const roomName = this.getVideoSessionsRoomName(booking.references);
-    if (!roomName) {
+    const roomNames = this.getVideoSessionsRoomNames(booking.references);
+    if (roomNames.length === 0) {
       throw new NotFoundException(`No Cal Video reference found with booking uid ${bookingUid}`);
     }
 
-    const sessions = await getCalVideoMeetingSessionsByRoomName(roomName);
-    return this.calVideoOutputService.getOutputVideoSessions(sessions.data);
+    const sessionsNested = await Promise.all(
+      roomNames.map(async (roomName) => {
+        const sessions = await getCalVideoMeetingSessionsByRoomName(roomName).catch((err: Error) => {
+          this.logger.warn(`Failed to fetch video sessions for room ${roomName}: ${err.message}`);
+          return { data: [] };
+        });
+        return sessions?.data ?? [];
+      })
+    );
+
+    return this.calVideoOutputService.getOutputVideoSessions(sessionsNested.flat());
   }
 }


### PR DESCRIPTION
## Summary & Problem
- Fixes #30091: After a booking is reassigned to another host, `GET /v2/bookings/{uid}/transcripts`, `recordings`, and `conferencing-sessions` return empty `data: []` arrays even though recordings and transcripts exist in Daily for the original meeting room.
- **Root Cause**: `getVideoSessionsRoomName` previously called `.pop()?.meetingId`, which only selected the newest room reference created during reassignment, ignoring earlier rooms where the conference session actually took place.

## Changes Made
- Updated `CalVideoService` in `apps/api/v2/src/platform/bookings/2024-08-13/services/cal-video.service.ts`:
  - Replaced single-room `.pop()` lookup with `getVideoSessionsRoomNames()` that gathers all distinct `CAL_VIDEO_TYPE` meeting IDs associated with the booking's references.
  - In `getRecordings()`, `getTranscripts()`, and `getVideoSessions()`, query across all associated room references and combine the results into a flat response.
  - Added safe error catches and logging so individual Daily room lookup failures do not fail the entire endpoint.
