### PR TITLE
fix(trpc): execute tempOrgRedirect rewrite on tx inside updateUser transaction

### DIFF
--- a/packages/trpc/server/routers/viewer/users/_router.ts
+++ b/packages/trpc/server/routers/viewer/users/_router.ts
@@ -86,7 +86,7 @@ export const userAdminRouter = router({
 
           // Update all of this users tempOrgRedirectUrls
           if (requestedUser.username && profile.organizationId) {
-            const data = await prisma.team.findUnique({
+            const data = await tx.team.findUnique({
               where: {
                 id: profile.organizationId,
               },
@@ -104,7 +104,7 @@ export const userAdminRouter = router({
 
             const toUrl = `${orgUrlPrefix}/${input.username}`;
 
-            await prisma.tempOrgRedirect.updateMany({
+            await tx.tempOrgRedirect.updateMany({
               where: {
                 type: RedirectType.User,
                 from: requestedUser.username, // Old username


### PR DESCRIPTION
## Summary

Fixes #30085.

Ensures that `tempOrgRedirect.updateMany` and `team.findUnique` inside the `updateUser` mutation execute within the interactive transaction (`tx`) rather than escaping to the outer `prisma` client.

## Problem

In `packages/trpc/server/routers/viewer/users/_router.ts`, `updateUser` opens a Prisma interactive transaction:

```ts
const user = await prisma.$transaction(async (tx) => {
  const userInternal = await tx.user.update({ where: { id: requestedUser.id }, data: input });

  if (requestedUser.movedToProfileId && input.username) {
    const profile = await tx.profile.update({ ... });

    if (requestedUser.username && profile.organizationId) {
      ...
      await prisma.tempOrgRedirect.updateMany({ ... }); // <-- ran on outer prisma client
    }
  }
});
```

Because `prisma.tempOrgRedirect.updateMany` ran on the outer `prisma` client instead of `tx`, it executed and committed on a separate connection immediately. If the transaction failed to commit (timeout, connection interruption, or concurrency conflict), the user and profile renames rolled back, but the redirect rewrite persisted, leaving `TempOrgRedirect` rows pointing to a non-existent URL.

## Solution

Switch `prisma.tempOrgRedirect.updateMany` and `prisma.team.findUnique` to `tx.tempOrgRedirect.updateMany` and `tx.team.findUnique`. All operations now participate in the same atomic unit of work and roll back together if the transaction fails.

Closes #30085.
