### PR TITLE
fix: correctly format zero-decimal currencies in no-show fee dialogs and emails (#30122)

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -3,6 +3,7 @@
 import { sdkActionManager } from "@calcom/embed-core/embed-iframe";
 import { isCancellationReasonRequired } from "@calcom/features/bookings/lib/cancellationReason";
 import { shouldChargeNoShowCancellationFee } from "@calcom/features/bookings/lib/payment/shouldChargeNoShowCancellationFee";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRefreshData } from "@calcom/lib/hooks/useRefreshData";
 import type { CancellationReasonRequirement } from "@calcom/prisma/enums";
@@ -252,7 +253,10 @@ export default function CancelBooking(props: Props) {
                   description={t("cancel_booking_acknowledge_no_show_fee", {
                     timeValue,
                     timeUnit,
-                    amount: booking.payment.amount / 100,
+                    amount: convertFromSmallestToPresentableCurrencyUnit(
+                      booking.payment.amount,
+                      booking.payment.currency
+                    ),
                     formatParams: { amount: { currency: booking.payment.currency } },
                   })}
                   onChange={(e) => setAcknowledgeCancellationNoShowFee(e.target.checked)}

--- a/apps/web/components/dialog/ChargeCardDialog.tsx
+++ b/apps/web/components/dialog/ChargeCardDialog.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
@@ -34,7 +35,7 @@ export const ChargeCardDialog = (props: IRescheduleDialog) => {
   };
 
   const currencyStringParams = {
-    amount: props.paymentAmount / 100.0,
+    amount: convertFromSmallestToPresentableCurrencyUnit(props.paymentAmount, props.paymentCurrency),
     formatParams: { amount: { currency: props.paymentCurrency } },
   };
 

--- a/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
+++ b/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { BaseScheduledEmail } from "./BaseScheduledEmail";
@@ -24,7 +25,10 @@ export const NoShowFeeChargedEmail = (
       subtitle={
         <>
           {t("no_show_fee_charged_subtitle", {
-            amount: calEvent.paymentInfo.amount / 100,
+            amount: convertFromSmallestToPresentableCurrencyUnit(
+              calEvent.paymentInfo.amount,
+              calEvent.paymentInfo.currency || "USD"
+            ),
             formatParams: { amount: { currency: calEvent.paymentInfo?.currency } },
           })}
         </>

--- a/packages/emails/templates/no-show-fee-charged-email.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.ts
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import renderEmail from "../src/renderEmail";
@@ -13,7 +14,10 @@ export default class NoShowFeeChargedEmail extends AttendeeScheduledEmail {
       subject: `${this.attendee.language.translate("no_show_fee_charged_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),
-        amount: this.calEvent.paymentInfo.amount / 100,
+        amount: convertFromSmallestToPresentableCurrencyUnit(
+          this.calEvent.paymentInfo.amount,
+          this.calEvent.paymentInfo.currency || "USD"
+        ),
         formatParams: { amount: { currency: this.calEvent.paymentInfo?.currency } },
       })}`,
       html: await renderEmail("NoShowFeeChargedEmail", {


### PR DESCRIPTION
### Summary of Changes
Fixes #30122

In the no-show fee (HOLD) cancellation and charge flows, four UI surfaces and email templates were dividing `Payment.amount` by 100 unconditionally (`amount / 100`). For the 16 zero-decimal currencies (JPY, KRW, VND, etc.), this caused prompts, dialogs, and emails to display 1/100th of the charged amount (e.g. ¥5,000 displayed as ¥50) while the user was charged ¥5,000.

### Changes Made:
- Replaced unconditional `/ 100` divisions with `convertFromSmallestToPresentableCurrencyUnit(amount, currency)` across:
  - `apps/web/components/booking/CancelBooking.tsx`
  - `apps/web/components/dialog/ChargeCardDialog.tsx`
  - `packages/emails/templates/no-show-fee-charged-email.ts`
  - `packages/emails/src/templates/NoShowFeeChargedEmail.tsx`

### Verification:
- Verified that zero-decimal currencies (e.g. JPY, KRW) display unscaled integer figures (¥5,000).
- Verified that standard currencies with minor units (e.g. USD, EUR) continue to display formatted decimal figures ($50.00).