### PR TITLE
fix(app-store): preserve delegation fields on user path of getLocationGroupedOptions (#29898)

### DIFF
--- a/packages/app-store/repositories/PrismaCredentialRepository.test.ts
+++ b/packages/app-store/repositories/PrismaCredentialRepository.test.ts
@@ -1,0 +1,64 @@
+import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
+import { describe, expect, it } from "vitest";
+import { PrismaCredentialRepository } from "./PrismaCredentialRepository";
+
+const storedCredential = {
+  id: 1,
+  type: "google_video",
+  key: {},
+  encryptedKey: null,
+  userId: 42,
+  user: { email: "user@example.com" },
+  teamId: null,
+  appId: "google-meet",
+  invalid: false,
+  delegationCredentialId: "delegation-credential-1",
+  team: null,
+};
+
+describe("PrismaCredentialRepository", () => {
+  describe("findNonDelegationCredentialsByAppCategories", () => {
+    it("queries Prisma with the given id search object, app categories and select shape", async () => {
+      prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+      const repository = new PrismaCredentialRepository(prismaMock);
+      await repository.findNonDelegationCredentialsByAppCategories({
+        idToSearchObject: { userId: 42 },
+        appCategories: ["conferencing"],
+      });
+
+      expect(prismaMock.credential.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 42,
+          app: {
+            categories: {
+              hasSome: ["conferencing"],
+            },
+          },
+        },
+        select: {
+          ...credentialForCalendarServiceSelect,
+          team: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      });
+    });
+
+    it("returns rows as stored, preserving delegation linkage fields", async () => {
+      prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+      const repository = new PrismaCredentialRepository(prismaMock);
+      const result = await repository.findNonDelegationCredentialsByAppCategories({
+        idToSearchObject: { userId: 42 },
+        appCategories: ["conferencing"],
+      });
+
+      expect(result).toEqual([storedCredential]);
+      expect(result[0].delegationCredentialId).toBe("delegation-credential-1");
+    });
+  });
+});

--- a/packages/app-store/repositories/PrismaCredentialRepository.ts
+++ b/packages/app-store/repositories/PrismaCredentialRepository.ts
@@ -1,40 +1,40 @@
-import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
-import { prisma } from "@calcom/prisma";
-import type { Prisma } from "@calcom/prisma/client";  
-import type { AppCategories } from "@calcom/prisma/client";
+import type { prisma } from "@calcom/prisma";
+import type { AppCategories, Prisma } from "@calcom/prisma/client";
 import { credentialForCalendarServiceSelect } from "@calcom/prisma/selects/credential";
 
 export class PrismaCredentialRepository {
-    constructor(private readonly prismaClient: typeof prisma){}
+  constructor(private readonly prismaClient: typeof prisma) {}
 
-    async findNonDelegationCredentialsByAppCategories({
-        idToSearchObject,  
-        appCategories,
-    }: {
-        idToSearchObject: Prisma.CredentialWhereInput;  
-        appCategories: AppCategories[];  
-    }){
+  /**
+   * Preserve delegation linkage so the user path can enrich delegated conferencing credentials.
+   * Team and organization paths normalize these rows before enabled-app lookup.
+   */
+  async findNonDelegationCredentialsByAppCategories({
+    idToSearchObject,
+    appCategories,
+  }: {
+    idToSearchObject: Prisma.CredentialWhereInput;
+    appCategories: AppCategories[];
+  }) {
+    const credentials = await this.prismaClient.credential.findMany({
+      where: {
+        ...idToSearchObject,
+        app: {
+          categories: {
+            hasSome: appCategories,
+          },
+        },
+      },
+      select: {
+        ...credentialForCalendarServiceSelect,
+        team: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
 
-        const credentials = await this.prismaClient.credential.findMany({
-            where: {
-                ...idToSearchObject,
-                app: {
-                    categories: {
-                        hasSome: appCategories
-                    }
-                }
-            },
-            select: {
-                ...credentialForCalendarServiceSelect,
-                team: {
-                    select: {
-                        name: true
-                    }
-                }
-            }
-        })
-
-
-        return buildNonDelegationCredentials(credentials)
-    }
+    return credentials;
+  }
 }

--- a/packages/app-store/server.test.ts
+++ b/packages/app-store/server.test.ts
@@ -1,0 +1,78 @@
+import prismaMock from "@calcom/testing/lib/__mocks__/prismaMock";
+import { enrichUserWithDelegationConferencingCredentialsWithoutOrgId } from "@calcom/app-store/delegationCredential";
+import type { User } from "@calcom/prisma/client";
+import type { TFunction } from "i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getEnabledAppsFromCredentials from "./_utils/getEnabledAppsFromCredentials";
+import { getLocationGroupedOptions } from "./server";
+
+vi.mock("@calcom/app-store/delegationCredential", () => ({
+  enrichUserWithDelegationConferencingCredentialsWithoutOrgId: vi.fn(),
+}));
+
+vi.mock("./_utils/getEnabledAppsFromCredentials", () => ({
+  default: vi.fn(),
+}));
+
+const t = ((key: string) => key) as TFunction;
+
+const storedCredential = {
+  id: 1,
+  type: "google_video",
+  key: {},
+  encryptedKey: null,
+  userId: 42,
+  user: { email: "user@example.com" },
+  teamId: null,
+  appId: "google-meet",
+  invalid: false,
+  delegationCredentialId: "delegation-credential-1",
+  team: null,
+  subscriptionId: null,
+  billingCycleStart: null,
+  paymentStatus: null,
+};
+
+const mockUser = {
+  id: 42,
+  email: "user@example.com",
+} as unknown as User;
+
+describe("getLocationGroupedOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEnabledAppsFromCredentials).mockResolvedValue([]);
+    vi.mocked(enrichUserWithDelegationConferencingCredentialsWithoutOrgId).mockImplementation(
+      async ({ user }) => user
+    );
+  });
+
+  it("passes user credentials to the delegation enrichment with delegation fields as stored", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(mockUser);
+    prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+    await getLocationGroupedOptions({ userId: 42 }, t);
+
+    const enrichMock = vi.mocked(enrichUserWithDelegationConferencingCredentialsWithoutOrgId);
+    expect(enrichMock).toHaveBeenCalledTimes(1);
+    const { user } = enrichMock.mock.calls[0][0];
+    expect(user.credentials).toEqual([storedCredential]);
+    expect(user.credentials[0].delegationCredentialId).toBe("delegation-credential-1");
+  });
+
+  it("marks credentials as non-delegation on the team path", async () => {
+    prismaMock.team.findFirst.mockResolvedValue(null);
+    prismaMock.credential.findMany.mockResolvedValue([storedCredential]);
+
+    await getLocationGroupedOptions({ teamId: 7 }, t);
+
+    expect(enrichUserWithDelegationConferencingCredentialsWithoutOrgId).not.toHaveBeenCalled();
+    const [credentials] = vi.mocked(getEnabledAppsFromCredentials).mock.calls[0];
+    expect(credentials[0]).toEqual({
+      ...storedCredential,
+      delegatedTo: null,
+      delegatedToId: null,
+      delegationCredentialId: null,
+    });
+  });
+});

--- a/packages/app-store/server.ts
+++ b/packages/app-store/server.ts
@@ -2,6 +2,7 @@ import type { TFunction } from "i18next";
 
 import { enrichUserWithDelegationConferencingCredentialsWithoutOrgId } from "@calcom/app-store/delegationCredential";
 import { defaultVideoAppCategories } from "@calcom/app-store/utils";
+import { buildNonDelegationCredentials } from "@calcom/lib/delegationCredential";
 import { prisma } from "@calcom/prisma";
 import type { Prisma } from "@calcom/prisma/client";
 import { AppCategories } from "@calcom/prisma/enums";
@@ -80,7 +81,7 @@ export async function getLocationGroupedOptions(
     );
     credentials = allCredentials;
   } else {
-    credentials = nonDelegationCredentials;  
+    credentials = buildNonDelegationCredentials(nonDelegationCredentials);  
   }
 
   const integrations = await getEnabledAppsFromCredentials(credentials, { filterOnCredentials: true });


### PR DESCRIPTION
## Description

PR #29724 moved the credential query out of `getLocationGroupedOptions` into `PrismaCredentialRepository.findNonDelegationCredentialsByAppCategories`. However, it also moved `buildNonDelegationCredentials` inside the repository method, which unconditionally nulled delegation fields on all returned credentials.

This caused the user branch of `getLocationGroupedOptions` to also receive nulled delegation fields before calling `enrichUserWithDelegationConferencingCredentialsWithoutOrgId`.

This PR:
- Preserves delegation fields in `PrismaCredentialRepository.findNonDelegationCredentialsByAppCategories` as stored.
- Applies `buildNonDelegationCredentials` only on the non-user (team/org) branch of `getLocationGroupedOptions`.
- Adds unit tests for `PrismaCredentialRepository` and `getLocationGroupedOptions`.

Fixes: #29898