### PR TITLE
fix(app-store): correct WhatsApp location URL format

### DIFF
--- a/packages/app-store/locations.test.ts
+++ b/packages/app-store/locations.test.ts
@@ -9,6 +9,8 @@ describe("WhatsApp static location", () => {
     expect(guessEventLocationType("https://wa.me/send?phone=4712345678")).toBeUndefined();
     expect(guessEventLocationType("https://wa.me/+4712345678")).toBeUndefined();
     expect(guessEventLocationType("https://wa.me/4712345678?foo=bar")).toBeUndefined();
+    expect(guessEventLocationType("http://wa.me/4712345678")).toBeUndefined();
+    expect(guessEventLocationType("https://www.wa.me/4712345678")).toBeUndefined();
   });
 
   it("exposes the canonical wa.me setup example", () => {

--- a/packages/app-store/locations.test.ts
+++ b/packages/app-store/locations.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getLocationFromApp, guessEventLocationType } from "./locations";
+
+describe("WhatsApp static location", () => {
+  it("accepts canonical links and rejects send links", () => {
+    expect(guessEventLocationType("https://wa.me/4712345678")).toEqual(
+      expect.objectContaining({ type: "integrations:whatsapp_video" })
+    );
+    expect(guessEventLocationType("https://wa.me/send?phone=4712345678")).toBeUndefined();
+    expect(guessEventLocationType("https://wa.me/+4712345678")).toBeUndefined();
+    expect(guessEventLocationType("https://wa.me/4712345678?foo=bar")).toBeUndefined();
+  });
+
+  it("exposes the canonical wa.me setup example", () => {
+    expect(getLocationFromApp("integrations:whatsapp_video")?.organizerInputPlaceholder?.trim()).toBe(
+      "https://wa.me/1234567890"
+    );
+  });
+});

--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -17,7 +17,7 @@
       "label": "WhatsApp",
       "linkType": "static",
       "organizerInputPlaceholder": "https://wa.me/1234567890",
-      "urlRegExp": "^https?:\\/\\/(www\\.)?wa\\.me\\/[0-9]+$"
+      "urlRegExp": "^https:\\/\\/wa\\.me\\/[0-9]+$"
     }
   },
   "isAuth": false

--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -16,8 +16,8 @@
       "type": "integrations:whatsapp_video",
       "label": "WhatsApp",
       "linkType": "static",
-      "organizerInputPlaceholder": "https://wa.me/send?phone=1234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa.me\\/[a-zA-Z0-9]*"
+      "organizerInputPlaceholder": "https://wa.me/1234567890",
+      "urlRegExp": "^https?:\\/\\/(www\\.)?wa\\.me\\/[0-9]+$"
     }
   },
   "isAuth": false


### PR DESCRIPTION
## What does this PR do?

Fixes #30118 by correcting the WhatsApp location setup example and tightening its URL matcher to accept only canonical wa.me/<phone number> links.

The previous placeholder used /send?phone=..., and the matcher accepted malformed URLs. The new config uses https://wa.me/1234567890 and rejects /send, +, and query-string suffixes.

## Visual Demo

N/A — this is a configuration-only app-store metadata change.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. N/A for this configuration-only fix.
- [x] I confirm automated tests are in place that prove my fix is effective.

## How should this be tested?

- Run the focused test: yarn test packages/app-store/locations.test.ts --run
- Run Biome on the changed files: yarn biome check packages/app-store/whatsapp/config.json packages/app-store/locations.test.ts
- Expected behavior: https://wa.me/4712345678 is accepted; /send, +, and query-string variants are rejected.

Local verification completed: Biome passed, config behavior assertions passed, and git diff checks passed. Focused Vitest and the repository type-check could not complete in this checkout because the immutable Yarn link step left the local node_modules state incomplete and generated Prisma dependencies unavailable.

## Checklist

No additional checklist items apply.