### PR TITLE
fix(whatsapp): validate canonical location URLs

### DIFF
--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -16,8 +16,8 @@
       "type": "integrations:whatsapp_video",
       "label": "WhatsApp",
       "linkType": "static",
-      "organizerInputPlaceholder": "https://wa.me/send?phone=1234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa.me\\/[a-zA-Z0-9]*"
+      "organizerInputPlaceholder": "https://wa.me/4712345678",
+      "urlRegExp": "^https?:\\/\\/(www\\.)?wa\\.me\\/[0-9]{7,15}$"
     }
   },
   "isAuth": false


### PR DESCRIPTION
## Summary

Fixes #30118.

- Update the WhatsApp location placeholder to the canonical `https://wa.me/<phone>` format.
- Validate only `http`/`https` WhatsApp short links with an optional `www` prefix and a 7–15 digit phone number.
- Escape the dot in `wa.me` and anchor the expression so malformed or trailing input is rejected.

## Validation

The updated expression was checked against canonical links, the old `/send?phone=` format, `+`-prefixed numbers, empty paths, alphabetic paths, malformed hosts, trailing path data, and phone numbers outside the 7–15 digit range.

No `/claim` command was added because #30118 is not currently marked as a funded bounty.