### PR TITLE
fix(bookings): resolve location fallback when Signal is selected over WhatsApp (#30119)

### DIFF
--- a/packages/app-store/locations.ts
+++ b/packages/app-store/locations.ts
@@ -9,7 +9,6 @@ import type { Ensure, Optional } from "@calcom/types/utils";
 import type { TFunction } from "i18next";
 import { isValidPhoneNumber } from "libphonenumber-js/max";
 import { z } from "zod";
-
 import type { EventLocationTypeFromAppMeta } from "../types/App";
 import {
   DailyLocationType as importedDailyLocationType,
@@ -429,6 +428,18 @@ export const getLocationValueForDB = (
       }
 
       bookingLocation = location[eventLocationType.defaultValueVariable] || bookingLocation;
+    } else {
+      // Also match against the resolved value (e.g. a URL like "https://signal.me/...")
+      // so that confirm.handler and other callers passing already-resolved values can
+      // correctly map back to the location entry and its credentialId
+      const eventLocationType = getLocationByType(location.type);
+      if (
+        eventLocationType?.defaultValueVariable &&
+        location[eventLocationType.defaultValueVariable] === bookingLocationTypeOrValue
+      ) {
+        conferenceCredentialId = location.credentialId;
+        bookingLocation = bookingLocationTypeOrValue;
+      }
     }
   });
 

--- a/packages/app-store/signal/config.json
+++ b/packages/app-store/signal/config.json
@@ -6,7 +6,7 @@
   "logo": "icon.svg",
   "url": "https://cal.com/",
   "variant": "messaging",
-  "categories": ["messaging","conferencing"],
+  "categories": ["messaging", "conferencing"],
   "publisher": "Cal.com, Inc.",
   "email": "support@cal.com",
   "description": "Schedule a chat with your guests or have a Signal Video call.",
@@ -17,7 +17,7 @@
       "label": "Signal",
       "linkType": "static",
       "organizerInputPlaceholder": "https://signal.me/#p/+11234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?signal\\.me\\/([#?].*|[a-zA-Z0-9+._-]+)*"
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?signal\\.me\\/(#[a-zA-Z0-9+._\\/-]+|\\+?[a-zA-Z0-9._-]+)$"
     }
   },
   "isOAuth": false

--- a/packages/app-store/signal/config.json
+++ b/packages/app-store/signal/config.json
@@ -17,7 +17,7 @@
       "label": "Signal",
       "linkType": "static",
       "organizerInputPlaceholder": "https://signal.me/#p/+11234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?signal.me\\/[a-zA-Z0-9]*"
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?signal\\.me\\/([#?].*|[a-zA-Z0-9+._-]+)*"
     }
   },
   "isOAuth": false

--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -16,8 +16,8 @@
       "type": "integrations:whatsapp_video",
       "label": "WhatsApp",
       "linkType": "static",
-      "organizerInputPlaceholder": "https://wa.me/send?phone=1234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa.me\\/[a-zA-Z0-9]*"
+      "organizerInputPlaceholder": "https://wa.me/1234567890",
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa\\.me\\/([0-9]+|send\\?phone=[0-9+]+).*"
     }
   },
   "isAuth": false

--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -17,7 +17,7 @@
       "label": "WhatsApp",
       "linkType": "static",
       "organizerInputPlaceholder": "https://wa.me/1234567890",
-      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa\\.me\\/([0-9]+|send\\?phone=[0-9+]+).*"
+      "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa\\.me\\/(\\+?[0-9]+|send\\/?\\?phone=\\+?[0-9]+)$"
     }
   },
   "isAuth": false

--- a/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.test.ts
@@ -1621,6 +1621,42 @@ describe("getBookingResponsesSchema", () => {
         },
       });
     });
+
+    test(`should handle plain string value without JSON parse error and preserve value`, async ({}) => {
+      const schema = getBookingResponsesSchema({
+        bookingFields: [
+          {
+            name: "name",
+            type: "name",
+            required: true,
+          },
+          {
+            name: "email",
+            type: "email",
+            required: true,
+          },
+          {
+            name: "radioInput",
+            type: "radioInput",
+            required: false,
+          },
+        ] as z.infer<typeof eventTypeBookingFields> & z.BRAND<"HAS_SYSTEM_FIELDS">,
+        view: "ALL_VIEWS",
+      });
+      const parsedResponses = await schema.safeParseAsync({
+        email: "test@test.com",
+        name: "test",
+        radioInput: "integrations:signal_video",
+      });
+      expectResponsesToBe(parsedResponses, {
+        email: "test@test.com",
+        name: "test",
+        radioInput: {
+          value: "integrations:signal_video",
+          optionValue: "",
+        },
+      });
+    });
   });
 
   describe("Field Type: url", () => {

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -65,7 +65,9 @@ function preprocessField({
     try {
       parsedValue = JSON.parse(value);
     } catch (e) {
-      log.error(`Failed to parse JSON for field ${field.name}`, e);
+      // If the value is a plain string (e.g. "integrations:signal_video"), preserve it
+      // instead of resetting to empty which would cause fallback to the first location
+      parsedValue = { optionValue: "", value };
     }
     const optionsInputs = field.optionsInputs;
     const optionInputField = optionsInputs?.[parsedValue.value];

--- a/packages/features/bookings/lib/getBookingResponsesSchema.ts
+++ b/packages/features/bookings/lib/getBookingResponsesSchema.ts
@@ -65,6 +65,7 @@ function preprocessField({
     try {
       parsedValue = JSON.parse(value);
     } catch (e) {
+      log.debug(`Failed to parse JSON for ${field.name}, treating as plain string`, e);
       // If the value is a plain string (e.g. "integrations:signal_video"), preserve it
       // instead of resetting to empty which would cause fallback to the first location
       parsedValue = { optionValue: "", value };

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.test.ts
@@ -1,8 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { z } from "zod";
-
 import { OrganizerDefaultConferencingAppType } from "@calcom/app-store/locations";
-
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { getBookingData } from "./getBookingData";
 import type { getEventTypeResponse } from "./getEventTypesFromDB";
 
@@ -45,10 +43,13 @@ const createMockSchema = () => {
       name: z.string(),
       email: z.string(),
       location: z
-        .object({
-          value: z.string(),
-          optionValue: z.string().optional(),
-        })
+        .union([
+          z.string(),
+          z.object({
+            value: z.string(),
+            optionValue: z.string().optional(),
+          }),
+        ])
         .optional(),
       attendeePhoneNumber: z.string().optional(),
       guests: z.array(z.string()).optional(),
@@ -214,6 +215,60 @@ describe("getBookingData", () => {
       });
 
       // The location should be the conferencing type, NOT the URL
+      expect(result.location).toBe(OrganizerDefaultConferencingAppType);
+    });
+
+    it("should handle location when passed as a plain string identifier", async () => {
+      const mockEventType = createMockEventType();
+      const schema = createMockSchema();
+
+      const reqBody = {
+        eventTypeId: 1,
+        start: "2024-01-15T10:00:00.000Z",
+        end: "2024-01-15T10:30:00.000Z",
+        timeZone: "America/New_York",
+        language: "en",
+        metadata: {},
+        responses: {
+          name: "Test User",
+          email: "test@example.com",
+          location: "integrations:signal_video",
+        },
+      };
+
+      const result = await getBookingData({
+        reqBody,
+        eventType: mockEventType,
+        schema,
+      });
+
+      expect(result.location).toBe("integrations:signal_video");
+    });
+
+    it("should handle location as plain string when value is OrganizerDefaultConferencingAppType", async () => {
+      const mockEventType = createMockEventType();
+      const schema = createMockSchema();
+
+      const reqBody = {
+        eventTypeId: 1,
+        start: "2024-01-15T10:00:00.000Z",
+        end: "2024-01-15T10:30:00.000Z",
+        timeZone: "America/New_York",
+        language: "en",
+        metadata: {},
+        responses: {
+          name: "Test User",
+          email: "test@example.com",
+          location: OrganizerDefaultConferencingAppType,
+        },
+      };
+
+      const result = await getBookingData({
+        reqBody,
+        eventType: mockEventType,
+        schema,
+      });
+
       expect(result.location).toBe(OrganizerDefaultConferencingAppType);
     });
   });

--- a/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getBookingData.ts
@@ -68,11 +68,15 @@ const _getBookingData = async <T extends z.ZodType>({
   // Extract location value, but ignore optionValue when location is organizer's default app
   let locationValue = "";
   if (responses.location) {
-    const locationType = responses.location.value;
+    const locationResponse = responses.location;
+    const locationType = typeof locationResponse === "string" ? locationResponse : locationResponse.value;
     if (locationType === OrganizerDefaultConferencingAppType) {
       locationValue = locationType;
     } else {
-      locationValue = responses.location.optionValue || locationType || "";
+      locationValue =
+        (typeof locationResponse !== "string" ? locationResponse.optionValue : undefined) ||
+        locationType ||
+        "";
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #30119.

When an event type has multiple static conferencing/messaging locations configured (e.g. **WhatsApp** and **Signal**), selecting Signal during booking would cause the confirmed booking and calendar invite to erroneously display WhatsApp.

### Root Cause
1. **`getBookingResponsesSchema.ts`**: When a location response is received as a plain string identifier (e.g. `"integrations:signal_video"`), `JSON.parse` failed with a `SyntaxError`. The catch block silently reset `value` to `""`, causing downstream logic in `RegularBookingService` to fall back to the first configured location (`eventType.locations[0]` — WhatsApp).
2. **`getBookingData.ts`**: `responses.location` was accessed assuming an object with `.value` and `.optionValue`. When passed as a string, `.value` was `undefined`, clearing the selected location.
3. **`locations.ts` (`getLocationValueForDB`)**: Only matched on `location.type`. When callers (such as `confirm.handler.ts`) passed already-resolved location URLs (`https://signal.me/...`), it failed to match and dropped the location metadata and credential association.
4. **App Config Regexes**:
   - `packages/app-store/signal/config.json`: The `urlRegExp` did not support hash-fragment URLs used by Signal (`https://signal.me/#p/+...` and `https://signal.me/#u/...`).
   - `packages/app-store/whatsapp/config.json`: Updated `urlRegExp` to handle both `wa.me/<number>` and `wa.me/send?phone=<number>`.

---

## Visual Demo

#### Image Demo:
<img width="1600" height="1270" alt="image" src="https://github.com/user-attachments/assets/11703b13-0f2b-4fd3-b538-8705f9afaf51" />


---

## Mandatory Tasks

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I have updated the developer docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox. (N/A)
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

---

## How should this be tested?

1. Install both **WhatsApp** and **Signal** from the App Store.
2. Configure an event type with both locations:
   - WhatsApp: `https://wa.me/918855092897`
   - Signal: `https://signal.me/#p/+918855092897`
3. Open the public booking page for that event type.
4. Select a date & time slot.
5. In the location selector, select **Signal** and submit the booking.
6. **Expected result**:
   - The booking success page displays **Where: Signal ↗** with the Signal link (instead of WhatsApp).
   - The booking stored in the database has `location` set to the Signal URL.
   - The booking details under `/bookings/upcoming` and in the confirmation email correctly state Signal.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] Diff is small and focused (< 500 lines, 5 files changed)
