### PR TITLE
Add a Kane CLI natural-language E2E test for booking availability

### DIFF
--- a/tests/kane-cli/booking-availability_test.md
+++ b/tests/kane-cli/booking-availability_test.md
@@ -1,0 +1,14 @@
+# Cal.com — public booking page shows available times
+
+A Kane CLI natural-language end-to-end test that opens a public Cal.com booking
+page, selects an available date, and verifies bookable time slots appear. It does
+not confirm a booking. Runs in a real browser (Kane CLI also automates mobile apps
+on the iOS Simulator and Android Emulator).
+
+## Open a booking page and verify time slots
+Go to https://cal.com/peer.
+Wait for the booking calendar to load.
+Click an available (selectable, not disabled) date.
+Wait for the available time slots to appear.
+Assert that one or more bookable time slots are displayed.
+Do not confirm or complete any booking.


### PR DESCRIPTION
## Add a Kane CLI natural-language end-to-end test

This adds one plain-markdown, natural-language end-to-end test covering opening a public Cal.com booking page, selecting an available date, and verifying bookable time slots appear (without confirming a booking).

**Why it might help**
- Readable by anyone: no selectors, no scripting. It lives in the repo as a `test.md` and re-runs on every deploy.
- Kane CLI drives a real browser, verifies each step with a visual/network check, and produces a sharable evidence report (video, steps, network). It also automates mobile apps on the iOS Simulator and Android Emulator.

**Evidence from a live run (passed):**
https://test-manager.lambdatest.com/projects/01KJSH1ECPR455A3XRGBKR3NV3/test-cases/01M23990S8KQCZG9G83A6A8PPE/dashboard/share/US_R8EMETTPBYAKMK15GJNEY9E782PXEUQUOVN3JQXX6L2ZDMVKFW3F9SAV1HTA79FY?type=summary&agentView=true&fqdn=summary-page

**How to run**
```
kane-cli testmd run tests/kane-cli/booking-availability_test.md --agent
```

Opening this for your consideration; approval is entirely yours. Happy to adjust the flow, the file location, or the format.
