### PR TITLE
fix(i18n/pl): booking_submitted_subject says "confirmed" instead of "submitted"

### DIFF
--- a/packages/i18n/locales/pl/common.json
+++ b/packages/i18n/locales/pl/common.json
@@ -196,7 +196,7 @@
   "password_reset_instructions": "Jeśli nie poprosiłeś o to, możesz bezpiecznie zignorować ten e-mail, a Twoje hasło nie zostanie zmienione.",
   "event_awaiting_approval_subject": "Oczekiwanie na zatwierdzenie: {{title}} w {{date}}",
   "event_still_awaiting_approval": "Wydarzenie nadal oczekuje na Twoje zatwierdzenie",
-  "booking_submitted_subject": "Rezerwacja potwierdzona: {{title}} w {{date}}",
+  "booking_submitted_subject": "Rezerwacja złożona: {{title}} w {{date}}",
   "download_recording_subject": "Pobierz nagranie: {{title}} z {{date}}",
   "download_transcript_email_subject": "Pobierz transkrypcję: {{title}} z dnia {{date}}",
   "download_your_recording": "Pobierz nagranie",


### PR DESCRIPTION
## What

One string in the Polish locale. `booking_submitted_subject` translates *submitted* as *confirmed*.

```diff
- "booking_submitted_subject": "Rezerwacja potwierdzona: {{title}} w {{date}}"
+ "booking_submitted_subject": "Rezerwacja złożona: {{title}} w {{date}}"
```

`potwierdzona` means **confirmed**. `złożona` means **submitted / placed**.

## Why it matters

This is the subject line of the email an attendee receives when the event type has **Requires confirmation** enabled. The email body is translated correctly — `booking_submitted` is *"Twoja rezerwacja została wysłana"* ("your booking has been submitted"), followed by *"{{user}} nadal musi potwierdzić lub odrzucić rezerwację"* ("still needs to confirm or reject the booking").

So the subject tells the attendee the booking **is confirmed**, and the body immediately tells them it **is not**. On an opt-in event type, that is the first thing they read.

It only surfaces on event types with Requires confirmation, which is probably why it has gone unnoticed — without it, the pending state never occurs.

Spotted on a live Polish-language booking page while setting up an opt-in event type.

## Scope

One key, one file, no other locale touched.