### PR TITLE
feat(bookings): add booking UID copy action

### DIFF
--- a/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
+++ b/apps/web/modules/bookings/components/BookingDetailsSheet.tsx
@@ -31,8 +31,8 @@ import {
   SheetTitle,
 } from "@calcom/ui/components/sheet";
 import { Tooltip } from "@calcom/ui/components/tooltip";
-import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import { BookingHistory } from "@calcom/web/modules/booking-audit/components/BookingHistory";
+import { ExternalLinkIcon, RepeatIcon } from "@coss/ui/icons";
 import assignmentReasonBadgeTitleMap from "@lib/booking/assignmentReasonBadgeTitleMap";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -43,12 +43,13 @@ import { BookingActionsStoreProvider } from "../../../components/booking/actions
 import { RejectBookingButton } from "../../../components/booking/RejectBookingButton";
 import type { BookingListingStatus } from "../../../components/booking/types";
 import { usePaymentStatus } from "../hooks/usePaymentStatus";
-import { useBookingDetailsSheetStore } from "../store/bookingDetailsSheetStore";
-import type { BookingOutput } from "../types";
 import {
   checkSheetActive,
   createBookingSheetKeydownHandler,
 } from "../lib/bookingSheetKeyboardHandler";
+import { useBookingDetailsSheetStore } from "../store/bookingDetailsSheetStore";
+import type { BookingOutput } from "../types";
+import { BookingUid } from "./BookingUid";
 import { JoinMeetingButton } from "./JoinMeetingButton";
 
 type BookingMetaData = z.infer<typeof bookingMetadataSchema>;
@@ -390,6 +391,10 @@ function BookingDetailsSheetInner({
                   timeZone={userTimeZone}
                   previousBooking={bookingDetails?.previousBooking}
                 />
+
+                <Section title={t("booking_uid")}>
+                  <BookingUid uid={booking.uid} />
+                </Section>
 
                 <OldRescheduledBookingInfo
                   booking={booking}

--- a/apps/web/modules/bookings/components/BookingUid.test.tsx
+++ b/apps/web/modules/bookings/components/BookingUid.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ButtonHTMLAttributes, ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BookingUid } from "./BookingUid";
+
+const copyToClipboard: ReturnType<typeof vi.fn> = vi.fn();
+let isCopied = false;
+
+vi.mock("@calcom/lib/hooks/useCopy", () => ({
+  useCopy: () => ({ copyToClipboard, isCopied }),
+}));
+
+vi.mock("@calcom/lib/hooks/useLocale", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@calcom/ui/components/button", () => ({
+  Button: ({
+    StartIcon,
+    tooltip: _,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { StartIcon: string; tooltip: string }): ReactElement => (
+    <button data-icon={StartIcon} {...props} />
+  ),
+}));
+
+describe("BookingUid", () => {
+  beforeEach(() => {
+    copyToClipboard.mockClear();
+    isCopied = false;
+  });
+
+  it("shows and copies the booking UID", () => {
+    render(<BookingUid uid="booking-123" />);
+
+    expect(screen.getByText("booking-123")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "copy_to_clipboard" }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith("booking-123");
+  });
+
+  it("shows copied feedback", () => {
+    isCopied = true;
+
+    render(<BookingUid uid="booking-123" />);
+
+    const button = screen.getByRole("button", { name: "copied" });
+    expect(button).toHaveAttribute("data-icon", "clipboard-check");
+  });
+});

--- a/apps/web/modules/bookings/components/BookingUid.tsx
+++ b/apps/web/modules/bookings/components/BookingUid.tsx
@@ -1,0 +1,34 @@
+import { useCopy } from "@calcom/lib/hooks/useCopy";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { Button } from "@calcom/ui/components/button";
+import type { ReactElement } from "react";
+
+export function BookingUid({ uid }: { uid: string }): ReactElement {
+  const { copyToClipboard, isCopied } = useCopy();
+  const { t } = useLocale();
+  let copyLabel = t("copy_to_clipboard");
+  let copyIcon: "clipboard" | "clipboard-check" = "clipboard";
+
+  if (isCopied) {
+    copyLabel = t("copied");
+    copyIcon = "clipboard-check";
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <code className="truncate font-mono text-default text-sm" title={uid}>
+        {uid}
+      </code>
+      <Button
+        type="button"
+        variant="icon"
+        color="minimal"
+        size="sm"
+        StartIcon={copyIcon}
+        tooltip={copyLabel}
+        aria-label={copyLabel}
+        onClick={(): void => copyToClipboard(uid)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Adds the booking UID to the booking details sheet with a one-click copy action. The control includes an accessible label, tooltip, and temporary copied-state feedback, making booking references easier to share during support and debugging workflows.

No schema changes or new dependencies are required.

## Visual Demo

The new Booking UID row appears directly below the booking time in the details sheet.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] Documentation changes are N/A for this small UI enhancement.
- [x] Automated tests prove the UID is displayed, copied, and reports copied-state feedback.

## How should this be tested?

1. Open the Bookings page with Bookings V3 enabled.
2. Select any booking to open its details sheet.
3. Confirm the Booking UID is shown below the time.
4. Select the copy icon and confirm the icon and accessible label change to the copied state.
5. Paste the clipboard contents and confirm they match the displayed UID.

Automated verification:

- TZ=UTC yarn vitest run apps/web/modules/bookings/components/BookingUid.test.tsx
- yarn biome lint on the three changed files
- NODE_OPTIONS=--max-old-space-size=8192 yarn type-check:ci --force