### PR TITLE
fix(ui): resolve React 19 ref deprecation warning in Tooltip (#30110)

### DIFF
--- a/packages/ui/components/tooltip/Tooltip.tsx
+++ b/packages/ui/components/tooltip/Tooltip.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import classNames from "@calcom/ui/classNames";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import React from "react";
-
-import classNames from "@calcom/ui/classNames";
 
 export function Tooltip({
   children,
@@ -40,13 +39,17 @@ export function Tooltip({
     </TooltipPrimitive.Content>
   );
 
+  if (!content) return <>{children}</>;
+
+  const trigger = React.isValidElement(children) ? children : <span>{children}</span>;
+
   return (
     <TooltipPrimitive.Root
       delayDuration={delayDuration || 50}
       open={open}
       defaultOpen={defaultOpen}
       onOpenChange={onOpenChange}>
-      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Trigger asChild>{trigger}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>{Content}</TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
   );

--- a/packages/ui/components/tooltip/Tooltip.tsx
+++ b/packages/ui/components/tooltip/Tooltip.tsx
@@ -39,7 +39,7 @@ export function Tooltip({
     </TooltipPrimitive.Content>
   );
 
-  if (!content) return <>{children}</>;
+  if (content === undefined || content === null || content === "") return <>{children}</>;
 
   const trigger = React.isValidElement(children) ? children : <span>{children}</span>;
 


### PR DESCRIPTION
### Summary

Fixes React 19 deprecation warning (`Accessing element.ref was removed in React 19`) triggered by `packages/ui/components/tooltip/Tooltip.tsx` when rendering tooltips across shell navigation and triggers.

Closes #30110

### Key Changes
- Updated `packages/ui/components/tooltip/Tooltip.tsx` to handle trigger element children safely (`React.isValidElement`).
- Added early-return for explicit empty content (`undefined`, `null`, `""`) while preserving valid numeric content like `0`.

### Before / After Demo

#### Before (on `main`)
https://github.com/user-attachments/assets/0ebf6f26-b18b-40e4-8b0c-57a0de14823f

#### After (with fix)
https://github.com/user-attachments/assets/9af582b3-6d73-465e-be60-d09fed2bb45c

### Verification
- [x] Verified local dev server runtime (`yarn dev`).
- [x] Formatted with Biome (`yarn biome check --write`).
- [x] Ran monorepo type-check (`yarn type-check:ci --force`).
