### PR TITLE
fix(openapi): document default false for CalVideoSettings boolean fields (#30086)

### DIFF
--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -8357,11 +8357,13 @@
         "properties": {
           "disableRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to record the meeting"
+            "description": "If true, the organizer will not be able to record the meeting",
+            "default": false
           },
           "disableRecordingForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to record the meeting"
+            "description": "If true, the guests will not be able to record the meeting",
+            "default": false
           },
           "redirectUrlOnExit": {
             "type": "object",
@@ -8369,19 +8371,23 @@
           },
           "enableAutomaticRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, enables the automatic recording for the event when organizer joins the call"
+            "description": "If true, enables the automatic recording for the event when organizer joins the call",
+            "default": false
           },
           "enableAutomaticTranscription": {
             "type": "boolean",
-            "description": "If true, enables the automatic transcription for the event whenever someone joins the call"
+            "description": "If true, enables the automatic transcription for the event whenever someone joins the call",
+            "default": false
           },
           "disableTranscriptionForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to receive transcription of the meeting"
+            "description": "If true, the guests will not be able to receive transcription of the meeting",
+            "default": false
           },
           "disableTranscriptionForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to receive transcription of the meeting"
+            "description": "If true, the organizer will not be able to receive transcription of the meeting",
+            "default": false
           },
           "sendTranscriptionEmails": {
             "type": "boolean",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
@@ -22,7 +22,6 @@ import {
   Min,
   ValidateNested,
 } from "class-validator";
-
 import { RequiresAtLeastOnePropertyWhenNotDisabled } from "../../../utils/RequiresOneOfPropertiesWhenNotDisabled";
 import { BookerActiveBookingsLimit_2024_06_14 } from "./booker-active-booking-limit.input";
 import { BookerLayouts_2024_06_14 } from "./booker-layouts.input";
@@ -141,6 +140,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForOrganizer?: boolean;
 
@@ -148,6 +148,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForGuests?: boolean;
 
@@ -162,6 +163,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic recording for the event when organizer joins the call",
+    default: false,
   })
   enableAutomaticRecordingForOrganizer?: boolean;
 
@@ -169,6 +171,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic transcription for the event whenever someone joins the call",
+    default: false,
   })
   enableAutomaticTranscription?: boolean;
 
@@ -176,6 +179,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForGuests?: boolean;
 
@@ -183,6 +187,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForOrganizer?: boolean;
 


### PR DESCRIPTION
## Description

In Prisma (`packages/prisma/schema.prisma`), `CalVideoSettings` defines boolean fields as non-nullable with `@default(false)`. However, in the committed OpenAPI spec and input DTOs, these properties were marked optional without specifying their default value.

This PR documents `default: false` in `@DocsPropertyOptional` and the committed v2 OpenAPI spec (`docs/api-reference/v2/openapi.json`) for the 6 `CalVideoSettings` boolean fields:
- `disableRecordingForOrganizer`
- `disableRecordingForGuests`
- `enableAutomaticRecordingForOrganizer`
- `enableAutomaticTranscription`
- `disableTranscriptionForGuests`
- `disableTranscriptionForOrganizer`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues

fixes: #30086