### PR TITLE
fix(dynamic-booking): respect username order when picking the conferencing app

### DIFF
--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -299,7 +299,15 @@ export const getPublicEvent = async (
       usernameList,
       orgSlug: org,
     });
-    const users = usersInOrgContext;
+    // The first member of a dynamic group decides which conferencing app is used, so the order
+    // given in the URL has to win here. findUsersByUsername does not guarantee that order, which
+    // means /alice+bob could pick bob's preference. handleNewBooking already sorts for exactly
+    // this reason (sortUsersByDynamicList in getLocationValuesForDb.ts) — without the same sort
+    // here, the booking page can advertise a different location than the one actually booked.
+    const users = [...usersInOrgContext].sort(
+      (a, b) =>
+        usernameList.indexOf(a.username ?? "") - usernameList.indexOf(b.username ?? "")
+    );
 
     const defaultEvent = getDefaultEvent(eventSlug);
     let locations = defaultEvent.locations ? (defaultEvent.locations as LocationObject[]) : [];


### PR DESCRIPTION
## What does this PR do?

Makes the booking page honour the username order from the URL when it picks the conferencing app
for a dynamic group booking, so it matches what `handleNewBooking` already does.

## The problem

For a dynamic group booking (`/alice+bob`), the **first** member decides which conferencing app is
used. `getPublicEvent` takes that member straight from the repository result:

```ts
const usersInOrgContext = await new UserRepository(prisma).findUsersByUsername({
  usernameList,
  orgSlug: org,
});
const users = usersInOrgContext;
...
const firstUsersMetadata = userMetadataSchema.parse(users[0].metadata || {});
const preferedLocationType = firstUsersMetadata?.defaultConferencingApp;
```

`findUsersByUsername` makes no promise about ordering, so `users[0]` is not necessarily the first
username from the URL. When only that first user has a `defaultConferencingApp` set, the preference
is silently dropped and the event falls back to the hardcoded Cal Video location from
`defaultEvents.ts`.

On our self-hosted instance this is reproducible: `/alice+bob`, where **alice** has Google Meet set
as her default conferencing app and **bob** has no preference, renders `integrations:daily` —
the same result as `/bob+alice`. The order simply has no effect. Setting a preference on the *other*
user makes it work, which is what put us on the trail.

## Why this is inconsistent

`handleNewBooking` sorts for exactly this reason before reading the first member:

```ts
// packages/features/bookings/lib/handleNewBooking/getLocationValuesForDb.ts
const sortUsersByDynamicList = <TUser extends { username: string | null }>(
  users: TUser[],
  dynamicUserList: string[]
) => { ... };

if (isDynamicGroupBookingCase) {
  users = sortUsersByDynamicList(users, dynamicUserList);
  const firstDynamicGroupMember = users[0];
  ...
}
```

So the two paths can disagree about who "the first member" is: the booking page advertises one
location, the booking itself resolves another. This PR applies the same ordering on the display
side.

## The fix

Sort the users by their position in `usernameList` before reading `users[0]`. Nothing else changes —
the existing preference resolution is untouched, and single-user events do not go through this
branch at all.

## Notes for the reviewer

- I sorted inline rather than exporting `sortUsersByDynamicList`, to avoid a new dependency from
  `features/eventtypes` into `features/bookings`. If you would rather share the helper, moving it
  next to `getUsernameList` in `defaultEvents.ts` and using it from both places would work — happy
  to change it.
- Users whose username is missing from the list sort to the front via `indexOf` returning `-1`.
  In practice every user in `usersInOrgContext` comes from `usernameList`, so this is not
  reachable; I left it rather than adding a branch that cannot be hit.

## How to test

1. Two users, `alice` and `bob`. Set **Google Meet** as the default conferencing app for `alice`
   only, leave `bob` without a preference.
2. Open `/alice+bob`.
3. **Before:** the location shows Cal Video — alice's preference is ignored, depending on the order
   the repository happens to return.
   **After:** the location shows Google Meet, and `/bob+alice` correctly falls back to Cal Video.
