### PR TITLE
fix(payments): don't scale zero-decimal currency amounts on no-show fee display

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -3,6 +3,7 @@
 import { sdkActionManager } from "@calcom/embed-core/embed-iframe";
 import { isCancellationReasonRequired } from "@calcom/features/bookings/lib/cancellationReason";
 import { shouldChargeNoShowCancellationFee } from "@calcom/features/bookings/lib/payment/shouldChargeNoShowCancellationFee";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRefreshData } from "@calcom/lib/hooks/useRefreshData";
 import type { CancellationReasonRequirement } from "@calcom/prisma/enums";
@@ -252,7 +253,10 @@ export default function CancelBooking(props: Props) {
                   description={t("cancel_booking_acknowledge_no_show_fee", {
                     timeValue,
                     timeUnit,
-                    amount: booking.payment.amount / 100,
+                    amount: convertFromSmallestToPresentableCurrencyUnit(
+                      booking.payment.amount,
+                      booking.payment.currency
+                    ),
                     formatParams: { amount: { currency: booking.payment.currency } },
                   })}
                   onChange={(e) => setAcknowledgeCancellationNoShowFee(e.target.checked)}

--- a/apps/web/components/booking/__tests__/CancelBooking.cancellationFee.test.tsx
+++ b/apps/web/components/booking/__tests__/CancelBooking.cancellationFee.test.tsx
@@ -274,4 +274,43 @@ describe("CancelBooking Cancellation Fee Warning", () => {
 
     expect(screen.queryByText(/I acknowledge that cancelling within/)).not.toBeInTheDocument();
   });
+
+  it("should not scale the fee for zero-decimal currencies", () => {
+    vi.mocked(shouldChargeModule.shouldChargeNoShowCancellationFee).mockReturnValue(true);
+
+    // JPY is stored unscaled (convertToSmallestCurrencyUnit is a no-op for it), so
+    // 5000 means ¥5000 and must not be presented as ¥50.
+    render(
+      <CancelBooking
+        booking={{
+          ...mockBookingWithCancellationFee,
+          payment: { amount: 5000, currency: "jpy", appId: "stripe" },
+        }}
+        profile={{ name: "Test User", slug: "test-user" }}
+        team={null}
+        isHost={false}
+        eventTypeMetadata={mockEventTypeMetadataWithFee}
+        {...mockProps}
+      />
+    );
+
+    expect(screen.getByText(/will result in a 5000 jpy cancellation fee/)).toBeInTheDocument();
+  });
+
+  it("should still scale the fee for two-decimal currencies", () => {
+    vi.mocked(shouldChargeModule.shouldChargeNoShowCancellationFee).mockReturnValue(true);
+
+    render(
+      <CancelBooking
+        booking={mockBookingWithCancellationFee}
+        profile={{ name: "Test User", slug: "test-user" }}
+        team={null}
+        isHost={false}
+        eventTypeMetadata={mockEventTypeMetadataWithFee}
+        {...mockProps}
+      />
+    );
+
+    expect(screen.getByText(/will result in a 10 usd cancellation fee/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/dialog/ChargeCardDialog.tsx
+++ b/apps/web/components/dialog/ChargeCardDialog.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
@@ -34,7 +35,7 @@ export const ChargeCardDialog = (props: IRescheduleDialog) => {
   };
 
   const currencyStringParams = {
-    amount: props.paymentAmount / 100.0,
+    amount: convertFromSmallestToPresentableCurrencyUnit(props.paymentAmount, props.paymentCurrency),
     formatParams: { amount: { currency: props.paymentCurrency } },
   };
 

--- a/apps/web/components/dialog/__tests__/ChargeCardDialog.test.tsx
+++ b/apps/web/components/dialog/__tests__/ChargeCardDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChargeCardDialog } from "../ChargeCardDialog";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/bookings/upcoming",
+}));
+
+vi.mock("@calcom/lib/hooks/useCompatSearchParams", () => ({
+  useCompatSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@calcom/trpc/react", () => ({
+  trpc: {
+    useUtils: () => ({
+      viewer: {
+        bookings: {
+          invalidate: vi.fn(),
+        },
+      },
+    }),
+  },
+}));
+
+// Echoes the interpolated amount so the assertion reads the exact number the
+// dialog passed to i18next, rather than an Intl-formatted string.
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === "charge_card_dialog_body") {
+        const opts = options as {
+          amount?: number;
+          formatParams?: { amount?: { currency?: string } };
+        };
+        return `You are about to charge the attendee [${opts?.amount}] ${opts?.formatParams?.amount?.currency}.`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const mockProps = {
+  isOpenDialog: true,
+  setIsOpenDialog: vi.fn(),
+  bookingId: 123,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ChargeCardDialog", () => {
+  it("does not scale the amount for zero-decimal currencies", () => {
+    // JPY is stored unscaled, so 5000 means ¥5000 and must not be presented as ¥50.
+    render(<ChargeCardDialog {...mockProps} paymentAmount={5000} paymentCurrency="jpy" />);
+
+    expect(screen.getByText(/about to charge the attendee \[5000\] jpy/)).toBeInTheDocument();
+  });
+
+  it("still scales the amount for two-decimal currencies", () => {
+    render(<ChargeCardDialog {...mockProps} paymentAmount={5000} paymentCurrency="usd" />);
+
+    expect(screen.getByText(/about to charge the attendee \[50\] usd/)).toBeInTheDocument();
+  });
+});

--- a/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
+++ b/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { BaseScheduledEmail } from "./BaseScheduledEmail";
@@ -24,7 +25,10 @@ export const NoShowFeeChargedEmail = (
       subtitle={
         <>
           {t("no_show_fee_charged_subtitle", {
-            amount: calEvent.paymentInfo.amount / 100,
+            amount: convertFromSmallestToPresentableCurrencyUnit(
+              calEvent.paymentInfo.amount,
+              calEvent.paymentInfo.currency ?? ""
+            ),
             formatParams: { amount: { currency: calEvent.paymentInfo?.currency } },
           })}
         </>

--- a/packages/emails/templates/no-show-fee-charged-email.test.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.test.ts
@@ -1,0 +1,63 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+
+import type { CalendarEvent, Person } from "@calcom/types/Calendar";
+
+import NoShowFeeChargedEmail from "./no-show-fee-charged-email";
+
+class TestNoShowFeeChargedEmail extends NoShowFeeChargedEmail {
+  public async getPayload() {
+    return await this.getNodeMailerPayload();
+  }
+}
+
+// Echoes the interpolated amount so the assertion reads the exact number the
+// template passed to i18next, rather than an Intl-formatted string.
+const t = ((key: string, vars?: Record<string, unknown>) => {
+  if (key === "no_show_fee_charged_email_subject") {
+    return `No-show fee of ${String(vars?.amount ?? "")} charged`;
+  }
+  if (key === "no_show_fee_charged_subtitle") {
+    return `Subtitle no-show fee of [${String(vars?.amount ?? "")}]`;
+  }
+  return key;
+}) as unknown as TFunction;
+
+const attendee: Person = {
+  name: "Attendee",
+  email: "attendee@example.com",
+  timeZone: "UTC",
+  language: { translate: t, locale: "en" },
+};
+
+const buildCalEvent = (amount: number, currency: string): CalendarEvent => ({
+  type: "30min",
+  title: "30 min meeting",
+  startTime: "2026-09-10T10:00:00Z",
+  endTime: "2026-09-10T10:30:00Z",
+  organizer: {
+    name: "Organizer",
+    email: "organizer@example.com",
+    timeZone: "UTC",
+    language: { translate: t, locale: "en" },
+  },
+  attendees: [attendee],
+  paymentInfo: { amount, currency, paymentOption: "HOLD" },
+});
+
+describe("NoShowFeeChargedEmail", () => {
+  it("does not scale the amount for zero-decimal currencies", async () => {
+    // JPY is stored unscaled, so 5000 means ¥5000 and must not be presented as ¥50.
+    const payload = await new TestNoShowFeeChargedEmail(buildCalEvent(5000, "JPY"), attendee).getPayload();
+
+    expect(payload.subject).toBe("No-show fee of 5000 charged");
+    expect(String(payload.html)).toContain("Subtitle no-show fee of [5000]");
+  });
+
+  it("still scales the amount for two-decimal currencies", async () => {
+    const payload = await new TestNoShowFeeChargedEmail(buildCalEvent(5000, "USD"), attendee).getPayload();
+
+    expect(payload.subject).toBe("No-show fee of 50 charged");
+    expect(String(payload.html)).toContain("Subtitle no-show fee of [50]");
+  });
+});

--- a/packages/emails/templates/no-show-fee-charged-email.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.ts
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import renderEmail from "../src/renderEmail";
@@ -13,7 +14,10 @@ export default class NoShowFeeChargedEmail extends AttendeeScheduledEmail {
       subject: `${this.attendee.language.translate("no_show_fee_charged_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),
-        amount: this.calEvent.paymentInfo.amount / 100,
+        amount: convertFromSmallestToPresentableCurrencyUnit(
+          this.calEvent.paymentInfo.amount,
+          this.calEvent.paymentInfo.currency ?? ""
+        ),
         formatParams: { amount: { currency: this.calEvent.paymentInfo?.currency } },
       })}`,
       html: await renderEmail("NoShowFeeChargedEmail", {


### PR DESCRIPTION
## What does this PR do?

- Fixes #30122

Four display sites in the no-show fee (HOLD) flow divided `Payment.amount` by 100 unconditionally:

```ts
amount: booking.payment.amount / 100,
```

Zero-decimal currencies have no minor unit, so `convertToSmallestCurrencyUnit` stores them **unscaled** and Stripe's `chargeCard` passes `payment.amount` to `paymentIntents.create` verbatim. Dividing that value for display understates it by 100×: a ¥5,000 no-show fee is shown as **¥50** to both the attendee and the host, and then ¥5,000 is charged.

The affected sites are:

| File | Surface |
| --- | --- |
| `apps/web/components/booking/CancelBooking.tsx` | Attendee's cancellation-fee acknowledgement checkbox |
| `apps/web/components/dialog/ChargeCardDialog.tsx` | Host's "Collect no-show fee" confirmation dialog |
| `packages/emails/templates/no-show-fee-charged-email.ts` | No-show fee charged email — subject |
| `packages/emails/src/templates/NoShowFeeChargedEmail.tsx` | No-show fee charged email — subheading |

The first of those is a **consent statement** — the attendee ticks a box acknowledging ¥50 and is charged ¥5,000.

The rest of the currency handling is already zero-decimal aware — the price input (`EventTypeAppSettingsInterface`), add-on pricing (`handlePayment`) and display (`formatPrice`) all route through `packages/lib/currencyConversions.ts`. Only these four did not, which is why the codebase currently contradicts itself on screen:

- In `bookings-single-view.tsx`, `<Price price={paymentStatus.amount} />` renders **¥5,000** through `formatPrice` while the `CancelBooking` checkbox on the same page renders **¥50**.
- `BaseScheduledEmail.tsx:141` renders the fee via `formatPrice` as **¥5,000** in the info row of the very same email whose subject and subheading say **¥50**.

This change routes all four through `convertFromSmallestToPresentableCurrencyUnit`, the exact inverse of the write-side conversion and the helper that already backs `formatPrice`.

**Scope:** the affected set is exactly the `zeroDecimalCurrencies` array in `packages/lib/currencyConversions.ts` (Stripe's own list): BIF, CLP, DJF, GNF, JPY, KMF, KRW, MGA, PYG, RWF, UGX, VND, VUV, XAF, XOF, XPF. Currencies with a minor unit are untouched, and each added test pins both a zero-decimal and a two-decimal currency so that stays true.

The two email sites pass `currency ?? ""` because `calEvent.paymentInfo.currency` is typed `string | undefined`. An empty currency is not zero-decimal, so it falls through to the existing `/100` behaviour — deliberately preserving today's semantics for a currency-less payment rather than widening a shared helper's signature for two callers.

Deliberately **out of scope**, and left untouched: the `/100` inside the three `currencyConversions`/`currencyOptions` helpers themselves (that is the correct branch), and `packages/app-store/mock-payment-app/components/EventTypeAppCardInterface.tsx:87` (a symmetric `*100`/`/100` round-trip in the e2e mock app, not a user-facing path).

This is the same class of bug as #29984 (PayPal) and #30039 (HitPay), but an independent one: those corrected the amount **charged**, this corrects the amount **displayed**.

## Visual Demo (For contributors especially)

Screenshots would be misleading here: the currency symbol and grouping look perfectly normal either way, because `Intl.NumberFormat` faithfully formats an already-corrupted number. The meaningful evidence is the number itself, captured by rendering the real components and the real email with translation mocks that echo the interpolated value.

**Before (fix reverted, tests in place)** — only the zero-decimal cases fail:

```
 × no-show-fee-charged-email > does not scale the amount for zero-decimal currencies
 × CancelBooking > should not scale the fee for zero-decimal currencies
 × ChargeCardDialog > does not scale the amount for zero-decimal currencies

 AssertionError: expected 'No-show fee of 50 charged' to be 'No-show fee of 5000 charged'
 TestingLibraryElementError: Unable to find an element with the text: /will result in a 5000 jpy cancellation fee/
 TestingLibraryElementError: Unable to find an element with the text: /about to charge the attendee \[5000\] jpy/

 Test Files  3 failed (3)
      Tests  3 failed | 8 passed (11)
```

The rendered output behind those failures, for a 5000 JPY payment:

> I acknowledge that cancelling within 1 hours will result in a **50 jpy** cancellation fee being charged to my card.

> You are about to charge the attendee **[50] jpy**.

And the two figures coexisting in one rendered email body:

```html
<div data-testid="subHeading" ...>Subtitle no-show fee of [50]</div>
...
<p>no_show_fee</p>
<p>¥5,000</p>
```

**After (this PR)**:

```
 ✓ apps/web/components/dialog/__tests__/ChargeCardDialog.test.tsx (2 tests)
 ✓ apps/web/components/booking/__tests__/CancelBooking.cancellationFee.test.tsx (7 tests)
 ✓ packages/emails/templates/no-show-fee-charged-email.test.ts (2 tests)

 Test Files  3 passed (3)
      Tests  11 passed (11)
```

End-to-end, traced through the repository's own helpers, for a HOLD no-show fee:

| Organizer configures | Stored `Payment.amount` | Stripe charges | Displayed (before) | Displayed (after) |
| --- | --- | ---: | ---: | ---: |
| 5000 JPY | `5000` | ¥5,000 | **¥50** ❌ | ¥5,000 ✅ |
| 50000 KRW | `50000` | ₩50,000 | **₩500** ❌ | ₩50,000 ✅ |
| 50 USD | `5000` | $50.00 | $50.00 ✅ | $50.00 ✅ |
| 50 EUR | `5000` | €50.00 | €50.00 ✅ | €50.00 ✅ |

The `[50]` / `[5000]` brackets in the snippets above are delimiters added by the test's translation mock so that `50` cannot prefix-match `5000`; they are not product output.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. — N/A, this is an internal currency-conversion fix with no documented behaviour change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or payment credentials are needed for the automated tests:

```bash
TZ=UTC yarn vitest run \
  apps/web/components/booking/__tests__/CancelBooking.cancellationFee.test.tsx \
  apps/web/components/dialog/__tests__/ChargeCardDialog.test.tsx \
  packages/emails/templates/no-show-fee-charged-email.test.ts
```

Each file asserts a zero-decimal currency (JPY) and a two-decimal currency (USD) at the same site. To see them fail without the fix, revert the four one-line changes and re-run — exactly the three JPY cases fail and the eight others pass.

Also run to confirm nothing regressed in the surrounding suites:

```bash
TZ=UTC yarn vitest run apps/web/components packages/emails   # 121 tests
yarn type-check:ci --force --filter=@calcom/web --filter=@calcom/emails
```

To verify manually:

- **Minimal test data:** an event type with the Stripe app enabled, currency **JPY**, price **5000**, payment option **Hold**, and "charge no-show fee if cancelled within" set to 1 hour.
- **Expected (happy path):** the cancellation acknowledgement checkbox, the host's **Collect no-show fee** dialog, and the resulting email's subject and subheading should all read **¥5,000** — matching the fee row lower in that same email and the amount Stripe captures. Before this change they all read ¥50.
- Repeat with currency **USD** and price **5000** to confirm unchanged behaviour: every surface should read **$50.00**.

## Checklist

- My PR is small and focused (4 one-line changes across 4 files, plus tests)
