### PR TITLE
fix(billing): use convertFromSmallestToPresentableCurrencyUnit for no-show fee currency formatting

### DIFF
--- a/apps/web/components/booking/CancelBooking.tsx
+++ b/apps/web/components/booking/CancelBooking.tsx
@@ -3,6 +3,7 @@
 import { sdkActionManager } from "@calcom/embed-core/embed-iframe";
 import { isCancellationReasonRequired } from "@calcom/features/bookings/lib/cancellationReason";
 import { shouldChargeNoShowCancellationFee } from "@calcom/features/bookings/lib/payment/shouldChargeNoShowCancellationFee";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRefreshData } from "@calcom/lib/hooks/useRefreshData";
 import type { CancellationReasonRequirement } from "@calcom/prisma/enums";
@@ -252,7 +253,10 @@ export default function CancelBooking(props: Props) {
                   description={t("cancel_booking_acknowledge_no_show_fee", {
                     timeValue,
                     timeUnit,
-                    amount: booking.payment.amount / 100,
+                    amount: convertFromSmallestToPresentableCurrencyUnit(
+                      booking.payment.amount,
+                      booking.payment.currency
+                    ),
                     formatParams: { amount: { currency: booking.payment.currency } },
                   })}
                   onChange={(e) => setAcknowledgeCancellationNoShowFee(e.target.checked)}

--- a/apps/web/components/dialog/ChargeCardDialog.tsx
+++ b/apps/web/components/dialog/ChargeCardDialog.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 
 import { Dialog } from "@calcom/features/components/controlled-dialog";
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
 import { Button } from "@calcom/ui/components/button";
@@ -34,7 +35,7 @@ export const ChargeCardDialog = (props: IRescheduleDialog) => {
   };
 
   const currencyStringParams = {
-    amount: props.paymentAmount / 100.0,
+    amount: convertFromSmallestToPresentableCurrencyUnit(props.paymentAmount, props.paymentCurrency),
     formatParams: { amount: { currency: props.paymentCurrency } },
   };
 

--- a/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
+++ b/packages/emails/src/templates/NoShowFeeChargedEmail.tsx
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import type { CalendarEvent, Person } from "@calcom/types/Calendar";
 
 import { BaseScheduledEmail } from "./BaseScheduledEmail";
@@ -24,7 +25,10 @@ export const NoShowFeeChargedEmail = (
       subtitle={
         <>
           {t("no_show_fee_charged_subtitle", {
-            amount: calEvent.paymentInfo.amount / 100,
+            amount: convertFromSmallestToPresentableCurrencyUnit(
+              calEvent.paymentInfo.amount,
+              calEvent.paymentInfo?.currency ?? "USD"
+            ),
             formatParams: { amount: { currency: calEvent.paymentInfo?.currency } },
           })}
         </>

--- a/packages/emails/templates/no-show-fee-charged-email.ts
+++ b/packages/emails/templates/no-show-fee-charged-email.ts
@@ -1,3 +1,4 @@
+import { convertFromSmallestToPresentableCurrencyUnit } from "@calcom/lib/currencyConversions";
 import { getReplyToHeader } from "@calcom/lib/getReplyToHeader";
 
 import renderEmail from "../src/renderEmail";
@@ -13,7 +14,10 @@ export default class NoShowFeeChargedEmail extends AttendeeScheduledEmail {
       subject: `${this.attendee.language.translate("no_show_fee_charged_email_subject", {
         title: this.calEvent.title,
         date: this.getFormattedDate(),
-        amount: this.calEvent.paymentInfo.amount / 100,
+        amount: convertFromSmallestToPresentableCurrencyUnit(
+          this.calEvent.paymentInfo.amount,
+          this.calEvent.paymentInfo?.currency ?? "USD"
+        ),
         formatParams: { amount: { currency: this.calEvent.paymentInfo?.currency } },
       })}`,
       html: await renderEmail("NoShowFeeChargedEmail", {

--- a/packages/lib/currencyConversions.test.ts
+++ b/packages/lib/currencyConversions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convertFromSmallestToPresentableCurrencyUnit,
+  convertToSmallestCurrencyUnit,
+} from "./currencyConversions";
+
+describe("currencyConversions", () => {
+  describe("convertFromSmallestToPresentableCurrencyUnit", () => {
+    it("converts two-decimal currencies by dividing by 100", () => {
+      expect(convertFromSmallestToPresentableCurrencyUnit(1000, "USD")).toBe(10);
+      expect(convertFromSmallestToPresentableCurrencyUnit(2550, "EUR")).toBe(25.5);
+    });
+
+    it("leaves zero-decimal currencies unchanged", () => {
+      expect(convertFromSmallestToPresentableCurrencyUnit(1000, "JPY")).toBe(1000);
+      expect(convertFromSmallestToPresentableCurrencyUnit(5000, "KRW")).toBe(5000);
+      expect(convertFromSmallestToPresentableCurrencyUnit(20000, "VND")).toBe(20000);
+    });
+  });
+
+  describe("convertToSmallestCurrencyUnit", () => {
+    it("converts two-decimal currencies by multiplying by 100", () => {
+      expect(convertToSmallestCurrencyUnit(10, "USD")).toBe(1000);
+      expect(convertToSmallestCurrencyUnit(25.5, "EUR")).toBe(2550);
+    });
+
+    it("leaves zero-decimal currencies unchanged", () => {
+      expect(convertToSmallestCurrencyUnit(1000, "JPY")).toBe(1000);
+      expect(convertToSmallestCurrencyUnit(5000, "KRW")).toBe(5000);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #30122

### Summary
No-show fee amounts in cancellation modals, email templates, and charge dialogs previously hardcoded `amount / 100`. For zero-decimal currencies (such as JPY, KRW, VND), payment amounts are stored unscaled in primary units, so dividing by 100 improperly formats the fee to 1/100th of its actual value.

This PR replaces hardcoded `amount / 100` with `convertFromSmallestToPresentableCurrencyUnit(amount, currency)` across `CancelBooking.tsx`, `ChargeCardDialog.tsx`, `NoShowFeeChargedEmail.tsx`, and `no-show-fee-charged-email.ts`.

### Key Changes
- Use `convertFromSmallestToPresentableCurrencyUnit(payment.amount, payment.currency)` instead of `payment.amount / 100`.
- Preserves correct formatting for both zero-decimal and 2-decimal currencies.