### PR TITLE
fix(openapi): add default false to CalVideoSettings boolean fields

### DIFF
--- a/docs/api-reference/v2/openapi.json
+++ b/docs/api-reference/v2/openapi.json
@@ -8357,11 +8357,13 @@
         "properties": {
           "disableRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to record the meeting"
+            "description": "If true, the organizer will not be able to record the meeting",
+            "default": false
           },
           "disableRecordingForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to record the meeting"
+            "description": "If true, the guests will not be able to record the meeting",
+            "default": false
           },
           "redirectUrlOnExit": {
             "type": "object",
@@ -8369,19 +8371,23 @@
           },
           "enableAutomaticRecordingForOrganizer": {
             "type": "boolean",
-            "description": "If true, enables the automatic recording for the event when organizer joins the call"
+            "description": "If true, enables the automatic recording for the event when organizer joins the call",
+            "default": false
           },
           "enableAutomaticTranscription": {
             "type": "boolean",
-            "description": "If true, enables the automatic transcription for the event whenever someone joins the call"
+            "description": "If true, enables the automatic transcription for the event whenever someone joins the call",
+            "default": false
           },
           "disableTranscriptionForGuests": {
             "type": "boolean",
-            "description": "If true, the guests will not be able to receive transcription of the meeting"
+            "description": "If true, the guests will not be able to receive transcription of the meeting",
+            "default": false
           },
           "disableTranscriptionForOrganizer": {
             "type": "boolean",
-            "description": "If true, the organizer will not be able to receive transcription of the meeting"
+            "description": "If true, the organizer will not be able to receive transcription of the meeting",
+            "default": false
           },
           "sendTranscriptionEmails": {
             "type": "boolean",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts
@@ -141,6 +141,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForOrganizer?: boolean;
 
@@ -148,6 +149,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to record the meeting",
+    default: false,
   })
   disableRecordingForGuests?: boolean;
 
@@ -162,6 +164,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic recording for the event when organizer joins the call",
+    default: false,
   })
   enableAutomaticRecordingForOrganizer?: boolean;
 
@@ -169,6 +172,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, enables the automatic transcription for the event whenever someone joins the call",
+    default: false,
   })
   enableAutomaticTranscription?: boolean;
 
@@ -176,6 +180,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the guests will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForGuests?: boolean;
 
@@ -183,6 +188,7 @@ export class CalVideoSettings {
   @IsBoolean()
   @DocsPropertyOptional({
     description: "If true, the organizer will not be able to receive transcription of the meeting",
+    default: false,
   })
   disableTranscriptionForOrganizer?: boolean;
 


### PR DESCRIPTION
## Summary
Fixes #30086

Aligns `CalVideoSettings` OpenAPI documentation with the Prisma schema defaults.
The Prisma `CalVideoSettings` model defines boolean properties (`disableRecordingForOrganizer`, `disableRecordingForGuests`, `enableAutomaticRecordingForOrganizer`, `enableAutomaticTranscription`, `disableTranscriptionForGuests`, and `disableTranscriptionForOrganizer`) with `@default(false)`.

This PR:
- Adds `default: false` to the corresponding `@DocsPropertyOptional()` decorators in `CalVideoSettings` (`packages/platform/types/event-types/event-types_2024_06_14/inputs/create-event-type.input.ts`).
- Updates `docs/api-reference/v2/openapi.json` to reflect `default: false` for these properties under `CalVideoSettings`.

## How was this tested?
- Built `@calcom/platform-types` successfully via TypeScript compiler.
- Verified OpenAPI JSON schema diff against `packages/prisma/schema.prisma` definitions.