### PR TITLE
fix(timezone): strip leading zero from single-digit hours for all minute offsets

### DIFF
--- a/packages/lib/timezone.test.ts
+++ b/packages/lib/timezone.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { formatOffset, filterBySearchText, addTimezonesToDropdown } from "./timezone";
+
+describe("timezone helper functions", () => {
+  describe("formatOffset", () => {
+    it("strips leading zero from single-digit whole-hour offsets", () => {
+      expect(formatOffset("+09:00")).toBe("+9:00");
+      expect(formatOffset("-04:00")).toBe("-4:00");
+    });
+
+    it("strips leading zero from single-digit fractional-hour offsets", () => {
+      expect(formatOffset("+05:30")).toBe("+5:30");
+      expect(formatOffset("-03:30")).toBe("-3:30");
+      expect(formatOffset("+05:45")).toBe("+5:45");
+      expect(formatOffset("+09:30")).toBe("+9:30");
+    });
+
+    it("preserves double-digit hour offsets unchanged", () => {
+      expect(formatOffset("+10:00")).toBe("+10:00");
+      expect(formatOffset("-11:00")).toBe("-11:00");
+      expect(formatOffset("+12:45")).toBe("+12:45");
+    });
+  });
+
+  describe("filterBySearchText", () => {
+    it("filters timezones by search text", () => {
+      const timezones = [
+        { label: "Asia/Kolkata", timezone: "Asia/Kolkata" },
+        { label: "America/New_York", timezone: "America/New_York" },
+      ];
+      expect(filterBySearchText("kolkata", timezones)).toHaveLength(1);
+      expect(filterBySearchText("kolkata", timezones)[0].label).toBe("Asia/Kolkata");
+    });
+  });
+
+  describe("addTimezonesToDropdown", () => {
+    it("converts timezone list into a dictionary", () => {
+      const timezones = [
+        { label: "Asia/Kolkata", timezone: "Asia/Kolkata" },
+      ];
+      const result = addTimezonesToDropdown(timezones);
+      expect(result).toEqual({ "Asia/Kolkata": "Asia/Kolkata" });
+    });
+  });
+});

--- a/packages/lib/timezone.ts
+++ b/packages/lib/timezone.ts
@@ -24,8 +24,8 @@ export const addTimezonesToDropdown = (timezones: Timezones) => {
   );
 };
 
-const formatOffset = (offset: string) =>
-  offset.replace(/^([-+])(0)(\d):00$/, (_, sign, _zero, hour) => `${sign}${hour}:00`);
+export const formatOffset = (offset: string) =>
+  offset.replace(/^([-+])0(\d:\d{2})$/, (_, sign, hourAndMinutes) => `${sign}${hourAndMinutes}`);
 
 export const handleOptionLabel = (option: ITimezoneOption, timezones: Timezones) => {
   const offsetUnit = option.label.split(/[-+]/)[0].substring(1);


### PR DESCRIPTION
Fixes #29853
Supersedes closed #29932.

## Description
Updates `formatOffset` regex to strip the leading zero for all single-digit hour offsets regardless of minutes (e.g., +05:30 -> +5:30).