### PR TITLE
fix(availability): use the travel timezone for a 23:59 date override end

### DIFF
--- a/packages/features/schedules/lib/date-ranges.test.ts
+++ b/packages/features/schedules/lib/date-ranges.test.ts
@@ -363,8 +363,8 @@ describe("processDateOverrides", () => {
   it("should end a 23:59 date override at midnight in the travel timezone", () => {
     const item = {
       date: new Date(Date.UTC(2023, 5, 12, 8, 0)),
-      startTime: new Date(Date.UTC(2023, 5, 12, 9, 0)), // 9 AM
-      endTime: new Date(Date.UTC(2023, 5, 12, 23, 59)), // 11:59 PM, the maximum the UI allows
+      startTime: new Date(Date.UTC(2023, 5, 12, 9, 0)),
+      endTime: new Date(Date.UTC(2023, 5, 12, 23, 59)), // 11:59 PM, the maximum the availability UI allows
     };
 
     const timeZone = "America/New_York";

--- a/packages/features/schedules/lib/date-ranges.test.ts
+++ b/packages/features/schedules/lib/date-ranges.test.ts
@@ -360,6 +360,37 @@ describe("processDateOverrides", () => {
     expect(result.start.format()).toEqual(dayjs("2023-06-12T06:00:00Z").tz(travelScheduleTz).format());
     expect(result.end.format()).toEqual(dayjs("2023-06-12T15:00:00Z").tz(travelScheduleTz).format());
   });
+  it("should end a 23:59 date override at midnight in the travel timezone", () => {
+    const item = {
+      date: new Date(Date.UTC(2023, 5, 12, 8, 0)),
+      startTime: new Date(Date.UTC(2023, 5, 12, 9, 0)), // 9 AM
+      endTime: new Date(Date.UTC(2023, 5, 12, 23, 59)), // 11:59 PM, the maximum the UI allows
+    };
+
+    const timeZone = "America/New_York";
+
+    const travelScheduleTz = "Europe/Berlin";
+
+    const travelSchedules = [
+      {
+        startDate: dayjs(new Date(Date.UTC(2023, 5, 11, 8, 0))).startOf("day"),
+        endDate: dayjs(new Date(Date.UTC(2023, 5, 15, 8, 0))).endOf("day"),
+        timeZone: travelScheduleTz,
+      },
+    ];
+
+    const result = processDateOverride({
+      item,
+      itemDateAsUtc: dayjs.utc(item.date),
+      timeZone,
+      travelSchedules: travelSchedules,
+    });
+
+    // 9 AM in Berlin, the travel timezone
+    expect(result.start.format()).toEqual(dayjs("2023-06-12T07:00:00Z").tz(travelScheduleTz).format());
+    // midnight in Berlin, not midnight in New York
+    expect(result.end.format()).toEqual(dayjs("2023-06-12T22:00:00Z").tz(travelScheduleTz).format());
+  });
 });
 
 describe("buildDateRanges", () => {

--- a/packages/features/schedules/lib/date-ranges.ts
+++ b/packages/features/schedules/lib/date-ranges.ts
@@ -199,7 +199,7 @@ export function processDateOverride({
   const endTimeMinutes = item.endTime.getUTCMinutes();
 
   if (endTimeHours === 23 && endTimeMinutes === 59) {
-    endDate = endDate.add(1, "day").tz(timeZone, true);
+    endDate = endDate.add(1, "day").tz(adjustedTimezone, true);
   } else {
     endDate = itemDateStartOfDay
       .add(endTimeHours, "hours")


### PR DESCRIPTION
## What does this PR do?

`processDateOverride` builds the two ends of a date override in two different
timezones when a travel schedule is active.

Line 188 resolves the timezone that applies on the override's date:

```ts
const adjustedTimezone = getAdjustedTimezone(overrideDate, timeZone, travelSchedules);
```

The start uses it (line 195), and so does the ordinary end branch (line 208).
The 23:59 branch does not:

```ts
if (endTimeHours === 23 && endTimeMinutes === 59) {
  endDate = endDate.add(1, "day").tz(timeZone, true);   // home timezone
} else {
  endDate = itemDateStartOfDay
    .add(endTimeHours, "hours")
    .add(endTimeMinutes, "minutes")
    .second(0)
    .tz(adjustedTimezone, true);                        // travel timezone
}
```

`.tz(zone, true)` keeps the local reading and changes which zone it belongs to,
so anchoring midnight to the home zone instead of the travel zone moves the end
of the range by the offset between them. The start of the same range is already
anchored to the travel zone, so the two ends of one interval end up in two
different frames of reference.

This is a strict no-op without a travel schedule: `getAdjustedTimezone`
initialises `let adjustedTimezone = timeZone` and only reassigns it inside the
loop, so with an empty `travelSchedules` the two arguments are the same string.

23:59 is not an edge case. `MINUTES_DAY_END` in `packages/lib/availability.ts`
is `MINUTES_IN_DAY - 1`, so every override saved as available for the whole day
lands on this branch.

Measured on 12 June 2023, `Europe/Berlin` and `America/New_York` six hours apart:

| Override | Home / travel | Today | With this PR |
| --- | --- | --- | --- |
| 09:00 â€“ 23:59 | New York / Berlin | `07:00Z â†’ next 04:00Z`, 21 h | `07:00Z â†’ 22:00Z`, 15 h |
| 09:00 â€“ 23:59 | Berlin / New York | `13:00Z â†’ 22:00Z`, 9 h | `13:00Z â†’ next 04:00Z`, 15 h |
| 18:00 â€“ 23:59 | Berlin / New York | `22:00Z â†’ 22:00Z`, **0 h** | `22:00Z â†’ next 04:00Z`, 6 h |
| 09:00 â€“ 17:00 | New York / Berlin | `07:00Z â†’ 15:00Z`, 8 h | unchanged |

Travelling east, the organizer is offered for six hours they never opened.
Travelling west, six hours of their evening disappear, and an evening-only
override collapses to an empty range so the whole day reads as unavailable.
Nothing errors in any of these cases.

Introduced in #13951, which added travel schedules. That PR converted
`.tz(timeZone, true)` to `.tz(adjustedTimezone, true)` in exactly two of the
three call sites inside `processDateOverride` â€” the start and the ordinary end
branch. The 23:59 branch does not appear in its diff at all. This restores the
third.

Prior art, for completeness: #23544 ("enhance timezone handling for Chile DST
transitions", closed unmerged) would have removed this line incidentally, as
part of a broad IANA-timezone refactor of the file at its old
`packages/lib/` path. Its description is entirely about DST offset maths in
`processWorkingHours`; it never identifies the travel-schedule mismatch, and it
never landed, so the defect is still on `main` today. This PR is one word in one
file, aimed at that specific defect, with the regression test the gap deserves.

Related but not fixed here: #30021 (a separate DST defect in
`processWorkingHours` in the same file), #23124 (travel schedules not reaching
non-default availability schedules, a defect upstream of this one) and #29501
(a feature request for per-override timezones).

## Visual Demo (For contributors especially)

N/A â€” no UI surface. The booking page renders whatever window is computed, so
before and after are two ordinary-looking but different sets of slots. The
meaningful evidence is the computed range, so it is given as test output.

Before, with the fix reverted and the new test in place:

```
FAIL packages/features/schedules/lib/date-ranges.test.ts > processDateOverrides >
  should end a 23:59 date override at midnight in the travel timezone

AssertionError: expected '2023-06-13T00:00:00-04:00' to deeply equal '2023-06-13T00:00:00+02:00'

Expected: "2023-06-13T00:00:00+02:00"
Received: "2023-06-13T00:00:00-04:00"

 Test Files  1 failed (1)
      Tests  1 failed | 50 passed | 2 skipped (53)
```

The same wall clock in two different zones â€” which is exactly the defect.

After, with this PR:

```
 Test Files  1 passed (1)
      Tests  51 passed | 2 skipped (53)
```

No collateral change across the availability suites:

```
 Test Files  3 passed (3)
      Tests  130 passed | 5 skipped (135)
```

#### Video Demo (if applicable):

N/A â€” no UI change.

#### Image Demo (if applicable):

N/A â€” no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. â€” N/A, internal availability calculation with no documented API change.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables, database or external services required.

```bash
TZ=UTC yarn vitest run packages/features/schedules/lib/date-ranges.test.ts
```

To see it fail without the fix, change `adjustedTimezone` back to `timeZone` on
the 23:59 branch in `date-ranges.ts` and re-run.

Both timezone passes that CI runs:

```bash
TZ=UTC yarn test -- --no-isolate
TZ=America/Los_Angeles VITEST_MODE=timezone yarn test -- --no-isolate
```

Wider availability coverage, green with the fix:

```bash
TZ=UTC yarn vitest run \
  packages/features/schedules/lib/date-ranges.test.ts \
  packages/features/schedules/lib/slots.test.ts \
  apps/web/test/lib/getSchedule.test.ts
```

Manual verification:

- **Minimal test data:** an organizer whose schedule timezone is
  `America/New_York`, with a travel schedule to `Europe/Berlin` covering
  12 June, and a date override on 12 June set to 9:00 AM â€“ 11:59 PM.
- **Expected (happy path):** the last bookable slot ends at midnight Berlin
  time. Before this change, slots continued to 6:00 AM Berlin time on the 13th.
- Repeat with a 9:00 AM â€“ 5:00 PM override to confirm the ordinary branch is
  unchanged, and with no travel schedule to confirm the change is a no-op.

I am an external contributor, so `required` will report red until a maintainer
applies the `run-ci` label. Happy to adjust anything.

## Checklist
