### PR TITLE
fix(embed-core): add iframe existence guard in __iframeReady handler (Issue #30130) [0x5ea575c120018f5f2e266d781e43f335aaaf3be6]

### DIFF
--- a/packages/embeds/embed-core/src/embed.ts
+++ b/packages/embeds/embed-core/src/embed.ts
@@ -460,8 +460,12 @@ export class Cal {
     });
 
     this.actionManager.on("__iframeReady", (e) => {
+      // Guard: if iframe doesn't exist (e.g., was destroyed during navigation), do not mark ready or call doInIframe
+      if (!this.iframe) {
+        return;
+      }
       this.iframeReady = true;
-      if (this.iframe && !e.detail.data.isPrerendering) {
+      if (!e.detail.data.isPrerendering) {
         // It's a bit late to make the iframe visible here. We just needed to wait for the HTML tag of the embedded calLink to be rendered(which then informs the browser of the color-scheme)
         // TODO: Right now it would wait for embed-iframe.js bundle to be loaded as well. We can speed that up by inlining the JS that informs about color-scheme being set in the HTML.
         // But it's okay to do it here for now because the embedded calLink also keeps itself hidden till it receives `parentKnowsIframeReady` message(It has it's own reasons for that)


### PR DESCRIPTION
## Summary
Fixes the bug where \__iframeReady\ handler calls \doInIframe\ without checking if iframe exists, causing errors when the handler fires after the iframe has been destroyed during navigation.

## Changes
- Added iframe existence guard in \__iframeReady\ handler before setting \iframeReady = true\ and calling \doInIframe\
- Moved the iframe existence check to the top of the handler, before setting \iframeReady = true\ and calling \doInIframe\

## Root Cause
The \__iframeReady\ handler was setting \iframeReady = true\ and calling \doInIframe\ before checking if \	his.iframe\ exists. During client-side navigation, the iframe can be destroyed while the event listener remains active, causing \doInIframe\ to throw 'iframe doesn't exist' error.

## Fix
Added early return guard at the start of the handler:
\\\	ypescript
if (!this.iframe) {
  return;
}
\\\

## Verification
- Fix matches the exact suggestion in the issue description
- No existing tests broken (no existing tests for this handler)
- TypeScript compilation passes

## Payout
Binance EVM: 0x5ea575c120018f5f2e266d781e43f335aaaf3be6

/claim #30130

Closes #30130