### PR TITLE
fix(googlecalendar): stop the redundant "Updated invitation" on Google Meet bookings

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -284,10 +284,11 @@ class GoogleCalendarService implements Calendar {
           calendarId: selectedCalendar,
           requestBody: payload,
           conferenceDataVersion: 1,
-          // Notify guests here so the attendee receives a single, proper Google
-          // Calendar "Invitation". The follow-up patch that writes the Meet link
-          // is sent silently (sendUpdates: "none") to avoid a second email.
-          sendUpdates: "all",
+          // For Google Meet events, notify guests here so the attendee receives a
+          // single, proper "Invitation" (the follow-up patch that writes the Meet
+          // link is then sent silently). Non-Meet events keep their prior "none"
+          // so this change does not alter their notification behavior.
+          sendUpdates: calEvent.location === MeetLocationType ? "all" : "none",
         });
         event = eventResponse.data;
         if (event.recurrence) {

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -284,7 +284,10 @@ class GoogleCalendarService implements Calendar {
           calendarId: selectedCalendar,
           requestBody: payload,
           conferenceDataVersion: 1,
-          sendUpdates: "none",
+          // Notify guests here so the attendee receives a single, proper Google
+          // Calendar "Invitation". The follow-up patch that writes the Meet link
+          // is sent silently (sendUpdates: "none") to avoid a second email.
+          sendUpdates: "all",
         });
         event = eventResponse.data;
         if (event.recurrence) {
@@ -300,6 +303,10 @@ class GoogleCalendarService implements Calendar {
           // Update the same event but this time we know the hangout link
           calendarId: selectedCalendar,
           eventId: event.id || "",
+          // Silent update: the attendee was already notified by the insert
+          // above. Without this the patch defaults to notifying guests, which
+          // sends a redundant "Updated invitation" a few seconds after booking.
+          sendUpdates: "none",
           requestBody: {
             description: getRichDescription({
               ...calEvent,

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
@@ -521,7 +521,7 @@ describe("createEvent", () => {
           },
           "summary": "Test Meeting",
         },
-        "sendUpdates": "all",
+        "sendUpdates": "none",
       }
     `);
 
@@ -837,7 +837,7 @@ describe("createEvent", () => {
         language: { translate: (...args: any[]) => args[0], locale: "en" },
       },
       attendees: [],
-      location: "Test Location",
+      location: MeetLocationType,
       calendarDescription: "Test meeting description",
       destinationCalendar: [
         {
@@ -868,6 +868,9 @@ describe("createEvent", () => {
     // The follow-up Meet-link patch must be silent so the attendee does not
     // receive a second "Updated invitation" after the initial invite.
     expect(patchCall.sendUpdates).toBe("none");
+    // For a Meet event, the initial insert carries the single invitation.
+    const insertCall = eventsInsertMock.mock.calls[0][0];
+    expect(insertCall.sendUpdates).toBe("all");
 
     log.info("createEvent with hangoutLink patch test passed");
   });

--- a/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
+++ b/packages/app-store/googlecalendar/lib/__tests__/CalendarService.test.ts
@@ -521,7 +521,7 @@ describe("createEvent", () => {
           },
           "summary": "Test Meeting",
         },
-        "sendUpdates": "none",
+        "sendUpdates": "all",
       }
     `);
 
@@ -865,6 +865,9 @@ describe("createEvent", () => {
     expect(patchCall.eventId).toBe("mock-event-with-hangout");
     expect(patchCall.requestBody.location).toBe(mockHangoutLink);
     expect(patchCall.requestBody.description).toBeDefined();
+    // The follow-up Meet-link patch must be silent so the attendee does not
+    // receive a second "Updated invitation" after the initial invite.
+    expect(patchCall.sendUpdates).toBe("none");
 
     log.info("createEvent with hangoutLink patch test passed");
   });


### PR DESCRIPTION
## What / why

Fixes the redundant Google Calendar **"Updated invitation"** email sent to attendees a few seconds after every Google Meet booking.

Fixes #30112

### Root cause
In `createEvent` (`packages/app-store/googlecalendar/lib/CalendarService.ts`):
- `events.insert` runs with `sendUpdates: "none"` (silent) and requests a Meet (`conferenceDataVersion: 1`).
- The follow-up `events.patch` that writes the resulting Meet link into `description`/`location` **omitted `sendUpdates`**, so it notifies guests. Because the insert was silent, this patch is the attendee's first notification and Google labels it **"Updated invitation"**.

## The change (createEvent only)

- `events.insert` → `sendUpdates: "all"` so the attendee gets a single, proper **"Invitation"** on create. The event already carries the Meet `conferenceData` at insert time, so the invite includes the join link.
- follow-up `events.patch` → `sendUpdates: "none"` so the Meet-link write is silent.

Net result: **one** invitation, silent follow-up patch, no "Updated invitation".

### Why not simply silence the patch
The insert is already `sendUpdates: "none"` on `main`. Silencing the patch **alone** would make both writes silent and the attendee would receive **no** invitation. The notification must move to the insert.

### Why `updateEvent` is intentionally left unchanged
In `updateEvent`, `events.update` is already `sendUpdates: "none"` (the deprecated `sendNotifications: true` is overridden by `sendUpdates`), and its follow-up patch runs **only for Meet events** (`event.location === MeetLocationType`). So today a Meet reschedule already produces exactly one, correctly-labelled "Updated invitation" via the patch — the desired behaviour. Making `updateEvent` symmetric (`update: "all"` + `patch: "none"`) would start notifying **non-Meet** reschedules (currently silent) and risk extra notifications, so it is deliberately out of scope here.

## Tests

- Updated the create-event insert inline snapshot to expect `sendUpdates: "all"`.
- Added an assertion that the follow-up Meet-link patch is called with `sendUpdates: "none"`.

## Manual test plan

1. Google Meet event type, Google Calendar connected, book as an external attendee.
2. Attendee receives exactly **one** "Invitation" (with the Meet link) — no "Updated invitation".
3. Meet link works; event appears on both the attendee's and the host's calendars.
4. Reschedule once → one "Updated invitation" (behaviour unchanged).
