### PR TITLE
fix(embed-core): add null check for this.iframe in __iframeReady handler (#30130)

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -461,7 +461,10 @@ export class Cal {
 
     this.actionManager.on("__iframeReady", (e) => {
       this.iframeReady = true;
-      if (this.iframe && !e.detail.data.isPrerendering) {
+      if (!this.iframe) {
+        return;
+      }
+      if (!e.detail.data.isPrerendering) {
         // It's a bit late to make the iframe visible here. We just needed to wait for the HTML tag of the embedded calLink to be rendered(which then informs the browser of the color-scheme)
         // TODO: Right now it would wait for embed-iframe.js bundle to be loaded as well. We can speed that up by inlining the JS that informs about color-scheme being set in the HTML.
         // But it's okay to do it here for now because the embedded calLink also keeps itself hidden till it receives `parentKnowsIframeReady` message(It has it's own reasons for that)


### PR DESCRIPTION
## Description
In \packages/embeds/embed-core/src/embed.ts\, the \__iframeReady\ action handler previously checked \if (this.iframe && !e.detail.data.isPrerendering)\ before updating style visibility, but subsequently invoked \	his.doInIframe(...) \ without ensuring \	his.iframe\ is defined. Because \doInIframe\ assumes \	his.iframe\ exists when \	his.iframeReady\ is set to true, this could lead to uncaught errors if the iframe instance is not present.

This PR adds an early return check \if (!this.iframe) { return; }\ inside the \__iframeReady\ handler, bringing it in line with guards used in other action listeners.

Fixes #30130