### PR TITLE
fix(whatsapp): use clean wa.me format for WhatsApp location input placeholder

### DIFF
--- a/packages/app-store/locations.test.ts
+++ b/packages/app-store/locations.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import whatsappConfig from "./whatsapp/config.json";
+
+describe("WhatsApp location configuration", () => {
+  it("uses the clean wa.me URL format for organizerInputPlaceholder without send?phone=", () => {
+    const placeholder = whatsappConfig.appData.location.organizerInputPlaceholder;
+    expect(placeholder).toBe("https://wa.me/1234567890");
+    expect(placeholder).not.toContain("send?phone=");
+    expect(placeholder).not.toContain("+");
+  });
+
+  it("validates clean wa.me URLs against urlRegExp", () => {
+    const regExp = new RegExp(whatsappConfig.appData.location.urlRegExp);
+    expect(regExp.test("https://wa.me/4712345678")).toBe(true);
+    expect(regExp.test("http://wa.me/1234567890")).toBe(true);
+  });
+});

--- a/packages/app-store/whatsapp/config.json
+++ b/packages/app-store/whatsapp/config.json
@@ -16,7 +16,7 @@
       "type": "integrations:whatsapp_video",
       "label": "WhatsApp",
       "linkType": "static",
-      "organizerInputPlaceholder": "https://wa.me/send?phone=1234567890",
+      "organizerInputPlaceholder": "https://wa.me/1234567890",
       "urlRegExp": "^http(s)?:\\/\\/(www\\.)?wa.me\\/[a-zA-Z0-9]*"
     }
   },


### PR DESCRIPTION
## Description
Fixes #30118.
Updates the `organizerInputPlaceholder` for WhatsApp location configuration from the deprecated `https://wa.me/send?phone=1234567890` format to the clean canonical `https://wa.me/1234567890` URL format without `/send` or `+`.

### Changes
- Updated `organizerInputPlaceholder` in `packages/app-store/whatsapp/config.json`.
- Added unit tests in `packages/app-store/locations.test.ts` to verify WhatsApp location placeholder format and validation regex.
