### PR TITLE
fix(security): use constant-time webhook secret comparisons

### DIFF
--- a/apps/web/app/api/recorded-daily-video/route.ts
+++ b/apps/web/app/api/recorded-daily-video/route.ts
@@ -15,6 +15,7 @@ import {
   submitBatchProcessorTranscriptionJob,
 } from "@calcom/features/conferencing/lib/videoClient";
 import { WEBAPP_URL } from "@calcom/lib/constants";
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import { getTeamIdFromEventType } from "@calcom/lib/getTeamIdFromEventType";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
@@ -70,7 +71,7 @@ export async function postHandler(request: NextRequest) {
     const webhookTimestamp = headersList.get("x-webhook-timestamp");
     const computed_signature = computeSignature(hmacSecret, body, webhookTimestamp);
 
-    if (headersList.get("x-webhook-signature") !== computed_signature) {
+    if (!timingSafeEqualStrings(headersList.get("x-webhook-signature"), computed_signature)) {
       return NextResponse.json({ message: "Signature does not match" }, { status: 403 });
     }
   }

--- a/apps/web/app/api/webhook/app-credential/route.ts
+++ b/apps/web/app/api/webhook/app-credential/route.ts
@@ -6,7 +6,7 @@ import z from "zod";
 import { appStoreMetadata } from "@calcom/app-store/appStoreMetaData";
 import { CREDENTIAL_SYNC_SECRET, CREDENTIAL_SYNC_SECRET_HEADER_NAME } from "@calcom/lib/constants";
 import { APP_CREDENTIAL_SHARING_ENABLED } from "@calcom/lib/constants";
-import { symmetricDecrypt } from "@calcom/lib/crypto";
+import { symmetricDecrypt, timingSafeEqualStrings } from "@calcom/lib/crypto";
 import prisma from "@calcom/prisma";
 
 const appCredentialWebhookRequestBodySchema = z.object({
@@ -23,7 +23,7 @@ async function postHandler(request: NextRequest) {
   }
 
   const secretHeader = request.headers.get(CREDENTIAL_SYNC_SECRET_HEADER_NAME);
-  if (secretHeader !== CREDENTIAL_SYNC_SECRET) {
+  if (!timingSafeEqualStrings(secretHeader, CREDENTIAL_SYNC_SECRET)) {
     return NextResponse.json({ message: "Invalid credential sync secret" }, { status: 403 });
   }
 

--- a/packages/app-store/feishucalendar/api/events.ts
+++ b/packages/app-store/feishucalendar/api/events.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import logger from "@calcom/lib/logger";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
@@ -56,14 +57,20 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 
   // used for events handler binding in feishu open platform, see
   // https://open.larksuite.com/document/ukTMukTMukTM/uUTNz4SN1MjL1UzM?lang=en-US
-  if (req.body.type === "url_verification" && req.body.token === open_verification_token) {
+  if (
+    req.body.type === "url_verification" &&
+    timingSafeEqualStrings(req.body.token, open_verification_token)
+  ) {
     log.debug("update token", req.body);
     return res.status(200).json({ challenge: req.body.challenge });
   }
 
   // used for receiving app_ticket, see
   // https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/application-v6/event/app_ticket-events
-  if (req.body.event?.type === "app_ticket" && open_verification_token === req.body.token) {
+  if (
+    req.body.event?.type === "app_ticket" &&
+    timingSafeEqualStrings(open_verification_token, req.body.token)
+  ) {
     const {
       body: {
         event: { app_ticket: appTicket },

--- a/packages/app-store/hitpay/api/webhook.ts
+++ b/packages/app-store/hitpay/api/webhook.ts
@@ -5,6 +5,7 @@ import type z from "zod";
 import { handlePaymentSuccess } from "@calcom/app-store/_utils/payments/handlePaymentSuccess";
 import { distributedTracing } from "@calcom/lib/tracing/factory";
 import { IS_PRODUCTION } from "@calcom/lib/constants";
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import { HttpError as HttpCode } from "@calcom/lib/http-error";
 import { getServerErrorFromUnknown } from "@calcom/lib/server/getServerErrorFromUnknown";
 import prisma from "@calcom/prisma";
@@ -104,7 +105,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { saltKey } = keyObj;
     const signed = generateSignatureArray(saltKey, excluded as ExcludedWebhookReturn);
-    if (signed !== obj.hmac) {
+    if (!timingSafeEqualStrings(signed, obj.hmac)) {
       throw new HttpCode({ statusCode: 400, message: "Bad Request" });
     }
 

--- a/packages/app-store/larkcalendar/api/events.ts
+++ b/packages/app-store/larkcalendar/api/events.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import logger from "@calcom/lib/logger";
 import { defaultHandler } from "@calcom/lib/server/defaultHandler";
 import { defaultResponder } from "@calcom/lib/server/defaultResponder";
@@ -56,14 +57,20 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
 
   // used for events handler binding in lark open platform, see
   // https://open.larksuite.com/document/ukTMukTMukTM/uUTNz4SN1MjL1UzM?lang=en-US
-  if (req.body.type === "url_verification" && req.body.token === open_verification_token) {
+  if (
+    req.body.type === "url_verification" &&
+    timingSafeEqualStrings(req.body.token, open_verification_token)
+  ) {
     log.debug("update token", req.body);
     return res.status(200).json({ challenge: req.body.challenge });
   }
 
   // used for receiving app_ticket, see
   // https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/application-v6/event/app_ticket-events
-  if (req.body.event?.type === "app_ticket" && open_verification_token === req.body.token) {
+  if (
+    req.body.event?.type === "app_ticket" &&
+    timingSafeEqualStrings(open_verification_token, req.body.token)
+  ) {
     const {
       body: {
         event: { app_ticket: appTicket },

--- a/packages/features/calendar-subscription/adapters/GoogleCalendarSubscription.adapter.ts
+++ b/packages/features/calendar-subscription/adapters/GoogleCalendarSubscription.adapter.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from "uuid";
 import { CalendarAuth } from "@calcom/app-store/googlecalendar/lib/CalendarAuth";
 import dayjs from "@calcom/dayjs";
 import { CalendarCacheEventService } from "@calcom/features/calendar-subscription/lib/cache/CalendarCacheEventService";
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import logger from "@calcom/lib/logger";
 import type { SelectedCalendar } from "@calcom/prisma/client";
 
@@ -35,7 +36,7 @@ export class GoogleCalendarSubscriptionAdapter implements ICalendarSubscriptionP
       log.warn("GOOGLE_WEBHOOK_TOKEN not configured");
       return false;
     }
-    if (token !== this.GOOGLE_WEBHOOK_TOKEN) {
+    if (!timingSafeEqualStrings(token, this.GOOGLE_WEBHOOK_TOKEN)) {
       log.warn("Invalid webhook token");
       return false;
     }

--- a/packages/features/calendar-subscription/adapters/Office365CalendarSubscription.adapter.ts
+++ b/packages/features/calendar-subscription/adapters/Office365CalendarSubscription.adapter.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqualStrings } from "@calcom/lib/crypto";
 import logger from "@calcom/lib/logger";
 import type { SelectedCalendar } from "@calcom/prisma/client";
 
@@ -97,7 +98,7 @@ export class Office365CalendarSubscriptionAdapter implements ICalendarSubscripti
       log.warn("MICROSOFT_WEBHOOK_TOKEN missing");
       return false;
     }
-    if (clientState !== this.webhookToken) {
+    if (!timingSafeEqualStrings(clientState, this.webhookToken)) {
       log.warn("Invalid clientState");
       return false;
     }

--- a/packages/lib/crypto.test.ts
+++ b/packages/lib/crypto.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { symmetricDecrypt, symmetricEncrypt } from "./crypto";
+import { symmetricDecrypt, symmetricEncrypt, timingSafeEqualStrings } from "./crypto";
 
 describe("crypto", () => {
+  describe("timingSafeEqualStrings", () => {
+    it("compares equal strings", () => {
+      expect(timingSafeEqualStrings("secret", "secret")).toBe(true);
+    });
+
+    it("rejects different strings and lengths", () => {
+      expect(timingSafeEqualStrings("secret", "secrex")).toBe(false);
+      expect(timingSafeEqualStrings("secret", "secret-longer")).toBe(false);
+    });
+
+    it("rejects missing values without throwing", () => {
+      expect(timingSafeEqualStrings(null, "secret")).toBe(false);
+      expect(timingSafeEqualStrings("secret", undefined)).toBe(false);
+    });
+
+    it("supports empty strings", () => {
+      expect(timingSafeEqualStrings("", "")).toBe(true);
+      expect(timingSafeEqualStrings("", "secret")).toBe(false);
+    });
+  });
+
   const testKey = "12345678901234567890123456789012"; // 32 bytes key
   const testText = "Hello, World!";
 

--- a/packages/lib/crypto.ts
+++ b/packages/lib/crypto.ts
@@ -1,5 +1,24 @@
 import crypto from "node:crypto";
 
+export function timingSafeEqualStrings(
+  actual: string | null | undefined,
+  expected: string | null | undefined
+): boolean {
+  if (typeof actual !== "string" || typeof expected !== "string") return false;
+
+  const actualBuffer = Buffer.from(actual, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const length = Math.max(actualBuffer.length, expectedBuffer.length);
+  const paddedActual = Buffer.alloc(length);
+  const paddedExpected = Buffer.alloc(length);
+
+  actualBuffer.copy(paddedActual);
+  expectedBuffer.copy(paddedExpected);
+
+  const isEqual = crypto.timingSafeEqual(paddedActual, paddedExpected);
+  return actualBuffer.length === expectedBuffer.length && isEqual;
+}
+
 const ALGORITHM = "aes256";
 const INPUT_ENCODING = "utf8";
 const OUTPUT_ENCODING = "hex";


### PR DESCRIPTION
 ## What does this PR do?

  - Fixes #30100

  Replaces plain secret, token, and HMAC comparisons with a shared constant-time comparison helper based on
  `crypto.timingSafeEqual`.

  Updated HitPay, Google Calendar, credential-sync, Office 365, Daily Video, Feishu, and Lark webhook validation paths.
  Added tests for matching values, mismatches, length differences, missing values, and empty strings.

  ## Visual Demo (For contributors especially)

  Not applicable; this is a backend security fix.

  #### Video Demo (if applicable):

  Not applicable.

  #### Image Demo (if applicable):

  Not applicable.

  ## Mandatory Tasks (DO NOT REMOVE)

  - [x] I have self-reviewed the code.
  - [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A.
  - [x] I confirm automated tests are in place that prove my fix is effective.

  ## How should this be tested?

  Run:

  ```bash
  yarn biome check packages/lib/crypto.ts packages/lib/crypto.test.ts
  yarn vitest run packages/lib/crypto.test.ts
  yarn type-check:ci --force
```
  The test suite covers equal values, mismatched values, different lengths, missing values, and empty strings.

  ## Checklist

  - [x] I have read the contributing guide.
  - [x] My code follows the project style guidelines.
  - [x] I have not added unnecessary comments.
  - [ ] I have not checked if these changes generate no new warnings.
  - [x] My PR is under 500 lines and 10 files.


  The working tree is clean.