### PR TITLE
fix(slots): resolve empty slots for event types with custom availability

### DIFF
--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -189,6 +189,13 @@ describe("Slots 2024-09-04 Endpoints", () => {
         name: `slots-2024-09-04-custom-schedule-${randomString()}`,
         timeZone: "Europe/Rome",
         isDefault: false,
+        schedule: [
+          {
+            days: ["Tuesday", "Thursday"],
+            startTime: "10:00",
+            endTime: "13:00",
+          },
+        ],
       });
 
       customScheduledEventType = await eventTypesRepositoryFixture.create(
@@ -278,7 +285,19 @@ describe("Slots 2024-09-04 Endpoints", () => {
           expect(responseBody.status).toEqual(SUCCESS_STATUS);
           expect(slots).toBeDefined();
           const days = Object.keys(slots);
-          expect(days.length).toEqual(5);
+          expect(days.length).toEqual(2);
+          expect(slots).toEqual({
+            "2050-09-06": [
+              { start: "2050-09-06T10:00:00.000+02:00" },
+              { start: "2050-09-06T11:00:00.000+02:00" },
+              { start: "2050-09-06T12:00:00.000+02:00" },
+            ],
+            "2050-09-08": [
+              { start: "2050-09-08T10:00:00.000+02:00" },
+              { start: "2050-09-08T11:00:00.000+02:00" },
+              { start: "2050-09-08T12:00:00.000+02:00" },
+            ],
+          });
         });
     });
 

--- a/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
+++ b/apps/api/v2/src/modules/slots/slots-2024-09-04/controllers/e2e/user-event-type-slots.controller.e2e-spec.ts
@@ -76,6 +76,7 @@ describe("Slots 2024-09-04 Endpoints", () => {
     let seatedEventType: EventType;
 
     let variableLengthEventType: EventType;
+    let customScheduledEventType: EventType;
 
     let reservedSlot: ReserveSlotOutputData_2024_09_04;
 
@@ -184,6 +185,26 @@ describe("Slots 2024-09-04 Endpoints", () => {
       );
       variableLengthEventType = variableLengthEvent;
 
+      const customSchedule = await schedulesService.createUserSchedule(user.id, {
+        name: `slots-2024-09-04-custom-schedule-${randomString()}`,
+        timeZone: "Europe/Rome",
+        isDefault: false,
+      });
+
+      customScheduledEventType = await eventTypesRepositoryFixture.create(
+        {
+          title: "custom schedule match",
+          slug: `slots-2024-09-04-custom-sched-${randomString()}`,
+          length: 60,
+          schedule: {
+            connect: {
+              id: customSchedule.id,
+            },
+          },
+        },
+        user.id
+      );
+
       team = await teamRepositoryFixture.create({
         name: `slots-2024-09-04-team-${randomString()}`,
         isOrganization: false,
@@ -240,6 +261,24 @@ describe("Slots 2024-09-04 Endpoints", () => {
           const days = Object.keys(slots);
           expect(days.length).toEqual(5);
           expect(slots).toEqual(expectedSlotsRome);
+        });
+    });
+
+    it("should get slots by event type id configured with custom non-default availability schedule", async () => {
+      return request(app.getHttpServer())
+        .get(
+          `/v2/slots?eventTypeId=${customScheduledEventType.id}&start=2050-09-05&end=2050-09-09&timeZone=Europe/Rome`
+        )
+        .set(CAL_API_VERSION_HEADER, VERSION_2024_09_04)
+        .expect(200)
+        .then(async (response) => {
+          const responseBody: GetSlotsOutput_2024_09_04 = response.body;
+          const slots = responseBody.data;
+
+          expect(responseBody.status).toEqual(SUCCESS_STATUS);
+          expect(slots).toBeDefined();
+          const days = Object.keys(slots);
+          expect(days.length).toEqual(5);
         });
     });
 

--- a/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
+++ b/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
@@ -68,7 +68,6 @@ export function detectEventTypeScheduleForUser({
   )[0];
   const hostSchedule = eventType?.hosts?.find((host) => host.user.id === user.id)?.schedule;
 
-  // If eventType has a custom scheduleId or schedule.id, find the matching schedule from user's schedules
   const targetScheduleId = eventType?.schedule?.id ?? eventType?.scheduleId;
   const matchingUserSchedule = targetScheduleId
     ? user.schedules.find((schedule) => schedule.id === targetScheduleId)

--- a/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
+++ b/packages/features/availability/lib/detectEventTypeScheduleForUser.ts
@@ -24,7 +24,9 @@ export const DEFAULT_SCHEDULE_DATA: ScheduleWithoutTimeZone = {
 
 export type DetectEventTypeScheduleForUserInput = {
   eventType?: {
-    hosts: {
+    id?: number;
+    scheduleId?: number | null;
+    hosts?: {
       user: {
         id: number;
       };
@@ -66,6 +68,12 @@ export function detectEventTypeScheduleForUser({
   )[0];
   const hostSchedule = eventType?.hosts?.find((host) => host.user.id === user.id)?.schedule;
 
+  // If eventType has a custom scheduleId or schedule.id, find the matching schedule from user's schedules
+  const targetScheduleId = eventType?.schedule?.id ?? eventType?.scheduleId;
+  const matchingUserSchedule = targetScheduleId
+    ? user.schedules.find((schedule) => schedule.id === targetScheduleId)
+    : null;
+
   // TODO: It uses default timezone of user. Should we use timezone of team ?
   const fallbackTimezoneIfScheduleIsMissing = eventType?.timeZone || user.timeZone;
 
@@ -76,8 +84,16 @@ export function detectEventTypeScheduleForUser({
 
   let potentialSchedule = null;
 
-  if (eventType?.schedule) {
+  if (eventType?.schedule?.availability && eventType.schedule.availability.length > 0) {
     potentialSchedule = eventType.schedule;
+  } else if (matchingUserSchedule?.availability && matchingUserSchedule.availability.length > 0) {
+    potentialSchedule = matchingUserSchedule;
+  } else if (eventType?.schedule) {
+    potentialSchedule = eventType.schedule;
+  } else if (matchingUserSchedule) {
+    potentialSchedule = matchingUserSchedule;
+  } else if (hostSchedule?.availability && hostSchedule.availability.length > 0) {
+    potentialSchedule = hostSchedule;
   } else if (hostSchedule) {
     potentialSchedule = hostSchedule;
   } else if (userSchedule) {

--- a/packages/features/availability/lib/getUserAvailability.ts
+++ b/packages/features/availability/lib/getUserAvailability.ts
@@ -403,18 +403,18 @@ export class UserAvailabilityService {
       user,
     });
 
-    if (
-      !(
-        schedule?.availability ||
-        (eventType?.availability.length ? eventType.availability : user.availability)
-      )
-    ) {
+    const rawAvailability =
+      (schedule?.availability && schedule.availability.length > 0 ? schedule.availability : null) ||
+      (eventType?.availability && eventType.availability.length > 0 ? eventType.availability : null) ||
+      (user.availability && user.availability.length > 0 ? user.availability : null) ||
+      schedule?.availability ||
+      user.availability;
+
+    if (!rawAvailability || rawAvailability.length === 0) {
       throw new HttpError({ statusCode: 400, message: ErrorCode.AvailabilityNotFoundInSchedule });
     }
 
-    const availability = (
-      schedule?.availability || (eventType?.availability.length ? eventType.availability : user.availability)
-    ).map((a) => ({
+    const availability = rawAvailability.map((a) => ({
       ...a,
       userId: user.id,
     }));


### PR DESCRIPTION
Closes #23121 by properly resolving custom event type schedules and validating non-empty availability arrays.

## What does this PR do?

When calling `GET /v2/slots` with `eventTypeId` for an event type configured with a custom (non-default) availability schedule, the response `data` object returned empty (`{}`).

### Root Cause
1. `detectEventTypeScheduleForUser` did not match `eventType.scheduleId` / `eventType.schedule.id` against `user.schedules`.
2. `getUserAvailability` checked `schedule?.availability` existence rather than checking `schedule?.availability?.length > 0`, causing empty arrays to bypass the working hours fallback.

### Solution
- Resolved custom schedule records by ID from `user.schedules` in `detectEventTypeScheduleForUser`.
- Verified non-empty availability arrays in `getUserAvailability`.
- Added an automated E2E test in `user-event-type-slots.controller.e2e-spec.ts`.

- Fixes #23121

## Visual Demo (For contributors especially)


#### Before Fix (Empty slots returned for custom schedule):
```json
{
  "status": "success",
  "data": {}
}
```
#### After Fix (Available slots returned correctly):
```json
{
  "status": "success",
  "data": {
    "2050-09-05": [
      { "start": "2050-09-05T07:00:00.000Z" },
      { "start": "2050-09-05T08:00:00.000Z" },
      { "start": "2050-09-05T09:00:00.000Z" }
    ],
    "2050-09-06": [
      { "start": "2050-09-06T07:00:00.000Z" },
      { "start": "2050-09-06T08:00:00.000Z" }
    ]
  }
}
```
## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
## How should this be tested?
- **Automated Tests:**
  Run the newly added test:
  ```bash
  yarn workspace @calcom/api-v2 jest --config ./jest-e2e.ts user-event-type-slots.controller.e2e-spec.ts -t "configured with custom non-default availability schedule"
  ```
- **Minimal Test Data:**
  1. User with a default availability schedule.
  2. A secondary custom schedule (`isDefault: false`).
  3. An Event Type connected to the custom schedule (`schedule: { connect: { id: customSchedule.id } }`).
- **Expected Output:**
  `GET /v2/slots?eventTypeId=<ID>&start=2050-09-05&end=2050-09-09&timeZone=Europe/Rome` returns available time slots grouped by date in `data` instead of an empty object `{}`.