### PR TITLE
fix(calendars): handle missing destination calendar metadata

### DIFF
--- a/packages/features/calendars/__tests__/DestinationCalendarSelector.test.tsx
+++ b/packages/features/calendars/__tests__/DestinationCalendarSelector.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import DestinationCalendarSelector from "../components/DestinationCalendarSelector";
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@calcom/ui/components/form", async () => ({
+  Select: (await import("react-select")).default,
+}));
+
+vi.mock("@calcom/ui/components/badge", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+type QueryData = NonNullable<ComponentProps<typeof DestinationCalendarSelector>["calendarsQueryData"]>;
+
+const calendar = {
+  externalId: "owner@example.com",
+  integration: "google_calendar",
+  name: "Personal",
+  email: "owner@example.com",
+  readOnly: false,
+};
+
+const connectedCalendar: QueryData["connectedCalendars"][number] = {
+  credentialId: 1,
+  integration: {
+    name: "Google Calendar",
+    type: "google_calendar",
+    description: "",
+    variant: "calendar",
+    slug: "google-calendar",
+    categories: ["calendar"],
+    logo: "",
+    publisher: "",
+    url: "",
+    email: "",
+  },
+  primary: { ...calendar, name: "owner@example.com" },
+  calendars: [calendar],
+};
+
+const renderSelector = (data: QueryData, value?: string) => {
+  const onChange = vi.fn();
+  const result = render(
+    <DestinationCalendarSelector
+      calendarsQueryData={data}
+      value={value}
+      onChange={onChange}
+      hidePlaceholder
+      hideAdvancedText
+    />
+  );
+  return { ...result, onChange };
+};
+
+describe("DestinationCalendarSelector", () => {
+  it.each([
+    ["Google Calendar", "owner@example.com", "Personal (Google Calendar - owner@example.com)"],
+    [undefined, "owner@example.com", "Personal (owner@example.com)"],
+    ["Google Calendar", null, "Personal (Google Calendar)"],
+    [undefined, null, "Personal"],
+    [" ", " ", "Personal"],
+  ])("formats the default with provider %s and account %s", (integrationTitle, primaryEmail, expected) => {
+    const { container } = renderSelector({
+      connectedCalendars: [connectedCalendar],
+      destinationCalendar: { ...calendar, integrationTitle, primaryEmail },
+    });
+
+    expect(screen.getByText("default")).toBeInTheDocument();
+    expect(container).toHaveTextContent(`default ${expected}`);
+    expect(container.textContent).not.toMatch(/undefined|null|\(\)|\(\s*-|-\s*\)/);
+  });
+
+  it.each([
+    ["Google Calendar", "owner@example.com", "(Google - owner@example.com)"],
+    ["Google Calendar", undefined, "(Google)"],
+    [" ", "owner@example.com", "(owner@example.com)"],
+    [" ", undefined, ""],
+  ])("formats selected and dropdown subtitles with provider %s and account %s", (name, account, subtitle) => {
+    const data = {
+      connectedCalendars: [
+        {
+          ...connectedCalendar,
+          integration: { ...connectedCalendar.integration, name },
+          primary: { ...calendar, name: account },
+        },
+      ],
+      destinationCalendar: null,
+    };
+    const { container } = renderSelector(data, calendar.externalId);
+
+    expect(container).toHaveTextContent(`Personal ${subtitle}`.trim());
+    expect(container.textContent).not.toMatch(/undefined|null|\(\)|\(\s*-|-\s*\)/);
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    expect(container.textContent).not.toMatch(/undefined|null|\(\)|\(\s*-|-\s*\)/);
+    fireEvent.click(screen.getByRole("option", { name: "Personal" }));
+    expect(container).toHaveTextContent(`Personal ${subtitle}`.trim());
+  });
+
+  it("omits missing primary account metadata from the dropdown group", () => {
+    const { container } = renderSelector({
+      connectedCalendars: [{ ...connectedCalendar, primary: null }],
+      destinationCalendar: null,
+    });
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    expect(screen.getByText("Google")).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/undefined|null|\(\)/);
+  });
+
+  it("keeps the Office 365 account email in the dropdown group", () => {
+    renderSelector({
+      connectedCalendars: [
+        {
+          ...connectedCalendar,
+          integration: { ...connectedCalendar.integration, name: "Office 365 Calendar" },
+          primary: { ...calendar, integration: "office365_calendar" },
+        },
+      ],
+      destinationCalendar: null,
+    });
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    expect(screen.getByText("Office 365 (owner@example.com)")).toBeInTheDocument();
+  });
+
+  it("filters read-only calendars and preserves colons in the selected external ID", () => {
+    const externalId = "https://calendar.example.com:443/personal";
+    const { onChange } = renderSelector({
+      connectedCalendars: [
+        {
+          ...connectedCalendar,
+          calendars: [
+            { ...calendar, integration: "apple_calendar", externalId },
+            { ...calendar, externalId: "readonly", name: "Read only", readOnly: true },
+            { ...calendar, externalId: "unnamed", name: undefined },
+          ],
+        },
+      ],
+      destinationCalendar: null,
+    });
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowDown" });
+    expect(screen.queryByRole("option", { name: "Read only" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+    expect(screen.getByRole("option", { name: "" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: "Personal" }));
+    expect(onChange).toHaveBeenCalledWith({ integration: "apple_calendar", externalId });
+  });
+});

--- a/packages/features/calendars/components/DestinationCalendarSelector.tsx
+++ b/packages/features/calendars/components/DestinationCalendarSelector.tsx
@@ -71,6 +71,19 @@ interface Option {
   subtitle: string;
 }
 
+const formatCalendarDetails = (...parts: (string | null | undefined)[]): string => {
+  const details = parts
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(" - ");
+  return details ? `(${details})` : "";
+};
+
+const formatCalendarLabel = (
+  name: string | null | undefined,
+  ...details: (string | null | undefined)[]
+): string => [name?.trim(), formatCalendarDetails(...details)].filter(Boolean).join(" ");
+
 export const SingleValueComponent = ({ ...props }: SingleValueProps<Option>) => {
   const { label, subtitle } = props.data;
   return (
@@ -142,9 +155,10 @@ const DestinationCalendarSelector = ({
       setSelectedOption({
         value: `${selected.integration}:${selected.externalId}`,
         label: selected.name ? `${selected.name} ` : "",
-        subtitle: `(${selectedIntegration?.integration.title?.replace(/calendar/i, "")} - ${
+        subtitle: formatCalendarDetails(
+          selectedIntegration?.integration.name.replace(/calendar/i, ""),
           selectedIntegration?.primary?.name
-        })`,
+        ),
       });
     }
   }, [connectedCalendarsList]);
@@ -155,18 +169,20 @@ const DestinationCalendarSelector = ({
   const options =
     connectedCalendarsList?.map((selectedCalendar) => ({
       key: selectedCalendar.credentialId,
-      label: `${selectedCalendar.integration.title?.replace(/calendar/i, "")} (${
+      label: formatCalendarLabel(
+        selectedCalendar.integration.name.replace(/calendar/i, ""),
         selectedCalendar.primary?.integration === "office365_calendar"
           ? selectedCalendar.primary?.email
           : selectedCalendar.primary?.name
-      })`,
+      ),
       options: (selectedCalendar.calendars ?? [])
         .filter((cal) => cal.readOnly === false)
         .map((cal) => ({
-          label: ` ${cal.name} `,
-          subtitle: `(${selectedCalendar?.integration.title?.replace(/calendar/i, "")} - ${
-            selectedCalendar?.primary?.name
-          })`,
+          label: cal.name?.trim() ?? "",
+          subtitle: formatCalendarDetails(
+            selectedCalendar.integration.name.replace(/calendar/i, ""),
+            selectedCalendar.primary?.name
+          ),
           value: `${cal.integration}:${cal.externalId}`,
         })),
     })) ?? [];
@@ -183,8 +199,11 @@ const DestinationCalendarSelector = ({
           ) : (
             <span className="text-default min-w-0 overflow-hidden truncate whitespace-nowrap">
               <Badge variant="blue">{t("default")}</Badge>{" "}
-              {destinationCalendar?.name &&
-                `${destinationCalendar.name} (${destinationCalendar?.integrationTitle} - ${destinationCalendar.primaryEmail})`}
+              {formatCalendarLabel(
+                destinationCalendar?.name,
+                destinationCalendar?.integrationTitle,
+                destinationCalendar?.primaryEmail
+              )}
             </span>
           )
         }

--- a/packages/features/calendars/lib/CalendarManager.test.ts
+++ b/packages/features/calendars/lib/CalendarManager.test.ts
@@ -1,11 +1,13 @@
 import { prisma } from "@calcom/prisma/__mocks__/prisma";
 import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
-import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { Calendar, CalendarEvent } from "@calcom/types/Calendar";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
 import {
   deduplicateCredentialsBasedOnSelectedCalendars,
   deleteEvent,
   getCalendarCredentials,
+  getConnectedCalendars,
   processEvent,
 } from "./CalendarManager";
 
@@ -97,6 +99,46 @@ function buildCalendarEvent(overrides = {}) {
 }
 
 describe("CalendarManager tests", () => {
+  it("uses the app name for the destination calendar when the deprecated title is absent", async () => {
+    const calendar = mockDeep<Calendar>();
+    calendar.listCalendars.mockResolvedValue([
+      {
+        externalId: "owner@example.com",
+        integration: "google_calendar",
+        name: "Personal",
+        email: "owner@example.com",
+        primary: true,
+      },
+    ]);
+    vi.mocked(getCalendar).mockResolvedValue(calendar);
+    const credentials = getCalendarCredentials([
+      {
+        ...buildCredential({
+          type: "google_calendar",
+          appId: "google-calendar",
+          id: 1,
+          delegatedToId: null,
+          user: { email: "owner@example.com" },
+        }),
+        encryptedKey: null,
+        delegationCredentialId: null,
+      },
+    ]).map((entry) => {
+      const integration = { ...entry.integration, name: "Google Calendar" };
+      delete integration.title;
+      return { ...entry, integration };
+    });
+
+    expect(credentials).toHaveLength(1);
+    const result = await getConnectedCalendars(credentials, [], "owner@example.com");
+
+    expect(result.destinationCalendar).toMatchObject({
+      integrationTitle: "Google Calendar",
+      primaryEmail: "owner@example.com",
+      externalId: "owner@example.com",
+    });
+  });
+
   describe("fn: processEvent", () => {
     it("should clear attendees when hideOrganizerEmail is true and no Zoho Calendar destination", () => {
       const calEvent = buildCalendarEvent({

--- a/packages/features/calendars/lib/CalendarManager.ts
+++ b/packages/features/calendars/lib/CalendarManager.ts
@@ -227,7 +227,7 @@ export const getConnectedCalendars = async (
           ...calendar,
           primary: calendar.primary ?? undefined,
           primaryEmail: connectedCalendar.primary?.email,
-          integrationTitle: connectedCalendar.integration?.title,
+          integrationTitle: connectedCalendar.integration.name,
         };
         break;
       }


### PR DESCRIPTION
## Problem

On first load, the “Add to calendar” selector can show `undefined` in its **Default** label because it interpolates the optional `destinationCalendar.integrationTitle`; selecting the same calendar switches to a separately constructed option label, which displays correctly in the reported production case.

## In production: 
<img width="520" height="365" alt="Screenshot 2026-09-09 at 12 33 57 PM" src="https://github.com/user-attachments/assets/1ce44e68-bd62-404c-9ccf-56cbd99dbde1" />

## Fix

Populate the existing `integrationTitle` response field from `App.name`, use `App.name` for selector options, and omit missing or blank label details together with their separators.

## Visual verification

The following screenshots use the real selector and app styles in a temporary route in the repository’s Next.js app, with simulated Google Calendar data containing `name` but no deprecated `title`; they demonstrate the fix rather than reproduce every detail of the production response.

| Local: before fix | Local: after fix |
| --- | --- |
| ![Before fix: undefined provider in the default label](https://raw.githubusercontent.com/chrisdadev13/cal.com/bbbaf2a2c779d5343a535c3e0cc97cb287e878f8/simulated-before.png) | ![After fix: Google Calendar provider in the default label](https://raw.githubusercontent.com/chrisdadev13/cal.com/bbbaf2a2c779d5343a535c3e0cc97cb287e878f8/simulated-after.png) |

## Validation

- Browser checks passed for reproducing the original default-label failure and displaying the provider in default, dropdown, and selected labels after the fix.
- All 12 selector regression tests passed in an isolated environment; coverage includes missing metadata, Office 365 account emails, read-only filtering, and external IDs containing colons.
- Added a backend regression test for an integration with a name and no title.
- Biome: no errors; `git diff --check`: passed.
- Full repository test and type-check commands remain unverified: workspace `vitest` and `turbo` executables are unavailable.